### PR TITLE
Remove defer attribute from inline script tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `defer` attribute from inline `<script>` tag ([#34](https://github.com/marp-team/marp-cli/pull/34))
+
 ### Changed
 
 - Use `util.promisify` to wrap callback-based funcs ([#32](https://github.com/marp-team/marp-cli/pull/32))

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,7 +117,7 @@ export class MarpCLIConfig {
       lang: this.conf.lang || (await osLocale()).replace(/[_@]/g, '-'),
       options: this.conf.options || {},
       readyScript: engine.browserScript
-        ? `<script defer>${engine.browserScript}</script>`
+        ? `<script>${engine.browserScript}</script>`
         : undefined,
       template: this.args.template || this.conf.template || 'bespoke',
       theme: theme instanceof Theme ? theme.name : theme,


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer), `defer` attribute of inline `<script>` element would have no effect.

Marp CLI has defined `defer` attr to inline script for browser context. So we can remove this attribute safely.