### PR TITLE
Convert slide deck into PDF with Puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,12 @@ jobs:
   '8.11.4':
     <<: *base
     docker:
-      - image: circleci/node:8.11.4
+      - image: circleci/node:8.11.4-browsers
 
   '6.14.2':
     <<: *base
     docker:
-      - image: circleci/node:6.14.2
+      - image: circleci/node:6.14.2-browsers
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Convert slide deck into PDF with Puppeteer
+
 ## v0.0.3 - 2018-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Convert slide deck into PDF with Puppeteer
+- Convert slide deck into PDF with Puppeteer ([#2](https://github.com/marp-team/marp-cli/pull/2))
 
 ## v0.0.3 - 2018-08-22
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **A CLI interface, for [Marp](https://github.com/marp-team/marp)** (using [@marp-team/marp-core](https://github.com/marp-team/marp-core)) and any slide deck converter based on [Marpit](https://github.com/marp-team/marpit) framework.
 
-It can convert Marp / Marpit Markdown files to static HTML (and CSS).
+It can convert Marp / Marpit Markdown files into static HTML (and CSS).
 
 ### :warning: _marp-cli is under construction and not ready to use stable._
 
@@ -16,11 +16,11 @@ It can convert Marp / Marpit Markdown files to static HTML (and CSS).
 [npx](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) is the best tool when you want to convert Markdown right now. Just run below if you are installed [Node.js](https://nodejs.org/) >= 8.2.0:
 
 ```bash
-# Convert slide deck to HTML
+# Convert slide deck into HTML
 npx @marp-team/marp-cli slide-deck.md
 npx @marp-team/marp-cli slide-deck.md -o output.html
 
-# Convert slide deck to PDF
+# Convert slide deck into PDF
 npx @marp-team/marp-cli slide-deck.md --pdf
 npx @marp-team/marp-cli slide-deck.md -o output.pdf
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ It can convert Marp / Marpit Markdown files to static HTML (and CSS).
 [npx](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) is the best tool when you want to convert Markdown right now. Just run below if you are installed [Node.js](https://nodejs.org/) >= 8.2.0:
 
 ```bash
+# Convert slide deck to HTML
+npx @marp-team/marp-cli slide-deck.md
 npx @marp-team/marp-cli slide-deck.md -o output.html
+
+# Convert slide deck to PDF
+npx @marp-team/marp-cli slide-deck.md --pdf
+npx @marp-team/marp-cli slide-deck.md -o output.pdf
 ```
 
 ## Install
@@ -57,7 +63,7 @@ Under construction.
 - [x] HTML templates
   - [ ] Template that has ready to actual presentation powered by [Bespoke](https://github.com/bespokejs/bespoke)
 - [ ] Select engine to use any Marpit based module
-- [ ] Export PDF directly by using [Puppetter](https://github.com/GoogleChrome/puppeteer)
+- [x] Export PDF directly by using [Puppeteer](https://github.com/GoogleChrome/puppeteer)
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npx @marp-team/marp-cli slide-deck.md --pdf
 npx @marp-team/marp-cli slide-deck.md -o output.pdf
 ```
 
+> :information_source: You have to install [Google Chrome](https://www.google.com/chrome/) (or [Chromium](https://www.chromium.org/)) to convert slide deck into PDF.
+
 ## Install
 
 ### Global install

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.1",
     "@types/pug": "^2.0.4",
+    "@types/puppeteer": "^1.6.0",
     "@types/yargs": "^11.1.1",
     "autoprefixer": "^9.1.2",
     "codecov": "^3.0.4",
@@ -82,7 +83,10 @@
     "@marp-team/marp-core": "^0.0.3",
     "@marp-team/marpit": "^0.0.12",
     "chalk": "^2.4.1",
+    "chrome-launcher": "^0.10.2",
     "globby": "^8.0.1",
+    "is-wsl": "^1.1.0",
+    "puppeteer-core": "^1.7.0",
     "yargs": "^12.0.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,13 @@ import { dependencies } from './package.json'
 
 export default [
   {
-    external: [...Object.keys(dependencies), 'fs', 'path', 'yargs/yargs'],
+    external: [
+      ...Object.keys(dependencies),
+      'fs',
+      'path',
+      'chrome-launcher/dist/chrome-finder',
+      'yargs/yargs',
+    ],
     input: 'src/marp-cli.ts',
     output: {
       exports: 'named',

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,7 +1,12 @@
 export class CLIError implements Error {
-  name = 'CLIError'
+  readonly errorCode: number
+  readonly message: string
+  readonly name = 'CLIError'
 
-  constructor(public message: string, public errorCode: number = 1) {}
+  constructor(message: string, errorCode: number = 1) {
+    this.message = message
+    this.errorCode = errorCode
+  }
 
   toString() {
     return this.message

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -49,7 +49,7 @@ export default async function(argv: string[] = []): Promise<number> {
         },
         pdf: {
           default: false,
-          describe: 'Convert slide deck to PDF',
+          describe: 'Convert slide deck into PDF',
           group: OptionGroup.Converter,
           type: 'boolean',
         },

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -117,15 +117,14 @@ export default async function(argv: string[] = []): Promise<number> {
         if (ret.output === '-') console.log(ret.result)
       })
     } catch (e) {
-      error(`Failed converting Markdown. (${e.message})`)
+      error(`Failed converting Markdown. (${e.message})`, e.errorCode)
     }
 
     return 0
   } catch (e) {
-    if (e instanceof CLIError) {
-      cli.error(e.message)
-      return e.errorCode
-    }
-    throw e
+    if (!(e instanceof CLIError)) throw e
+
+    cli.error(e.message)
+    return e.errorCode
   }
 }

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -5,7 +5,7 @@ import globby from 'globby'
 import { Argv } from 'yargs'
 import yargs from 'yargs/yargs'
 import * as cli from './cli'
-import { Converter } from './converter'
+import { Converter, ConvertType } from './converter'
 import { CLIError, error } from './error'
 import { MarpReadyScript } from './ready'
 import templates from './templates'
@@ -47,6 +47,12 @@ export default async function(argv: string[] = []): Promise<number> {
           group: OptionGroup.Basic,
           type: 'string',
         },
+        pdf: {
+          default: false,
+          describe: 'Convert slide deck to PDF',
+          group: OptionGroup.Converter,
+          type: 'boolean',
+        },
         template: {
           describe: 'Template name',
           group: OptionGroup.Converter,
@@ -75,6 +81,10 @@ export default async function(argv: string[] = []): Promise<number> {
       readyScript: await MarpReadyScript.bundled(),
       template: args.template || 'bare',
       theme: args.theme,
+      type:
+        args.pdf || `${args.output}`.toLowerCase().endsWith('.pdf')
+          ? ConvertType.pdf
+          : ConvertType.html,
     })
 
     // Find target markdown files
@@ -96,9 +106,7 @@ export default async function(argv: string[] = []): Promise<number> {
 
     // Convert markdown into HTML
     try {
-      const processed = await converter.convertFiles(...files)
-
-      processed.forEach(ret => {
+      await converter.convertFiles(files, ret => {
         const from = path.relative(process.cwd(), ret.path)
         const output =
           ret.output === '-'

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -9,7 +9,6 @@ export interface TemplateOptions {
 }
 
 export interface TemplateResult {
-  options: TemplateOptions
   rendered: MarpitRenderResult
   result: string
 }
@@ -23,13 +22,14 @@ export const bare: Template = opts => {
     slideContainer: [],
   })
 
-  const result = barePug({
-    ...opts,
-    ...rendered,
-    bare: { css: bareScss },
-  })
-
-  return { rendered, result, options: opts }
+  return {
+    rendered,
+    result: barePug({
+      ...opts,
+      ...rendered,
+      bare: { css: bareScss },
+    }),
+  }
 }
 
 const templates: { [name: string]: Template } = { bare }

--- a/src/templates/bare.pug
+++ b/src/templates/bare.pug
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+doctype
 html(lang="en")
   head
     meta(charset="UTF-8")

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -9,3 +9,8 @@ declare module '*.scss' {
   const scss: string
   export default scss
 }
+
+declare module 'puppeteer-core' {
+  import * as puppeteer from 'puppeteer'
+  export = puppeteer
+}

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -140,6 +140,29 @@ describe('Converter', () => {
         expect(result.output).toBe('-')
       })
     })
+
+    context('when convert type is PDF', () => {
+      const pdfInstance = (opts = {}) =>
+        instance({ ...opts, type: ConvertType.pdf })
+
+      it('converts markdown file into PDF', async () => {
+        const write = jest.spyOn(fs, 'writeFile')
+
+        return useSpy([write], async () => {
+          write.mockImplementation((_, __, callback) => callback())
+
+          const opts = { output: 'test.pdf' }
+          const result = await pdfInstance(opts).convertFile(onePath)
+          const pdf: Buffer = write.mock.calls[0][1]
+
+          expect(write).toHaveBeenCalled()
+          expect(write.mock.calls[0][0]).toBe('test.pdf')
+          expect(pdf.toString('ascii', 0, 5)).toBe('%PDF-')
+          expect(result.output).toBe('test.pdf')
+          expect(result.result).toBe(write.mock.calls[0][1])
+        })
+      })
+    })
   })
 
   describe('#convertFiles', () => {

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import context from './_helpers/context'
 import { useSpy } from './_helpers/spy'
-import { Converter } from '../src/converter'
+import { Converter, ConvertType } from '../src/converter'
 import { bare as bareTpl } from '../src/templates'
 import { CLIError } from '../src/error'
 
@@ -18,6 +18,7 @@ describe('Converter', () => {
       engine: Marp,
       options: {},
       template: 'bare',
+      type: ConvertType.html,
       ...opts,
     })
 
@@ -27,9 +28,16 @@ describe('Converter', () => {
         engine: Marp,
         options: { html: true } as MarpitOptions,
         template: 'test-template',
+        type: ConvertType.html,
       }
 
       expect(new Converter(options).options).toMatchObject(options)
+    })
+
+    it('throws error when convert type is PDF and output is stdout', () => {
+      expect(() => instance({ type: ConvertType.pdf, output: '-' })).toThrow(
+        CLIError
+      )
     })
   })
 
@@ -55,7 +63,6 @@ describe('Converter', () => {
       expect(result.result).toContain(result.rendered.html)
       expect(result.result).toContain(result.rendered.css)
       expect(result.result).toContain(readyScript)
-      expect(result.options.readyScript).toBe(readyScript)
       expect(result.rendered.css).toContain('@theme default')
     })
 
@@ -142,27 +149,30 @@ describe('Converter', () => {
 
         return useSpy([write], async () => {
           write.mockImplementation((_, __, callback) => callback())
-          const result = await instance().convertFiles(onePath, twoPath)
 
+          await instance().convertFiles([onePath, twoPath])
           expect(write).toHaveBeenCalledTimes(2)
-          expect(result.map(r => r.path)).toStrictEqual([onePath, twoPath])
+          expect(write.mock.calls[0][0]).toBe(`${onePath.slice(0, -3)}.html`)
+          expect(write.mock.calls[1][0]).toBe(`${twoPath.slice(0, -6)}.html`)
         })
       })
 
       it('throws CLIError when output is defined', () =>
-        expect(() =>
-          instance({ output: 'specified.html' }).convertFiles(onePath, twoPath)
-        ).toThrow(CLIError))
+        expect(
+          instance({ output: 'test' }).convertFiles([onePath, twoPath])
+        ).rejects.toBeInstanceOf(CLIError))
 
       it('converts passed files when output is stdout', async () => {
         const write = jest.spyOn(fs, 'writeFile')
 
         return useSpy([write], async () => {
-          const ins = instance({ output: '-' })
-          const result = await ins.convertFiles(onePath, twoPath)
+          const files = [onePath, twoPath]
+
+          await instance({ output: '-' }).convertFiles(files, result =>
+            expect(files.includes(result.path)).toBe(true)
+          )
 
           expect(write).not.toHaveBeenCalled()
-          expect(result.map(r => r.path)).toStrictEqual([onePath, twoPath])
         })
       })
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["es2016"],
+    "lib": ["es2016", "dom"],
     "module": "commonjs",
     "noImplicitAny": false,
     "outDir": "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,21 +184,48 @@
   dependencies:
     "@types/babel-types" "*"
 
+"@types/core-js@^0.9.41":
+  version "0.9.46"
+  resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.46.tgz#ea701ee34cbb6dfe6d100f1530319547c93c8d79"
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
 
 "@types/jest@^23.3.1":
   version "23.3.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.1.tgz#a4319aedb071d478e6f407d1c4578ec8156829cf"
 
+"@types/mkdirp@^0.3.29":
+  version "0.3.29"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
+
 "@types/node@*", "@types/node@^10.7.1":
   version "10.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
 
+"@types/node@^9.3.0":
+  version "9.6.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.28.tgz#198927ce0786106ec2a7c8652d46d5f8b87bfc5f"
+
 "@types/pug@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.4.tgz#8772fcd0418e3cd2cc171555d73007415051f4b2"
+
+"@types/puppeteer@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-1.6.0.tgz#3dc6613cfbbb5e91443f5137fb4831973857ab7f"
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
+"@types/rimraf@^0.0.28":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
 
 "@types/yargs@^11.1.1":
   version "11.1.1"
@@ -253,6 +280,12 @@ acorn@^4.0.4, acorn@~4.0.2:
 acorn@^5.0.0, acorn@^5.5.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
+agent-base@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ajv-keywords@^3.0.0:
   version "3.2.0"
@@ -915,6 +948,19 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
+chrome-launcher@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.10.2.tgz#f7d860ddec627b6f01015736b5ae1e33b3d165b1"
+  dependencies:
+    "@types/core-js" "^0.9.41"
+    "@types/mkdirp" "^0.3.29"
+    "@types/node" "^9.3.0"
+    "@types/rimraf" "^0.0.28"
+    is-wsl "^1.1.0"
+    lighthouse-logger "^1.0.0"
+    mkdirp "0.5.1"
+    rimraf "^2.6.1"
+
 ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
@@ -1110,6 +1156,15 @@ component-emitter@^1.2.1:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+concat-stream@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 concat-with-sourcemaps@^1.0.5:
   version "1.1.0"
@@ -1416,7 +1471,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
-debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1647,6 +1702,16 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -1805,6 +1870,15 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-zip@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
+  dependencies:
+    concat-stream "1.6.2"
+    debug "2.6.9"
+    mkdirp "0.5.1"
+    yauzl "2.4.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -1849,6 +1923,12 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -2296,6 +2376,13 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -2376,7 +2463,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2704,6 +2791,10 @@ is-windows@^1.0.2:
 is-word-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
+
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -3302,6 +3393,12 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lighthouse-logger@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-1.0.1.tgz#f073d83f7acbc96729bf100a121c8f006991ae61"
+  dependencies:
+    debug "^2.6.8"
+
 linkify-it@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
@@ -3622,6 +3719,10 @@ mime-types@^2.1.12, mime-types@~2.1.17:
   dependencies:
     mime-db "~1.35.0"
 
+mime@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -3675,7 +3776,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -4141,6 +4242,10 @@ pause-stream@0.0.11:
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   dependencies:
     through "~2.3"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -4828,6 +4933,10 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
 promise.series@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/promise.series/-/promise.series-0.2.0.tgz#2cc7ebe959fc3a6619c04ab4dbdc9e452d864bbd"
@@ -4844,6 +4953,10 @@ prompts@^0.1.9:
   dependencies:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
+
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
 ps-tree@^1.1.0:
   version "1.1.0"
@@ -4960,6 +5073,19 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
+puppeteer-core@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-1.7.0.tgz#c10f660983e9a4faacf6b8e50861c7739871c752"
+  dependencies:
+    debug "^3.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
+    progress "^2.0.0"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^5.1.1"
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -5026,7 +5152,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -6185,6 +6311,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
 typescript@^1.8.9:
   version "1.8.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
@@ -6508,7 +6638,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^5.2.0:
+ws@^5.1.1, ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   dependencies:
@@ -6628,3 +6758,9 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"


### PR DESCRIPTION
This PR will support converting Marp slide deck into PDF directly. We use a [headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome) through [Puppeteer](https://github.com/GoogleChrome/puppeteer).

marp-cli recognizes `--pdf` option or `-o` option with `.pdf` extension.

```bash
# --pdf option
npx @marp-team/marp-cli slide-deck.md --pdf

# -o option with .pdf extension
npx @marp-team/marp-cli slide-deck.md -o convert.pdf
```

We are using [puppeteer-core](https://www.npmjs.com/package/puppeteer-core) package to avoid installing a new Chromium to your computer, so the PDF conversion will require Chrome that is installed by user.

Fix yhatt/marp#50, yhatt/marp#164, and yhatt/marp#222.

> **For [yhatt/marp](https://github.com/yhatt/marp) user:** marp-cli is based on the new Marpit framework. You might have to update your Markdown written for the pre-released Marp.