### PR TITLE
Override theme CSS by file

### DIFF
--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -94,13 +94,13 @@ export default async function(argv: string[] = []): Promise<number> {
           type: 'boolean',
         },
         theme: {
-          describe: 'Override theme',
+          describe: 'Override theme by name or CSS file',
           group: OptionGroup.Marp,
           type: 'string',
         },
         'theme-set': {
           array: true,
-          describe: 'Path to additional theme CSS file(s)',
+          describe: 'Path to additional theme CSS files',
           group: OptionGroup.Marp,
           type: 'string',
         },


### PR DESCRIPTION
This PR will support to override theme CSS at `--theme` option by file path.

`--theme` option may allow passing CSS file path in addition to the name of theme. The passed theme CSS is always used in all convertions even though theme was specified in Marp Markdown.

The notable point is that allows anonymous theme. Normally [Marpit framework requires `@theme` metadata comment to theme CSS.](https://marpit.marp.app/theme-css?id=metadata) But marp-cli will generate the unique name (like `/* @theme ym2qyqimipqn2gfzjddbnrdrwrkb2vtkk3sjkdj0x */`) for the theme CSS passed to `--theme`. It is useful when developing/debugging theme.

```css
@import 'default';

section {
  background: #f93;
}
```

```bash
marp --theme theme.css slide.md
```

### ToDo

- [ ] Add tests for `--theme` option by file