### PR TITLE
Enable chromium --enable-blink-gen-property-trees argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Use `util.promisify` to wrap callback-based funcs ([#32](https://github.com/marp-team/marp-cli/pull/32))
+- Enable `--enable-blink-gen-property-trees` chromium flag to prevent incorrect rendering while PDF conversion ([#33](https://github.com/marp-team/marp-cli/pull/33))
 
 ## v0.0.12 - 2018-10-09
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -183,7 +183,10 @@ export class Converter {
 
   private static async runBrowser() {
     if (!Converter.browser) {
-      const args: string[] = []
+      // Fix the rendered position of elements in <foreignObject>
+      // See: https://bugs.chromium.org/p/chromium/issues/detail?id=467484
+      const args = ['--enable-blink-gen-property-trees']
+
       let finder: () => string[] = require('is-wsl')
         ? chromeFinder.wsl
         : chromeFinder[process.platform]


### PR DESCRIPTION
Marpit's inline SVG mode causes incorrect rendering of elements inside `<foreignObject>` in current Chrome, but it will be fixed by Chromium's BlinkGenPropertyTrees. This PR will add `--enable-blink-gen-property-trees` option as the default argument to convert PDF.

It could render slide deck with the correct layout more certainly.

See: https://bugs.chromium.org/p/chromium/issues/detail?id=467484