### PR TITLE
Use singleton Chrome instance to convert into PDF

### DIFF
--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -176,5 +176,7 @@ export default async function(argv: string[] = []): Promise<number> {
 
     cli.error(e.message)
     return e.errorCode
+  } finally {
+    await Converter.closeBrowser()
   }
 }

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -10,6 +10,7 @@ import { CLIError } from '../src/error'
 
 jest.mock('fs')
 
+afterAll(() => Converter.closeBrowser())
 afterEach(() => jest.restoreAllMocks())
 
 describe('Converter', () => {


### PR DESCRIPTION
Fix to use singleton Chrome instance to convert into PDF.

Currently we launch Chrome process per converting files. To divide process might be a rational behavior for handling unexpected errors of browser, but it cannot recieve better performance in multiple fiie conversion or watch mode because it repeats launch and close at each Chrome processes.

We have fix to use the same instance of Chrome as much as possible. We would launch again instance if it has disconnected by some reason.