### PR TITLE
Add html option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `--html` option ([#7](https://github.com/marp-team/marp-cli/pull/7))
+
 ## v0.0.5 - 2018-08-29
 
 ### Added

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -12,6 +12,7 @@ export enum ConvertType {
 
 export interface ConverterOption {
   engine: typeof Marpit
+  html?: boolean
   lang: string
   options: MarpitOptions
   output?: string
@@ -96,13 +97,19 @@ export class Converter {
   }
 
   private generateEngine(mergeOptions: MarpitOptions) {
-    const engine = new this.options.engine({
-      ...this.options.options,
-      ...mergeOptions,
-    })
+    const { html, options } = this.options
+    const opts: any = { ...options, ...mergeOptions }
+
+    // for marp-core
+    if (html !== undefined) opts.html = !!html
+
+    const engine = new this.options.engine(opts)
 
     if (typeof engine.render !== 'function')
       error('Specified engine has not implemented render() method.')
+
+    // for Marpit engine
+    engine.markdown.set({ html: !!html })
 
     return engine
   }

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -14,6 +14,7 @@ import { name, version } from '../package.json'
 enum OptionGroup {
   Basic = 'Basic Options:',
   Converter = 'Converter Options:',
+  Marp = 'Marp / Marpit Options:',
 }
 
 const usage = `
@@ -60,9 +61,14 @@ export default async function(argv: string[] = []): Promise<number> {
           choices: Object.keys(templates),
           type: 'string',
         },
+        html: {
+          describe: 'Enable or disable HTML tag',
+          group: OptionGroup.Marp,
+          type: 'boolean',
+        },
         theme: {
           describe: 'Override theme',
-          group: OptionGroup.Converter,
+          group: OptionGroup.Marp,
           type: 'string',
         },
       })
@@ -77,6 +83,7 @@ export default async function(argv: string[] = []): Promise<number> {
     // Initialize converter
     const converter = new Converter({
       engine: Marp,
+      html: args.html,
       lang: (await osLocale()).replace(/[_@]/g, '-'),
       options: {},
       output: args.output,

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -50,10 +50,11 @@ describe('Converter', () => {
   })
 
   describe('#convert', () => {
+    const md = '# <i>Hello!</i>'
+
     it('returns the result of template', async () => {
       const options = { html: true }
       const readyScript = '<b>ready</b>'
-      const md = '# <i>Hello!</i>'
       const result = await instance({ options, readyScript }).convert(md)
 
       expect(result.result).toMatch(/^<!DOCTYPE html>[\s\S]+<\/html>$/)
@@ -64,23 +65,31 @@ describe('Converter', () => {
     })
 
     it('throws CLIError when selected engine is not implemented render() method', () => {
-      const subject = instance({ engine: function _() {} }).convert('')
+      const subject = instance({ engine: function _() {} }).convert(md)
       expect(subject).rejects.toBeInstanceOf(CLIError)
     })
 
     it('throws CLIError when selected template is not found', () => {
-      const subject = instance({ template: 'not-found' }).convert('')
+      const subject = instance({ template: 'not-found' }).convert(md)
       expect(subject).rejects.toBeInstanceOf(CLIError)
     })
 
     it('settings lang attribute of <html> by lang option', async () => {
-      const { result } = await instance({ lang: 'zh' }).convert('')
+      const { result } = await instance({ lang: 'zh' }).convert(md)
       expect(result).toContain('<html lang="zh">')
     })
 
     it("overrides theme by converter's theme option", async () => {
-      const { rendered } = await instance({ theme: 'gaia' }).convert('')
+      const { rendered } = await instance({ theme: 'gaia' }).convert(md)
       expect(rendered.css).toContain('@theme gaia')
+    })
+
+    it("overrides html option by converter's html option", async () => {
+      const enabled = (await instance({ html: true }).convert(md)).rendered
+      expect(enabled.html).toContain('<i>Hello!</i>')
+
+      const disabled = (await instance({ html: false }).convert(md)).rendered
+      expect(disabled.html).toContain('&lt;i&gt;Hello!&lt;/i&gt;')
     })
   })
 


### PR DESCRIPTION
This PR will add `--html` option to enable or disable HTML tag.

For security reason, Both of Marpit and Marp Core have disabled HTML by default (In future we might allow several tags like `<br>` by whitelisting). CLI interface can allow HTML by user's operation.

```bash
marp markdown.md --html
marp markdown.md --html=true

# This option would be useful when Marp Core supported HTML whitelist.
marp markdown.md --html=false
```

For supporting Marpit based engine, we will set markdown-it's html option forcely.

To avoid confusing with an export type (HTML or PDF), we added option group about `Marp / Marpit Options` to the help message.