### PR TITLE
Use util.promisify to wrap callback-based funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Use `util.promisify` to wrap callback-based funcs ([#32](https://github.com/marp-team/marp-cli/pull/32))
+
 ## v0.0.12 - 2018-10-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@types/pug": "^2.0.4",
     "@types/puppeteer": "^1.9.0",
     "@types/supertest": "^2.0.6",
-    "@types/util.promisify": "^1.0.0",
     "@types/ws": "^6.0.1",
     "@types/yargs": "^12.0.1",
     "autoprefixer": "^9.1.5",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/pug": "^2.0.4",
     "@types/puppeteer": "^1.9.0",
     "@types/supertest": "^2.0.6",
+    "@types/util.promisify": "^1.0.0",
     "@types/ws": "^6.0.1",
     "@types/yargs": "^12.0.1",
     "autoprefixer": "^9.1.5",
@@ -89,7 +90,8 @@
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.1.1"
+    "typescript": "^3.1.1",
+    "util.promisify": "^1.0.0"
   },
   "dependencies": {
     "@marp-team/marp-core": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.1.1",
-    "util.promisify": "^1.0.0"
+    "typescript": "^3.1.1"
   },
   "dependencies": {
     "@marp-team/marp-core": "^0.0.11",
@@ -111,6 +110,7 @@
     "portfinder": "^1.0.17",
     "puppeteer-core": "^1.9.0",
     "tmp": "^0.0.33",
+    "util.promisify": "^1.0.0",
     "ws": "^6.1.0",
     "yargs": "^12.0.2"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,14 @@ import cosmiconfig from 'cosmiconfig'
 import path from 'path'
 import fs from 'fs'
 import osLocale from 'os-locale'
+import promisify from 'util.promisify'
 import { info, warn } from './cli'
 import { ConverterOption, ConvertType } from './converter'
 import resolveEngine, { ResolvableEngine } from './engine'
 import { CLIError } from './error'
 import { Theme, ThemeSet } from './theme'
+
+const lstat = promisify(fs.lstat)
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type Overwrite<T, U> = Omit<T, Extract<keyof T, keyof U>> & U
@@ -155,9 +158,7 @@ export class MarpCLIConfig {
     let stat: fs.Stats
 
     try {
-      stat = await new Promise<fs.Stats>((resolve, reject) =>
-        fs.lstat(dir, (e, stats) => (e ? reject(e) : resolve(stats)))
-      )
+      stat = await lstat(dir)
     } catch (e) {
       if (e.code !== 'ENOENT') throw e
       throw new CLIError(`Input directory "${dir}" is not found.`)

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -94,7 +94,7 @@ export class Converter {
 
   async convertFile(file: File, opts: ConvertFileOption = {}) {
     const buffer = await file.load()
-    const template = await this.convert(buffer.toString(), file)
+    const template = await this.convert(buffer!.toString(), file)
     const newFile = file.convert(this.options.output, this.options.type)
     newFile.buffer = new Buffer(template.result)
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,8 +2,11 @@ import { Marpit } from '@marp-team/marpit'
 import fs from 'fs'
 import path from 'path'
 import pkgUp from 'pkg-up'
+import promisify from 'util.promisify'
 import importFrom from 'import-from'
 import { CLIError } from './error'
+
+const readFile = promisify(fs.readFile)
 
 export type Engine = typeof Marpit
 export type ResolvableEngine = Engine | string
@@ -62,12 +65,9 @@ export class ResolvedEngine {
     const scriptPath = require(pkgPath)[ResolvedEngine.browserScriptKey]
     if (!scriptPath) return undefined
 
-    this.browserScript = await new Promise<string>((res, rej) =>
-      fs.readFile(
-        path.resolve(path.dirname(pkgPath), scriptPath),
-        (e, buf) => (e ? rej(e) : res(buf.toString()))
-      )
-    )
+    this.browserScript = (await readFile(
+      path.resolve(path.dirname(pkgPath), scriptPath)
+    )).toString()
   }
 
   // NOTE: It cannot test because of overriding `require` in Jest context.

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,9 +2,12 @@ import express, { Express } from 'express'
 import fs from 'fs'
 import path from 'path'
 import url from 'url'
+import promisify from 'util.promisify'
 import { Converter, ConvertedCallback } from './converter'
 import { error } from './error'
 import { File, markdownExtensions } from './file'
+
+const lstat = promisify(fs.lstat)
 
 export class Server {
   readonly converter: Converter
@@ -49,9 +52,7 @@ export class Server {
       )
 
       try {
-        const stat = await new Promise<fs.Stats>((resolve, reject) =>
-          fs.lstat(targetPath, (e, stats) => (e ? reject(e) : resolve(stats)))
-        )
+        const stat: fs.Stats = await lstat(targetPath)
 
         if (stat.isFile()) {
           fn = targetPath

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,10 +1,13 @@
 import { MarpitOptions, MarpitRenderResult, Element } from '@marp-team/marpit'
 import fs from 'fs'
 import path from 'path'
+import promisify from 'util.promisify'
 import barePug from './bare/bare.pug'
 import bareScss from './bare/bare.scss'
 import bespokePug from './bespoke/bespoke.pug'
 import bespokeScss from './bespoke/bespoke.scss'
+
+const readFile = promisify(fs.readFile)
 
 export interface TemplateOptions {
   base?: string
@@ -62,13 +65,8 @@ export const bespoke: Template = async opts => {
   }
 }
 
-export function libJs(fn: string) {
-  return new Promise<string>((resolve, reject) =>
-    fs.readFile(
-      path.resolve(__dirname, fn), // __dirname is "lib" after bundle
-      (e, data) => (e ? reject(e) : resolve(data.toString()))
-    )
-  )
+export async function libJs(fn: string) {
+  return (await readFile(path.resolve(__dirname, fn))).toString()
 }
 
 export async function watchJs(notifyWS?: string) {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,7 +2,11 @@ import { Marpit } from '@marp-team/marpit'
 import fs from 'fs'
 import globby from 'globby'
 import path from 'path'
+import promisify from 'util.promisify'
 import { warn } from './cli'
+
+const lstat = promisify(fs.lstat)
+const readFile = promisify(fs.readFile)
 
 const themeExtensions = ['*.css']
 
@@ -34,9 +38,7 @@ export class Theme {
   }
 
   async load() {
-    this.readBuffer = await new Promise<Buffer>((resolve, reject) =>
-      fs.readFile(this.filename, (e, buf) => (e ? reject(e) : resolve(buf)))
-    )
+    this.readBuffer = await readFile(this.filename)
   }
 
   private genUniqName() {
@@ -128,9 +130,7 @@ export class ThemeSet {
     for (const f of fn) {
       if (!globby.hasMagic(f)) {
         try {
-          const stat = await new Promise<fs.Stats>((resolve, reject) =>
-            fs.lstat(f, (e, stats) => (e ? reject(e) : resolve(stats)))
-          )
+          const stat: fs.Stats = await lstat(f)
 
           if (stat.isFile() || stat.isDirectory() || stat.isSymbolicLink())
             fnForWatch.add(path.resolve(f))

--- a/test/__mocks__/fs.ts
+++ b/test/__mocks__/fs.ts
@@ -1,4 +1,11 @@
+import { custom } from 'util.promisify'
+
 const fs = require.requireActual('fs')
+
+fs.writeFile[custom] = (path, data) =>
+  new Promise((resolve, reject) =>
+    fs.writeFile(path, data, e => (e ? reject(e) : resolve()))
+  )
 
 fs.__mockWriteFile = (mockFn = (_, __, callback) => callback()) =>
   jest.spyOn(fs, 'writeFile').mockImplementation(mockFn)

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,11 +342,6 @@
   dependencies:
     "@types/superagent" "*"
 
-"@types/util.promisify@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/util.promisify/-/util.promisify-1.0.0.tgz#26a77d9b210e937430fa549b922d34f8e51185a0"
-  integrity sha512-JK7Ecs9ETHfYSoG5ZILe30Ar9fmMT7vZTirfZQQ9OAZDB8TfPVV6aQkYPtfx2MFfB+yrSY4jCfrvMdemv/9VHw==
-
 "@types/ws@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,6 +342,11 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/util.promisify@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/util.promisify/-/util.promisify-1.0.0.tgz#26a77d9b210e937430fa549b922d34f8e51185a0"
+  integrity sha512-JK7Ecs9ETHfYSoG5ZILe30Ar9fmMT7vZTirfZQQ9OAZDB8TfPVV6aQkYPtfx2MFfB+yrSY4jCfrvMdemv/9VHw==
+
 "@types/ws@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"


### PR DESCRIPTION
This PR will use `util.promisify` to wrap callback-based funcs for converting to async functions

We had wrapped some functions manually. And now, we can recieve same results by simple definition provided from `util.promisify()`. We're using polyfill to support Node 6 environment.