### PR TITLE
Add official Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,34 @@ jobs:
     docker:
       - image: circleci/node:6.14.2-browsers
 
+  docker-image:
+    docker:
+      - image: docker:git
+    working_directory: ~/marp-cli
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      - run:
+          name: Build Docker image
+          command: docker build --no-cache -t marpteam/marp-cli:latest .
+
+      - run:
+          name: Push to Docker Hub
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push marpteam/marp-cli:latest
+
 workflows:
   version: 2
   build:
     jobs:
       - 8.11.4
       - 6.14.2
+      - docker-image:
+          requires:
+            - 8.11.4
+            - 6.14.2
+#         filters:
+#           branches:
+#             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,6 @@ workflows:
           requires:
             - 8.11.4
             - 6.14.2
-#         filters:
-#           branches:
-#             only: master
+          filters:
+            branches:
+              only: master

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/*
+!src/
+!LICENSE
+!marp-cli.js
+!package.json
+!rollup.config.js
+!tsconfig.json
+!yarn.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/*
 !src/
+!lib/
 !LICENSE
 !marp-cli.js
 !package.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 **/*
 !src/
-!lib/
 !LICENSE
 !marp-cli.js
 !package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add official Docker image ([#14](https://github.com/marp-team/marp-cli/pull/14))
+
 ## v0.0.7 - 2018-09-06
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:8.11.4-alpine
+
+RUN apk update && apk upgrade && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    apk add --no-cache \
+      grep \
+      chromium@edge \
+      freetype@edge \
+      harfbuzz@edge \
+      nss@edge
+
+RUN addgroup -S marp-cli && adduser -S -g marp-cli marp-cli \
+    && mkdir -p /marp \
+    && mkdir -p /home/marp-cli/.app \
+    && chown -R marp-cli:marp-cli /home/marp-cli \
+    && chown -R marp-cli:marp-cli /marp
+
+USER marp-cli
+ENV IS_DOCKER true
+
+WORKDIR /home/marp-cli/.app
+COPY --chown=marp-cli:marp-cli . /home/marp-cli/.app
+RUN yarn install && yarn build \
+    && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean
+
+WORKDIR /marp
+ENTRYPOINT ["node", "/home/marp-cli/.app/marp-cli.js"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:8.11.4-alpine
+LABEL maintainer "Marp team"
 
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
@@ -10,20 +11,18 @@ RUN apk update && apk upgrade && \
       harfbuzz@edge \
       nss@edge
 
-RUN addgroup -S marp-cli && adduser -S -g marp-cli marp-cli \
-    && mkdir -p /marp \
-    && mkdir -p /home/marp-cli/.app \
-    && chown -R marp-cli:marp-cli /home/marp-cli \
-    && chown -R marp-cli:marp-cli /marp
+RUN addgroup -S marp && adduser -S -g marp marp \
+    && mkdir -p /home/marp/app /home/marp/.cli \
+    && chown -R marp:marp /home/marp
 
-USER marp-cli
+USER marp
 ENV IS_DOCKER true
 
-WORKDIR /home/marp-cli/.app
-COPY --chown=marp-cli:marp-cli . /home/marp-cli/.app
+WORKDIR /home/marp/.cli
+COPY --chown=marp:marp . /home/marp/.cli/
 RUN yarn install && yarn build \
     && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean
 
-WORKDIR /marp
-ENTRYPOINT ["node", "/home/marp-cli/.app/marp-cli.js"]
+WORKDIR /home/marp/app
+ENTRYPOINT ["node", "/home/marp/.cli/marp-cli.js"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It can convert Marp / Marpit Markdown files into static HTML (and CSS).
 
 ## Try it now!
 
+### npx
+
 [npx](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) is the best tool when you want to convert Markdown right now. Just run below if you are installed [Node.js](https://nodejs.org/) >= 8.2.0:
 
 ```bash
@@ -26,6 +28,18 @@ npx @marp-team/marp-cli slide-deck.md -o output.pdf
 ```
 
 > :information_source: You have to install [Google Chrome](https://www.google.com/chrome/) (or [Chromium](https://www.chromium.org/)) to convert slide deck into PDF.
+
+### Docker
+
+Do you hate to install node/chrome locally? We have an official Docker image ready to use CLI.
+
+```bash
+# Convert slide deck into HTML
+docker run --rm -v $PWD:/home/marp/app/ marpteam/marp-cli slide-deck.md
+
+# Convert slide deck into PDF by using Chromium in Docker
+docker run --rm -v $PWD:/home/marp/app/ marpteam/marp-cli slide-deck.md --pdf
+```
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npx @marp-team/marp-cli slide-deck.md -o output.pdf
 
 ### Docker
 
-Do you hate to install node/chrome locally? We have an official Docker image ready to use CLI.
+Do you hate to install node/chrome locally? We have [an official Docker image](https://hub.docker.com/r/marpteam/marp-cli/) ready to use CLI.
 
 ```bash
 # Convert slide deck into HTML

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -144,11 +144,16 @@ export class Converter {
   }
 
   private static runBrowser() {
+    const args: string[] = []
     const finder: () => string[] = require('is-wsl')
       ? chromeFinder.wsl
       : chromeFinder[process.platform]
 
+    if (process.env.IS_DOCKER)
+      args.push('--no-sandbox', '--disable-dev-shm-usage')
+
     return puppeteer.launch({
+      args,
       executablePath: finder ? finder()[0] : undefined,
     })
   }


### PR DESCRIPTION
This PR would add official Docker image in [`marpteam/marp-cli` at Docker Hub](https://hub.docker.com/r/marpteam/marp-cli/). It can convert Marp Markdown into HTML or PDF without installing node and Chrome/Chromium.

There are remaining issues as below, but currently we only have implemented basic feature.

- Create a light weight image by excluding chromium
- Support PDF conversion with several languages by including Noto fonts

In pre-release, we would have only `latest` tag created by automated build from `master` branch. We will be tagging by version from the first minor release (when todo on README.md are all done).

Related to yhatt/marp#232 and yhatt/marp#233.