### PR TITLE
Use Buffer.from() instead of deprecated constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `Buffer.from()` instead of deprecated constructor ([#37](https://github.com/marp-team/marp-cli/pull/37))
+
 ## v0.0.13 - 2018-11-10
 
 ### Added

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -96,7 +96,7 @@ export class Converter {
     const buffer = await file.load()
     const template = await this.convert(buffer!.toString(), file)
     const newFile = file.convert(this.options.output, this.options.type)
-    newFile.buffer = new Buffer(template.result)
+    newFile.buffer = Buffer.from(template.result)
 
     const result: ConvertResult = { file, newFile, template }
     if (this.options.server && opts.initial) return result

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -526,7 +526,9 @@ describe('Marp CLI', () => {
       const cliInfo = jest.spyOn(cli, 'info').mockImplementation()
       const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
 
-      jest.spyOn(getStdin, 'buffer').mockResolvedValue(new Buffer('# markdown'))
+      jest
+        .spyOn(getStdin, 'buffer')
+        .mockResolvedValue(Buffer.from('# markdown'))
 
       // @ts-ignore: reset cached stdin buffer
       File.stdinBuffer = undefined


### PR DESCRIPTION
`new Buffer()` has already marked as deprecated by security reason, and Node 10 outputs warning about deprecation.
https://nodesource.com/blog/understanding-the-buffer-deprecation-in-node-js-10/

We must use `Buffer.from()` instead of deprecated constructor.