### PR TITLE
Use user-installed marp-core by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Use user-installed marp-core by default ([#12](https://github.com/marp-team/marp-cli/pull/12))
+
 ## v0.0.6 - 2018-09-05
 
 ### Added
@@ -25,7 +29,7 @@
 
 ### Changed
 
-- Update [@marp-team/marp-core](https://github.com/marp-team/marp-core) to [v0.0.4](https://github.com/marp-team/marp-core/releases/tag/v0.0.4) ([#6](https://github.com/marp-team/marp-cli/pull/5))
+- Update [@marp-team/marp-core](https://github.com/marp-team/marp-core) to [v0.0.4](https://github.com/marp-team/marp-core/releases/tag/v0.0.4) ([#6](https://github.com/marp-team/marp-cli/pull/6))
 
 ### Fixed
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ export interface IMarpCLIArguments {
 export type IMarpCLIConfig = Overwrite<
   Omit<IMarpCLIArguments, 'configFile'>,
   {
-    engine?: ResolvableEngine
+    engine?: ResolvableEngine | ResolvableEngine[]
     html?: ConverterOption['html']
     lang?: string
     options?: ConverterOption['options']
@@ -50,7 +50,7 @@ export class MarpCLIConfig {
       if (this.conf.engine)
         return resolveEngine(this.conf.engine, this.confPath)
 
-      return resolveEngine(Marp)
+      return resolveEngine(['@marp-team/marp-core', Marp])
     })()
 
     const output = this.args.output || this.conf.output

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export class MarpCLIConfig {
   }
 
   async converterOption(): Promise<ConverterOption> {
-    const engine = await (async () => {
+    const engine = await (() => {
       if (this.args.engine) return resolveEngine(this.args.engine)
       if (this.conf.engine)
         return resolveEngine(this.conf.engine, this.confPath)

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -1,4 +1,4 @@
-import { Marp } from '@marp-team/marp-core'
+import Marp from '@marp-team/marp-core'
 import resolve, { ResolvedEngine } from '../src/engine'
 
 jest.mock('../src/engine')
@@ -10,7 +10,10 @@ describe('Engine', () => {
   describe('.resolve', () => {
     it('returns ResolvedEngine class with resolved class', async () => {
       expect((await resolve(Marp)).klass).toBe(Marp)
-      expect((await resolve(coreModule)).klass).toBe(Marp)
+      expect((await resolve(coreModule)).klass.name).toBe('Marp')
+
+      // Return with the first resolved class
+      expect((await resolve(['__invalid_module__', Marp])).klass).toBe(Marp)
     })
 
     it("loads browser script from defined in module's marpBrowser section", async () => {

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -85,7 +85,7 @@ describe('Marp CLI', () => {
       return useSpy([error], async () => {
         expect(await marpCli(['--engine', '@marp-team/invalid'])).toBe(1)
         expect(error).toHaveBeenCalledWith(
-          expect.stringContaining('"@marp-team/invalid" has not resolved.')
+          expect.stringContaining('The specified engine has not resolved.')
         )
       })
     })


### PR DESCRIPTION
When the `marp` command was installed in global, it might confuse by using a global command in a project that has already installed marp-core. The user-installed core would never use, and it will use bundled core in global when user not specify engine name.

This PR will support to resolve path for user-installed core by default.