### PR TITLE
Fix incorrect SVG scaling on Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add official Docker image ([#14](https://github.com/marp-team/marp-cli/pull/14))
 
+### Fixed
+
+- Fix incorrect SVG scaling on Chrome ([#15](https://github.com/marp-team/marp-cli/pull/15))
+
 ## v0.0.7 - 2018-09-06
 
 ### Changed

--- a/src/templates/bare/bare.scss
+++ b/src/templates/bare/bare.scss
@@ -16,4 +16,7 @@ body > svg {
   height: 100%;
   scroll-snap-align: center center;
   width: 100%;
+
+  /* Hack for incorrect rendering on Chrome */
+  transform: translateZ(0);
 }

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -30,6 +30,9 @@ $progressHeight: 5px;
     width: 100%;
     z-index: -1;
 
+    /* Hack for incorrect rendering on Chrome */
+    transform: translateZ(0);
+
     &.bespoke-marp-active {
       pointer-events: auto;
       z-index: 0;


### PR DESCRIPTION
The slide-deck outputted with bare template would not scaled-down correctly if you are opening it in Mac's Chrome. This problem had been a headache continued from marp-team/marpit#35 over 3 months.

We found a bit hacky workaround that use `transform` style. This PR would apply `transform: translateZ(0);` to SVG element of each template.

|Before|After|
|:---:|:---:|
|<img width="1508" alt="before" src="https://user-images.githubusercontent.com/3993388/45346774-2eac9280-b5e5-11e8-9d23-49457bb0a7c6.png">|<img width="1508" alt="after" src="https://user-images.githubusercontent.com/3993388/45346791-379d6400-b5e5-11e8-8bec-8e0d5c3f4a9b.png">|

> *APPENDIX:* It seems to be caused by the layout engine. Chrome has other problems that may be resolved by very similar workaround, e.g. [`writing-mode`](https://bugs.chromium.org/p/chromium/issues/detail?id=878787) (reproduced on Windows).
