### PR TITLE
Fix to be used incorrect CJK fonts in exported PDF

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "chrome-launcher": "^0.10.2",
     "globby": "^8.0.1",
     "is-wsl": "^1.1.0",
+    "os-locale": "^3.0.0",
     "puppeteer-core": "^1.7.0",
     "yargs": "^12.0.1"
   }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -13,6 +13,7 @@ export enum ConvertType {
 
 export interface ConverterOption {
   engine: typeof Marpit
+  lang: string
   options: MarpitOptions
   output?: string
   readyScript?: string
@@ -52,6 +53,7 @@ export class Converter {
       additionals += `\n<!-- theme: ${JSON.stringify(this.options.theme)} -->`
 
     return this.template({
+      lang: this.options.lang,
       readyScript: this.options.readyScript,
       renderer: tplOpts =>
         this.generateEngine(tplOpts).render(`${markdown}${additionals}`),

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -1,7 +1,8 @@
 import { Marp } from '@marp-team/marp-core'
 import { version as coreVersion } from '@marp-team/marp-core/package.json'
-import path from 'path'
 import globby from 'globby'
+import osLocale from 'os-locale'
+import path from 'path'
 import { Argv } from 'yargs'
 import yargs from 'yargs/yargs'
 import * as cli from './cli'
@@ -76,6 +77,7 @@ export default async function(argv: string[] = []): Promise<number> {
     // Initialize converter
     const converter = new Converter({
       engine: Marp,
+      lang: (await osLocale()).replace(/[_@]/g, '-'),
       options: {},
       output: args.output,
       readyScript: await MarpReadyScript.bundled(),

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -3,6 +3,7 @@ import bareScss from './templates/bare.scss'
 import { MarpitOptions, MarpitRenderResult } from '@marp-team/marpit'
 
 export interface TemplateOptions {
+  lang: string
   readyScript?: string
   renderer: (tplOpts: MarpitOptions) => MarpitRenderResult
   [prop: string]: any

--- a/src/templates/bare.pug
+++ b/src/templates/bare.pug
@@ -1,5 +1,5 @@
 doctype
-html(lang="en")
+html(lang=lang)
   head
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width, initial-scale=1.0")

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,7 +1242,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.4:
+cross-spawn@^6.0.0, cross-spawn@^6.0.4:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -1776,6 +1776,18 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
   dependencies:
     merge "^1.2.0"
+
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -2484,6 +2496,10 @@ inversify@^4.10.0:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -3378,6 +3394,12 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  dependencies:
+    invert-kv "^2.0.0"
+
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -3619,6 +3641,13 @@ mem@^1.1.0:
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+mem@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-3.0.1.tgz#152410d0d7e835e4a4363e626238d9e5be3d6f5a"
+  dependencies:
+    mimic-fn "^1.0.0"
+    p-is-promise "^1.1.0"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -4101,6 +4130,14 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
+os-locale@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.0.0.tgz#b868acc459f0f81c8ddde3a11cb0b030f8dd7bf0"
+  dependencies:
+    execa "^0.10.0"
+    lcid "^2.0.0"
+    mem "^3.0.1"
+
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -4115,6 +4152,10 @@ osenv@0, osenv@^0.1.4:
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
 
 p-limit@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
The `lang` attribute of `<html>` element will follow system locale. While exporting PDF, the headless Chrome would be able to use correct fonts by locale.

For example, we expects the rendered font in PDF to use "メイリオ" (Meiryo) on Japanese Windows. But v0.0.4 is using Chinese "新細明體" (PMingLiU).

### ToDo

- [ ] Add tests