### PR TITLE
Improve error message of theme option when passed directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add `--theme-set` option to use additional theme CSS files ([#21](https://github.com/marp-team/marp-cli/pull/21))
 - Support auto reloading of additional theme CSS in watch mode ([#22](https://github.com/marp-team/marp-cli/pull/22))
-- Override theme by file path of theme CSS in `--theme` option ([#23](https://github.com/marp-team/marp-cli/pull/23))
+- Override theme by file path of theme CSS in `--theme` option ([#23](https://github.com/marp-team/marp-cli/pull/23), [#24](https://github.com/marp-team/marp-cli/pull/24))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "rollup-plugin-pug": "^0.1.6",
     "rollup-plugin-terser": "^2.0.2",
     "rollup-plugin-typescript": "^0.8.1",
+    "strip-ansi": "^4.0.0",
     "stylelint": "^9.5.0",
     "stylelint-config-prettier": "^4.0.0",
     "stylelint-config-standard": "^18.2.0",


### PR DESCRIPTION
User might think that `--theme` option may allow theme directory. But it returns not-friendly error when specify directory actually.

![](https://user-images.githubusercontent.com/3993388/45798458-eb3cdd00-bce4-11e8-8daa-99ece36a3410.png)

We have improved error message on passing directory to `--theme` option. It leads user to use `--theme-set` option.

![](https://user-images.githubusercontent.com/3993388/45798467-f1cb5480-bce4-11e8-976a-d2c390239df8.png)
