### PR TITLE
Support auto-reload of user theme CSS in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `--theme-set` option to use additional theme CSS files ([#21](https://github.com/marp-team/marp-cli/pull/21))
+- Support auto reloading of additional theme CSS in watch mode ([#22](https://github.com/marp-team/marp-cli/pull/22))
 
 ### Changed
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,11 +73,11 @@ export class MarpCLIConfig {
     const themeSetPathes =
       this.args.themeSet ||
       (this.conf.themeSet
-        ? Array.isArray(this.conf.themeSet)
-          ? this.conf.themeSet
-          : [this.conf.themeSet]
-        : undefined) ||
-      []
+        ? (Array.isArray(this.conf.themeSet)
+            ? this.conf.themeSet
+            : [this.conf.themeSet]
+          ).map(f => path.resolve(path.dirname(this.confPath!), f))
+        : [])
 
     const themeSet = await ThemeSet.initialize(themeSetPathes)
     if (themeSet.themes.size === 0 && themeSetPathes.length > 0)

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -75,8 +75,19 @@ export class Converter {
         type === ConvertType.html
           ? await notifier.register(file.absolutePath)
           : undefined,
-      renderer: tplOpts =>
-        this.generateEngine(tplOpts).render(`${markdown}${additionals}`),
+      renderer: tplOpts => {
+        const engine = this.generateEngine(tplOpts)
+        const ret = engine.render(`${markdown}${additionals}`)
+        const themeDirective = ((<any>engine).lastGlobalDirectives || {}).theme
+
+        return {
+          ...ret,
+          theme:
+            themeDirective !== undefined
+              ? themeDirective
+              : (engine.themeSet.default! || {}).name,
+        }
+      },
     })
   }
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -7,7 +7,7 @@ import { Engine } from './engine'
 import { error } from './error'
 import { File, FileType } from './file'
 import templates, { TemplateResult } from './templates/'
-import { Theme } from './theme'
+import { ThemeSet } from './theme'
 import { notifier } from './watcher'
 
 export enum ConvertType {
@@ -26,7 +26,7 @@ export interface ConverterOption {
   readyScript?: string
   template: string
   theme?: string
-  themeSet?: Theme[]
+  themeSet: ThemeSet
   type: ConvertType
   watch: boolean
 }
@@ -102,6 +102,8 @@ export class Converter {
       await this.convertFileToPDF(newFile)
 
     await newFile.save()
+    this.options.themeSet.observe(file.absolutePath, template.rendered.theme)
+
     return { file, newFile, template }
   }
 
@@ -174,8 +176,7 @@ export class Converter {
     if (!(engine instanceof Marp)) engine.markdown.set({ html: !!html })
 
     // Additional themes
-    if (this.options.themeSet)
-      this.options.themeSet.forEach(theme => engine.themeSet.add(theme.css))
+    this.options.themeSet.registerTo(engine)
 
     return engine
   }

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -166,14 +166,21 @@ export default async function(argv: string[] = []): Promise<number> {
 
     // Watch mode
     if (cvtOpts.watch) {
-      watcher(cvtOpts.inputDir || args._, {
-        converter,
-        finder,
-        events: {
-          onConverted,
-          onError: e => cli.error(`Failed converting Markdown. (${e.message})`),
-        },
-      })
+      watcher(
+        [
+          ...(cvtOpts.inputDir ? [cvtOpts.inputDir] : args._),
+          ...cvtOpts.themeSet.fnForWatch,
+        ],
+        {
+          converter,
+          finder,
+          events: {
+            onConverted,
+            onError: e =>
+              cli.error(`Failed converting Markdown. (${e.message})`),
+          },
+        }
+      )
     }
 
     return 0

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -11,17 +11,13 @@ export interface TemplateOptions {
   lang: string
   notifyWS?: string
   readyScript?: string
-  renderer: (tplOpts: MarpitOptions) => TemplateRenderResult
+  renderer: (tplOpts: MarpitOptions) => MarpitRenderResult
   [prop: string]: any
 }
 
 export interface TemplateResult {
-  rendered: TemplateRenderResult
+  rendered: MarpitRenderResult
   result: string
-}
-
-export interface TemplateRenderResult extends MarpitRenderResult {
-  theme: string | undefined
 }
 
 export type Template = (locals: TemplateOptions) => Promise<TemplateResult>

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -21,7 +21,7 @@ export interface TemplateResult {
 }
 
 export interface TemplateRenderResult extends MarpitRenderResult {
-  theme?: string
+  theme: string | undefined
 }
 
 export type Template = (locals: TemplateOptions) => Promise<TemplateResult>

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -11,13 +11,17 @@ export interface TemplateOptions {
   lang: string
   notifyWS?: string
   readyScript?: string
-  renderer: (tplOpts: MarpitOptions) => MarpitRenderResult
+  renderer: (tplOpts: MarpitOptions) => TemplateRenderResult
   [prop: string]: any
 }
 
 export interface TemplateResult {
-  rendered: MarpitRenderResult
+  rendered: TemplateRenderResult
   result: string
+}
+
+export interface TemplateRenderResult extends MarpitRenderResult {
+  theme?: string
 }
 
 export type Template = (locals: TemplateOptions) => Promise<TemplateResult>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,10 +1,14 @@
+import { Marpit } from '@marp-team/marpit'
 import fs from 'fs'
 import globby from 'globby'
+import path from 'path'
 
 const themeExtensions = ['*.css']
 
 export class Theme {
   readonly filename: string
+  name?: string
+
   private readBuffer?: Buffer
 
   private constructor(filename: string) {
@@ -19,28 +23,102 @@ export class Theme {
     return this.buffer.toString()
   }
 
-  private async read() {
+  async load() {
     this.readBuffer = await new Promise<Buffer>((resolve, reject) =>
       fs.readFile(this.filename, (e, buf) => (e ? reject(e) : resolve(buf)))
     )
   }
 
-  static async create(filename: string) {
+  static async initialize(filename: string) {
     const instance = new Theme(filename)
-    await instance.read()
+    await instance.load()
+
+    return instance
+  }
+}
+
+export class ThemeSet {
+  readonly fn: string[]
+  readonly fnForWatch: string[]
+
+  /** The key-value pair from file path to instance */
+  readonly themes: Map<string, Theme> = new Map()
+
+  onThemeUpdated: (path: string) => void = () => {}
+
+  private observedMarkdowns: Map<string, string | undefined> = new Map()
+
+  private constructor(opts: { fn: string[]; fnForWatch: string[] }) {
+    this.fn = opts.fn
+    this.fnForWatch = opts.fnForWatch
+  }
+
+  async findPath() {
+    return await ThemeSet.findPath(this.fn)
+  }
+
+  async load(fn: string) {
+    const filename = path.resolve(fn)
+    let theme = this.themes.get(filename)
+
+    if (theme) {
+      await theme.load()
+    } else {
+      theme = await Theme.initialize(filename)
+      this.themes.set(filename, theme)
+    }
+
+    if (theme.name !== undefined) this.notify(theme.name)
+  }
+
+  observe(markdownPath: string, theme: string | undefined) {
+    this.observedMarkdowns.set(markdownPath, theme)
+  }
+
+  registerTo(engine: Marpit) {
+    for (const theme of this.themes.values()) {
+      const engineTheme = engine.themeSet.add(theme.css)
+      theme.name = engineTheme.name
+    }
+  }
+
+  unobserve(markdownPath: string) {
+    this.observedMarkdowns.delete(markdownPath)
+  }
+
+  private notify(theme: string) {
+    this.observedMarkdowns.forEach((v, path) => {
+      if (v === theme) this.onThemeUpdated(path)
+    })
+  }
+
+  static async initialize(fn: string[]) {
+    const found = await ThemeSet.findPath(fn)
+    const fnForWatch: Set<string> = new Set(found.map(f => path.resolve(f)))
+
+    for (const f of fn) {
+      if (!globby.hasMagic(f)) {
+        try {
+          const stat = await new Promise<fs.Stats>((resolve, reject) =>
+            fs.lstat(f, (e, stats) => (e ? reject(e) : resolve(stats)))
+          )
+
+          if (stat.isFile() || stat.isDirectory() || stat.isSymbolicLink())
+            fnForWatch.add(path.resolve(f))
+        } catch (e) {}
+      }
+    }
+
+    const instance = new ThemeSet({ fn, fnForWatch: [...fnForWatch] })
+    for (const f of found) await instance.load(f)
 
     return instance
   }
 
-  static async find(from: string | string[]) {
-    const pathes = await globby(from, {
+  private static async findPath(fn: string[]): Promise<string[]> {
+    return await globby(fn, {
       absolute: true,
       expandDirectories: { files: themeExtensions },
     })
-
-    const instances: Theme[] = []
-    for (const fn of pathes) instances.push(await this.create(fn))
-
-    return instances
   }
 }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -24,13 +24,7 @@ export class Watcher {
       .watch(watchPath, { disableGlobbing: true, ignoreInitial: true })
       .on('change', f => this.convert(f))
       .on('add', f => this.convert(f))
-      .on('unlink', f => {
-        const fn = path.resolve(f)
-        const { themeSet } = this.converter.options
-
-        themeSet.unobserve(fn)
-        themeSet.themes.delete(fn)
-      })
+      .on('unlink', f => this.delete(f))
 
     this.converter.options.themeSet.onThemeUpdated = f => this.convert(f)
 
@@ -39,8 +33,8 @@ export class Watcher {
     cli.info(chalk.green('[Watch mode] Start watching...'))
   }
 
-  private async convert(fn) {
-    const resolvedFn = path.resolve(fn)
+  private async convert(filename: string) {
+    const resolvedFn = path.resolve(filename)
     const mdFiles = (await this.finder()).filter(
       f => path.resolve(f.path) === resolvedFn
     )
@@ -62,6 +56,14 @@ export class Watcher {
 
     // Reload Theme CSS
     if (cssFile !== undefined) this.converter.options.themeSet.load(resolvedFn)
+  }
+
+  private delete(filename: string) {
+    const fn = path.resolve(filename)
+    const { themeSet } = this.converter.options
+
+    themeSet.unobserve(fn)
+    themeSet.themes.delete(fn)
   }
 
   static watch(watchPath: string[], opts: Watcher.Options) {

--- a/test/_configs/custom-engine/marp.config.js
+++ b/test/_configs/custom-engine/marp.config.js
@@ -3,6 +3,8 @@ class CustomEngine {
     this.markdown = {
       set: jest.fn(),
     }
+
+    this.themeSet = {}
   }
 
   render() {

--- a/test/_configs/marpit/config.js
+++ b/test/_configs/marpit/config.js
@@ -1,4 +1,5 @@
 module.exports = {
   engine: '@marp-team/marpit',
-  theme: 'default',
+  theme: 'a',
+  themeSet: '../../_files/themes/a.css',
 }

--- a/test/_configs/package-json/package.json
+++ b/test/_configs/package-json/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "marp": {
-    "theme": "gaia"
+    "theme": "b",
+    "themeSet": ["../../_files/themes"]
   }
 }

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -72,6 +72,7 @@ describe('Converter', () => {
       expect(result.result).toContain(readyScript)
       expect(result.result).not.toContain('<base')
       expect(result.rendered.css).toContain('@theme default')
+      expect(result.rendered.theme).toBe('default')
     })
 
     it('throws CLIError when selected engine is not implemented render() method', () => {
@@ -92,6 +93,7 @@ describe('Converter', () => {
     it("overrides theme by converter's theme option", async () => {
       const { rendered } = await instance({ theme: 'gaia' }).convert(md)
       expect(rendered.css).toContain('@theme gaia')
+      expect(rendered.theme).toBe('gaia')
     })
 
     it("overrides html option by converter's html option", async () => {

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -72,7 +72,6 @@ describe('Converter', () => {
       expect(result.result).toContain(readyScript)
       expect(result.result).not.toContain('<base')
       expect(result.rendered.css).toContain('@theme default')
-      expect(result.rendered.theme).toBe('default')
     })
 
     it('throws CLIError when selected engine is not implemented render() method', () => {
@@ -93,7 +92,6 @@ describe('Converter', () => {
     it("overrides theme by converter's theme option", async () => {
       const { rendered } = await instance({ theme: 'gaia' }).convert(md)
       expect(rendered.css).toContain('@theme gaia')
-      expect(rendered.theme).toBe('gaia')
     })
 
     it("overrides html option by converter's html option", async () => {

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -190,8 +190,9 @@ describe('Marp CLI', () => {
         ).toBe(0)
         expect(convert).toBeCalledTimes(1)
 
-        const { css } = (await convert.mock.results[0].value).rendered
+        const { css, theme } = (await convert.mock.results[0].value).rendered
         expect(css).toContain('@theme a')
+        expect(theme).toBe('a')
       })
     })
 
@@ -204,9 +205,10 @@ describe('Marp CLI', () => {
 
           expect(await marpCli([...baseArgs, '--theme', name])).toBe(0)
           expect(convert).toBeCalledTimes(1)
-          expect((await convert.mock.results[0].value).rendered.css).toContain(
-            `@theme ${name}`
-          )
+
+          const { css, theme } = (await convert.mock.results[0].value).rendered
+          expect(css).toContain(`@theme ${name}`)
+          expect(theme).toBe(name)
         }
       })
     })
@@ -220,9 +222,10 @@ describe('Marp CLI', () => {
 
           expect(await marpCli([...baseArgs(themes), '--theme', name])).toBe(0)
           expect(convert).toBeCalledTimes(1)
-          expect((await convert.mock.results[0].value).rendered.css).toContain(
-            `@theme ${name}`
-          )
+
+          const { css, theme } = (await convert.mock.results[0].value).rendered
+          expect(css).toContain(`@theme ${name}`)
+          expect(theme).toBe(name)
         }
       })
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -331,7 +331,7 @@ describe('Marp CLI', () => {
         expect(await marpCli(['md.md', '-o', '-'])).toBe(0)
 
         const html = stdout.mock.calls[0][0].toString()
-        expect(html).toContain('@theme gaia')
+        expect(html).toContain('@theme b')
       })
 
       context('when --config-file / -c option is passed', () => {
@@ -359,7 +359,7 @@ describe('Marp CLI', () => {
           expect(await marpCli(['-c', conf, onePath, '-o', '-'])).toBe(0)
 
           const html = stdout.mock.calls[0][0].toString()
-          expect(html).toContain('@theme a') // override to user theme
+          expect(html).toContain('@theme a')
         })
 
         it('allows custom engine specified in js config', async () => {

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -189,10 +189,9 @@ describe('Marp CLI', () => {
           await marpCli(['--theme-set', themeA, '--theme', 'a', filePath])
         ).toBe(0)
         expect(convert).toBeCalledTimes(1)
-
-        const { css, theme } = (await convert.mock.results[0].value).rendered
-        expect(css).toContain('@theme a')
-        expect(theme).toBe('a')
+        expect((await convert.mock.results[0].value).rendered.css).toContain(
+          '@theme a'
+        )
       })
     })
 
@@ -205,10 +204,9 @@ describe('Marp CLI', () => {
 
           expect(await marpCli([...baseArgs, '--theme', name])).toBe(0)
           expect(convert).toBeCalledTimes(1)
-
-          const { css, theme } = (await convert.mock.results[0].value).rendered
-          expect(css).toContain(`@theme ${name}`)
-          expect(theme).toBe(name)
+          expect((await convert.mock.results[0].value).rendered.css).toContain(
+            `@theme ${name}`
+          )
         }
       })
     })
@@ -222,10 +220,9 @@ describe('Marp CLI', () => {
 
           expect(await marpCli([...baseArgs(themes), '--theme', name])).toBe(0)
           expect(convert).toBeCalledTimes(1)
-
-          const { css, theme } = (await convert.mock.results[0].value).rendered
-          expect(css).toContain(`@theme ${name}`)
-          expect(theme).toBe(name)
+          expect((await convert.mock.results[0].value).rendered.css).toContain(
+            `@theme ${name}`
+          )
         }
       })
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -189,9 +189,9 @@ describe('Marp CLI', () => {
           await marpCli(['--theme-set', themeA, '--theme', 'a', filePath])
         ).toBe(0)
         expect(convert).toBeCalledTimes(1)
-        expect((await convert.mock.results[0].value).rendered.css).toContain(
-          '@theme a'
-        )
+
+        const { css } = (await convert.mock.results[0].value).rendered
+        expect(css).toContain('@theme a')
       })
     })
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -6,6 +6,7 @@ import * as cli from '../src/cli'
 import { File } from '../src/file'
 import { Converter, ConvertType } from '../src/converter'
 import { CLIError } from '../src/error'
+import { ThemeSet } from '../src/theme'
 import { Watcher } from '../src/watcher'
 
 const { version } = require('../package.json')
@@ -175,9 +176,11 @@ describe('Marp CLI', () => {
     const themeC = assetFn('_files/themes/nested/c.css')
 
     let convert: jest.SpyInstance
+    let observeSpy: jest.SpyInstance
 
     beforeEach(() => {
       convert = jest.spyOn(Converter.prototype, 'convert')
+      observeSpy = jest.spyOn(ThemeSet.prototype, 'observe')
 
       jest.spyOn(cli, 'info').mockImplementation()
       ;(<any>fs).__mockWriteFile()
@@ -192,6 +195,7 @@ describe('Marp CLI', () => {
 
         const { css } = (await convert.mock.results[0].value).rendered
         expect(css).toContain('@theme a')
+        expect(observeSpy).toHaveBeenCalledWith(filePath, 'a')
       })
     })
 
@@ -201,12 +205,14 @@ describe('Marp CLI', () => {
       it('becomes to be able to use multiple additional themes', async () => {
         for (const name of ['b', 'c']) {
           convert.mockClear()
+          observeSpy.mockClear()
 
           expect(await marpCli([...baseArgs, '--theme', name])).toBe(0)
           expect(convert).toBeCalledTimes(1)
           expect((await convert.mock.results[0].value).rendered.css).toContain(
             `@theme ${name}`
           )
+          expect(observeSpy).toHaveBeenCalledWith(filePath, name)
         }
       })
     })
@@ -217,12 +223,14 @@ describe('Marp CLI', () => {
       it('becomes to be able to use the all css files in directory', async () => {
         for (const name of ['a', 'b', 'c']) {
           convert.mockClear()
+          observeSpy.mockClear()
 
           expect(await marpCli([...baseArgs(themes), '--theme', name])).toBe(0)
           expect(convert).toBeCalledTimes(1)
           expect((await convert.mock.results[0].value).rendered.css).toContain(
             `@theme ${name}`
           )
+          expect(observeSpy).toHaveBeenCalledWith(filePath, name)
         }
       })
 
@@ -351,7 +359,7 @@ describe('Marp CLI', () => {
           expect(await marpCli(['-c', conf, onePath, '-o', '-'])).toBe(0)
 
           const html = stdout.mock.calls[0][0].toString()
-          expect(html).not.toContain('@theme default') // Marpit engine has not default theme
+          expect(html).toContain('@theme a') // override to user theme
         })
 
         it('allows custom engine specified in js config', async () => {

--- a/test/theme.ts
+++ b/test/theme.ts
@@ -1,0 +1,105 @@
+import { Marpit } from '@marp-team/marpit'
+import path from 'path'
+import { ThemeSet } from '../src/theme'
+
+afterEach(() => jest.restoreAllMocks())
+
+describe('ThemeSet', () => {
+  const themeDir = path.resolve(__dirname, '_files/themes')
+  const themeA = path.resolve(themeDir, './a.css')
+
+  describe('.initialize', () => {
+    it('creates ThemeSet instance with initial loading', async () => {
+      const themeSet = await ThemeSet.initialize([themeDir])
+
+      expect(themeSet.fn).toStrictEqual([themeDir])
+      expect(themeSet.fnForWatch).toContain(themeDir)
+      expect(themeSet.fnForWatch).toHaveLength(4) // dir + files
+
+      // Themes
+      expect(themeSet.themes.size).toBe(3)
+      for (const theme of themeSet.themes.values())
+        expect(theme.css.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('#findPath', () => {
+    it('returns the result of findings from original pathes', async () => {
+      const themeSet = await ThemeSet.initialize([themeDir])
+      const found = await themeSet.findPath()
+
+      expect(found).toHaveLength(3)
+      for (const fn of found) expect(fn).toMatch(/\.css$/)
+    })
+  })
+
+  describe('#load', () => {
+    context('with new file', () => {
+      it('loads theme and add to theme set', async () => {
+        const themeSet = await ThemeSet.initialize([])
+        expect(themeSet.themes.size).toBe(0)
+
+        await themeSet.load(themeA)
+        expect(themeSet.themes.size).toBe(1)
+      })
+    })
+
+    context('with already registered file', () => {
+      it('reloads theme by Theme#load', async () => {
+        const themeSet = await ThemeSet.initialize([themeA])
+        expect(themeSet.themes.size).toBe(1)
+
+        const [themeInstance] = [...themeSet.themes.values()]
+        const load = jest.spyOn(themeInstance, 'load').mockResolvedValue(0)
+
+        await themeSet.load(themeA)
+        expect(themeSet.themes.size).toBe(1)
+        expect(load).toHaveBeenCalledTimes(1)
+      })
+
+      context('when theme has resolved name', () => {
+        it('triggers onThemeUpdated event to observed markdown files', async () => {
+          const themeSet = await ThemeSet.initialize([themeA])
+          themeSet.registerTo(new Marpit())
+
+          themeSet.onThemeUpdated = jest.fn()
+          themeSet.observe('testA.md', 'a')
+          themeSet.observe('testA2.md', 'a')
+          themeSet.observe('testB.md', 'b')
+
+          await themeSet.load(themeA)
+          expect(themeSet.onThemeUpdated).toHaveBeenCalledTimes(2)
+          expect(themeSet.onThemeUpdated).toHaveBeenCalledWith('testA.md')
+          expect(themeSet.onThemeUpdated).toHaveBeenCalledWith('testA2.md')
+
+          // It does no longer trigger after #unobserve
+          ;(<jest.Mock>themeSet.onThemeUpdated).mockClear()
+          themeSet.unobserve('testA.md')
+
+          await themeSet.load(themeA)
+          expect(themeSet.onThemeUpdated).toHaveBeenCalledTimes(1)
+          expect(themeSet.onThemeUpdated).toHaveBeenCalledWith('testA2.md')
+          expect(themeSet.onThemeUpdated).not.toHaveBeenCalledWith('testA.md')
+        })
+      })
+    })
+  })
+
+  describe('#registerTo', () => {
+    it('registers theme to specified Marpit engine', async () => {
+      const themeSet = await ThemeSet.initialize([themeDir])
+      const marpit = new Marpit()
+
+      themeSet.registerTo(marpit)
+      expect(marpit.themeSet.has('a')).toBe(true)
+      expect(marpit.themeSet.has('b')).toBe(true)
+      expect(marpit.themeSet.has('c')).toBe(true)
+
+      // Reflects parsed theme name back to own themes
+      const names = [...themeSet.themes.values()].map(t => t.name)
+      expect(names).toContain('a')
+      expect(names).toContain('b')
+      expect(names).toContain('c')
+    })
+  })
+})


### PR DESCRIPTION
This PR will support auto-reload of user theme CSS specified by `--theme-set` option in watch mode.

After rendering Markdown to HTML, we track the change of used theme CSS. When you have updated observed CSS, an auto-reloading is triggered to markdowns that has used updated theme.

![autoreload](https://user-images.githubusercontent.com/3993388/45731426-81540300-bc12-11e8-84aa-6fcc14ca28af.gif)

We have refactored the way of management user-created themes, using `ThemeSet` class.