### PR TITLE
Recognize theme CSS in input directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add server mode provided by `--server` (`-s`) option ([#27](https://github.com/marp-team/marp-cli/pull/27))
 - Add fonts for internationalization to Docker image ([#26](https://github.com/marp-team/marp-cli/pull/26))
 
+### Changed
+
+- Recognize theme CSS in input directory specified by `--input-dir` (`-I`) option ([#28](https://github.com/marp-team/marp-cli/pull/28))
+
 ## v0.0.10 - 2018-09-20
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,7 @@ export class MarpCLIConfig {
       return resolveEngine(['@marp-team/marp-core', Marp])
     })()
 
+    const inputDir = await this.inputDir()
     const output =
       this.args.output ||
       (this.conf.output
@@ -87,7 +88,10 @@ export class MarpCLIConfig {
           ).map(f => path.resolve(path.dirname(this.confPath!), f))
         : [])
 
-    const themeSet = await ThemeSet.initialize(themeSetPathes, initialThemes)
+    const themeSet = await ThemeSet.initialize(
+      (inputDir ? [inputDir] : []).concat(themeSetPathes),
+      initialThemes
+    )
 
     if (
       themeSet.themes.size <= initialThemes.length &&
@@ -96,6 +100,7 @@ export class MarpCLIConfig {
       warn('Not found additional theme CSS files.')
 
     return {
+      inputDir,
       output,
       server,
       themeSet,
@@ -106,7 +111,6 @@ export class MarpCLIConfig {
         ) || false,
       engine: engine.klass,
       html: this.pickDefined(this.args.html, this.conf.html),
-      inputDir: await this.inputDir(),
       lang: this.conf.lang || (await osLocale()).replace(/[_@]/g, '-'),
       options: this.conf.options || {},
       readyScript: engine.browserScript

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -52,7 +52,7 @@ export default async function(argv: string[] = []): Promise<number> {
         },
         'input-dir': {
           alias: 'I',
-          describe: 'The base input directory to find markdown',
+          describe: 'The base directory to find markdown and theme CSS',
           group: OptionGroup.Basic,
           type: 'string',
         },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,7 @@ import { Marpit } from '@marp-team/marpit'
 import fs from 'fs'
 import globby from 'globby'
 import path from 'path'
+import { warn } from './cli'
 
 const themeExtensions = ['*.css']
 
@@ -95,8 +96,13 @@ export class ThemeSet {
 
   registerTo(engine: Marpit) {
     for (const theme of this.themes.values()) {
-      const engineTheme = engine.themeSet.add(theme.css)
-      theme.name = engineTheme.name
+      try {
+        const engineTheme = engine.themeSet.add(theme.css)
+        theme.name = engineTheme.name
+      } catch (e) {
+        const fn = path.relative(process.cwd(), theme.filename)
+        warn(`Cannot register theme CSS: ${fn} (${e.message})`)
+      }
     }
   }
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -107,6 +107,14 @@ describe('Marp CLI', () => {
       writeFile.mock.calls.forEach(([fn]) => expect(fn).toMatch(/\.html$/))
     })
 
+    it('allows using theme css in specified dir', async () => {
+      jest.spyOn(cli, 'info').mockImplementation()
+      expect(await marpCli(['--input-dir', files, '--theme', 'a'])).toBe(0)
+
+      for (const [, buffer] of writeFile.mock.calls)
+        expect(buffer.toString()).toContain('/* @theme a */')
+    })
+
     it('prints error and return error code with invalid option(s)', async () => {
       const err = jest.spyOn(console, 'error').mockImplementation()
       jest.spyOn(console, 'warn').mockImplementation()
@@ -163,7 +171,7 @@ describe('Marp CLI', () => {
         )
         expect(serverStart).toBeCalledTimes(1)
         expect(Watcher.watch).toHaveBeenCalledWith(
-          [files],
+          expect.arrayContaining([files]),
           expect.objectContaining({
             mode: Watcher.WatchMode.Notify,
           })

--- a/test/theme.ts
+++ b/test/theme.ts
@@ -101,5 +101,22 @@ describe('ThemeSet', () => {
       expect(names).toContain('b')
       expect(names).toContain('c')
     })
+
+    context('when registered theme is not compatible to Marpit engine', () => {
+      const emptyCSS = path.resolve(__dirname, '_files/themes/empty')
+
+      it('outputs warning and ignores registration', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation()
+        const themeSet = await ThemeSet.initialize([emptyCSS])
+        const marpit = new Marpit()
+
+        themeSet.registerTo(marpit)
+
+        expect(marpit.themeSet.size).toBe(0)
+        expect(warn).toBeCalledWith(
+          expect.stringContaining('Cannot register theme CSS')
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
This PR will change the behavior of `--input-dir` (`-I`) option to recognize theme CSS in specified directory.

One of the expected use case is that there is theme CSS next to Markdown.

```
slides
├── slide1.md
├── slide2.md
├── slide3.md
├── my-theme1.css
└── my-theme2.css
```

Currently we have to specify folder twice in input arguments (or `--input-dir` option) and `--theme-set` option if you want to use these. It is bit redundant.

```
marp ./slides --theme-set ./slides
```

So we'll find out theme CSS from specified directory if `--input-dir` option was defined. Internally the directory will be added to the array of theme set option.

Thus, you would be OK just to run together with `-I` option in this case.

```
marp -I ./slides
```

In current version, it would throw an error and fail conversion when there is not `@theme` metadata in CSS found from theme set directories. We improve this behavior to output the warning which file had a problem. It no longer stop the conversion.