### PR TITLE
Upgrade marp-core to fix fitting header regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade marp-core to [v0.0.11](https://github.com/marp-team/marp-core/releases/tag/v0.0.11) to fix fitting header regression ([#30](https://github.com/marp-team/marp-cli/pull/30))
+
 ## v0.0.11 - 2018-10-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "typescript": "^3.1.1"
   },
   "dependencies": {
-    "@marp-team/marp-core": "^0.0.10",
+    "@marp-team/marp-core": "^0.0.11",
     "@marp-team/marpit": "^0.1.3",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marp-core@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.0.10.tgz#61ae67e78680400a438a968cb5d9cf6b1d85d489"
-  integrity sha512-wyOIHfOtmCXjuMnfeH4t6yAHk+DwSctxshzWu4/nOddol/vV8A09RvG/BKQ1iLw/BwTxkOIe3N4WJ++ZOt/Dxw==
+"@marp-team/marp-core@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.0.11.tgz#1d0d6f7a6fd522363c8a44ad324f48ccb4b92f63"
+  integrity sha512-cb27UZ1Py2yzAN/sgvzwkF2/DkdZTAS+8bsW8Y6ASbtsaYTLCtx9De7etMAkfCGQLjlEF8FVKoE3/TWIbkmJrg==
   dependencies:
     "@marp-team/marpit" "^0.1.3"
     emoji-regex "^7.0.1"


### PR DESCRIPTION
marp-team/marp-core has updated to v0.0.11 by reason of found out a regression of fitting header. Refer to marp-team/marp-core#37.