### PR TITLE
Add fonts to Docker image for internationalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add fonts for internationalization to Docker image ([#26](https://github.com/marp-team/marp-cli/pull/26))
+
 ## v0.0.10 - 2018-09-20
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,18 @@ LABEL maintainer "Marp team"
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
     apk add --no-cache \
       grep \
       chromium@edge \
       freetype@edge \
       harfbuzz@edge \
+      wqy-zenhei@edge \
+      ttf-liberation@edge \
+      font-noto-devanagari@edge \
+      font-noto-arabic@edge \
+      font-noto-bengali@edge \
+      font-ipa@edge \
       nss@edge
 
 RUN addgroup -S marp && adduser -S -g marp marp \

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -177,12 +177,14 @@ export class Converter {
   private static async runBrowser() {
     if (!Converter.browser) {
       const args: string[] = []
-      const finder: () => string[] = require('is-wsl')
+      let finder: () => string[] = require('is-wsl')
         ? chromeFinder.wsl
         : chromeFinder[process.platform]
 
-      if (process.env.IS_DOCKER)
+      if (process.env.IS_DOCKER) {
         args.push('--no-sandbox', '--disable-dev-shm-usage')
+        finder = () => ['/usr/bin/chromium-browser']
+      }
 
       Converter.browser = await puppeteer.launch({
         args,


### PR DESCRIPTION
This PR will add fonts to Docker image for internationalization.

In several languages, you may see fonts as [tofu] by converting PDF in Docker environment. In general, we recommend using Web fonts if you want to specify your favorite fonts in theme. But otherwise, we will use the added basic fonts.

We have added fonts that has [many native speakers]. In future we would accept pull requests about the other language.

### Fonts rendering

|Before|After|
|:---:|:--:|
|![before](https://user-images.githubusercontent.com/3993388/45885436-68557880-bdf1-11e8-9533-6c196ed03509.png)|![after](https://user-images.githubusercontent.com/3993388/45885443-6d1a2c80-bdf1-11e8-80c5-b4b9412065af.png)|

### Troubleshooting about CJK fonts

Chinese hans and Japanese kanji have small differences of glyph. By default we use chinese fonts, but we can use Japanese fonts by `-e LANG=ja_JP` option or `lang` option in config file. Refer to #3 too.

[tofu]: https://en.wikipedia.org/wiki/Tofu_(disambiguation)
[many native speakers]: https://en.wikipedia.org/wiki/List_of_languages_by_number_of_native_speakers