### PR TITLE
Improved server mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Serve directory index and default markdown `index.md` or `PITCHME.md` in server mode ([#38](https://github.com/marp-team/marp-cli/pull/38))
+
 ### Fixed
 
 - Use `Buffer.from()` instead of deprecated constructor ([#37](https://github.com/marp-team/marp-cli/pull/37))

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "watch": "rollup -w -c"
   },
   "devDependencies": {
+    "@types/cheerio": "^0.22.9",
     "@types/chokidar": "^1.7.5",
     "@types/cosmiconfig": "^5.0.3",
     "@types/express": "^4.16.0",
@@ -59,6 +60,7 @@
     "autoprefixer": "^9.3.1",
     "bespoke": "^1.1.0",
     "bespoke-keys": "^1.1.0",
+    "cheerio": "^1.0.0-rc.2",
     "codecov": "^3.1.0",
     "cssnano": "^4.1.7",
     "jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "pkg-up": "^2.0.0",
     "portfinder": "^1.0.19",
     "puppeteer-core": "^1.10.0",
+    "serve-index": "^1.9.1",
     "tmp": "^0.0.33",
     "util.promisify": "^1.0.0",
     "ws": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jest-plugin-context": "^2.9.0",
     "node-sass": "^4.10.0",
     "npm-run-all": "^4.1.3",
+    "postcss-url": "^8.0.0",
     "prettier": "^1.15.2",
     "pug": "^2.0.3",
     "rimraf": "^2.6.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,7 @@ const external = [
   'crypto',
   'fs',
   'path',
+  'querystring',
   'url',
   'chrome-launcher/dist/chrome-finder',
   'yargs/yargs',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import commonjs from 'rollup-plugin-commonjs'
 import json from 'rollup-plugin-json'
 import nodeResolve from 'rollup-plugin-node-resolve'
 import postcss from 'rollup-plugin-postcss'
+import postcssUrl from 'postcss-url'
 import pugPlugin from 'rollup-plugin-pug'
 import { terser } from 'rollup-plugin-terser'
 import typescript from 'rollup-plugin-typescript'
@@ -27,7 +28,15 @@ const plugins = [
   typescript({ resolveJsonModule: false }),
   postcss({
     inject: false,
-    plugins: [autoprefixer(), cssnano({ preset: 'default' })],
+    plugins: [
+      postcssUrl({
+        filter: '**/assets/**/*.svg',
+        encodeType: 'base64',
+        url: 'inline',
+      }),
+      autoprefixer(),
+      cssnano({ preset: 'default' }),
+    ],
   }),
   pugPlugin({ pugRuntime: 'pug-runtime' }),
   !process.env.ROLLUP_WATCH && terser(),

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -197,7 +197,10 @@ export default async function(argv: string[] = []): Promise<number> {
       )
 
       if (cvtOpts.server) {
-        const server = new Server(converter, { onConverted })
+        const server = new Server(converter, {
+          onConverted,
+          directoryIndex: ['index.md', 'PITCHME.md'], // GitPitch compatible
+        })
         await server.start()
 
         cli.info(

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,8 +37,6 @@ export class Server {
     new Promise<void>(res => this.server!.listen(this.port, res))
   }
 
-  private
-
   private async preprocess(req: express.Request, res: express.Response) {
     // Check file path
     const pathname = url.parse(req.url).pathname || ''

--- a/src/server.ts
+++ b/src/server.ts
@@ -84,7 +84,6 @@ export class Server {
 
   private setup() {
     this.server = express()
-    this.server.set('env', 'development')
     this.server
       .get('*', (req, res, next) =>
         this.preprocess(req, res).then(() => {

--- a/src/server/assets/icon-directory.svg
+++ b/src/server/assets/icon-directory.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M82 30H57a13.91 13.91 0 0 1-8.54-3.54l-2.92-2.92A13.91 13.91 0 0 0 37 20H17a5 5 0 0 0-5 5v50c0 2.75.55 2.82 1.21.15l7.58-30.3A6.74 6.74 0 0 1 27 40h60a3.73 3.73 0 0 1 3.79 4.85l-7.58 30.3A6.74 6.74 0 0 1 77 80H22" fill="none" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/></svg>

--- a/src/server/assets/icon-file.svg
+++ b/src/server/assets/icon-file.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M70 30L53.54 13.54C51.59 11.59 50 12.25 50 15v20a5 5 0 0 0 5 5h20a5 5 0 0 1 5 5v40a5 5 0 0 1-5 5H25a5 5 0 0 1-5-5V15a5 5 0 0 1 5-5h15" fill="none" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/></svg>

--- a/src/server/assets/icon-marp.svg
+++ b/src/server/assets/icon-marp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><style>.l{fill:none;stroke:#0288d1;stroke-linecap:round;stroke-linejoin:round;stroke-width:5px}</style></defs><path class="l" d="M36.71 76.79l53.57-53.58v53.58H36.71z"/><path class="l" d="M10 76.79l53.57-53.58v53.58H10z"/></svg>

--- a/src/server/index.pug
+++ b/src/server/index.pug
@@ -4,16 +4,13 @@ html
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
-    style= style
+    style!= style
   body
     h1= directory
     ul.index
       each file in files
         li(class={ convertible: file.convertible, directory: file.directory })
-          a(href=encodeURIComponent(file.name))= file.name
+          a.link.file(href=encodeURIComponent(file.name))= file.name
 
           if file.convertible
-            |
-            | (
-            a(href=`${encodeURIComponent(file.name)}?pdf`) PDF
-            | )
+            a.link.pdf(href=`${encodeURIComponent(file.name)}?pdf`) PDF

--- a/src/server/index.pug
+++ b/src/server/index.pug
@@ -4,9 +4,16 @@ html
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
+    style= style
   body
     h1= directory
-    ul
+    ul.index
       each file in files
-        li
-          a(href=file.name)= file.name
+        li(class={ convertible: file.convertible, directory: file.directory })
+          a(href=encodeURIComponent(file.name))= file.name
+
+          if file.convertible
+            |
+            | (
+            a(href=`${encodeURIComponent(file.name)}?pdf`) PDF
+            | )

--- a/src/server/index.pug
+++ b/src/server/index.pug
@@ -1,0 +1,12 @@
+doctype
+html
+  head
+    meta(charset="UTF-8")
+    meta(name="viewport", content="width=device-width, initial-scale=1.0")
+    meta(http-equiv="X-UA-Compatible", content="ie=edge")
+  body
+    h1= directory
+    ul
+      each file in files
+        li
+          a(href=file.name)= file.name

--- a/src/server/index.scss
+++ b/src/server/index.scss
@@ -1,3 +1,75 @@
-ul.index li:not(.convertible):not(.directory) {
-  display: none;
+$list-height: 30px;
+$list-icon-size: 24px;
+$list-icon-horizontal-gap: 0.5em;
+$list-icon-vertical-gap: 5px;
+
+body {
+  background: #fff;
+  color: #444;
+  font-size: 15px;
+}
+
+h1 {
+  font-size: 26px;
+}
+
+ul.index {
+  list-style: none;
+  margin: 1em 2em;
+  max-width: 720px;
+  padding: 0;
+
+  li {
+    background-image: url('./assets/icon-file.svg');
+    background-size: $list-icon-size $list-icon-size;
+    background-repeat: no-repeat;
+    background-position: left center;
+
+    display: flex;
+    height: $list-height;
+    margin: $list-icon-vertical-gap 0 0 0;
+    padding: 0 0 0 calc(#{$list-icon-size} + #{$list-icon-horizontal-gap});
+
+    &.convertible {
+      background-image: url('./assets/icon-marp.svg');
+    }
+
+    &.directory {
+      background-image: url('./assets/icon-directory.svg');
+    }
+
+    &:not(.convertible):not(.directory) {
+      display: none;
+    }
+
+    a.link {
+      border-radius: 5px;
+      box-sizing: border-box;
+      color: #02669d;
+      display: block;
+      height: $list-height;
+      line-height: $list-height - 10px;
+      padding: 5px 10px;
+      text-decoration: none;
+
+      &:focus,
+      &:hover {
+        background: #f8f8f8;
+        text-decoration: underline;
+      }
+
+      &.file {
+        flex: 1;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+
+      &.pdf {
+        color: #9d3302;
+        flex: 0 1 auto;
+        margin: 0 0 0 $list-icon-horizontal-gap;
+      }
+    }
+  }
 }

--- a/src/server/index.scss
+++ b/src/server/index.scss
@@ -58,6 +58,10 @@ ul.index {
         text-decoration: underline;
       }
 
+      &:hover:active {
+        background: #f0f0f0;
+      }
+
       &.file {
         flex: 1;
         overflow: hidden;

--- a/src/server/index.scss
+++ b/src/server/index.scss
@@ -1,0 +1,3 @@
+ul.index li:not(.convertible):not(.directory) {
+  display: none;
+}

--- a/test/server.ts
+++ b/test/server.ts
@@ -141,6 +141,9 @@ describe('Server', () => {
         expect($('ul.index li')).toHaveLength(6) // Actual file count
         expect($('ul.index li.directory')).toHaveLength(2) // Directories
         expect($('ul.index li.convertible')).toHaveLength(3) // Markdown files
+
+        // PDF query parameter
+        expect($('li a[href*="?pdf"]')).toHaveLength(3)
       })
 
       context('with specified directoryIndex costructor option', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,6 +1899,11 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -4751,7 +4756,7 @@ mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3:
+mime@^2.0.3, mime@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
   integrity sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
@@ -6130,6 +6135,17 @@ postcss-unique-selectors@^4.0.1:
     alphanum-sort "^1.0.0"
     postcss "^7.0.0"
     uniqs "^2.0.0"
+
+postcss-url@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-url/-/postcss-url-8.0.0.tgz#7b10059bd12929cdbb1971c60f61a0e5af86b4ca"
+  integrity sha512-E2cbOQ5aii2zNHh8F6fk1cxls7QVFZjLPSrqvmiza8OuXLzIpErij8BDS5Y3STPfJgpIMNCPEr8JlKQWEoozUw==
+  dependencies:
+    mime "^2.3.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.0"
+    postcss "^7.0.2"
+    xxhashjs "^0.2.1"
 
 postcss-value-parser@^3.0.0, postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
   version "3.3.1"
@@ -8392,6 +8408,13 @@ xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
+
+xxhashjs@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^3.2.1:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,7 +380,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.5:
+accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   integrity sha1-63d99gEXI6OxTopywIBcjoZ0a9I=
@@ -911,6 +911,11 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+batch@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
+  integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -4694,7 +4699,7 @@ mime-db@~1.37.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
   integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
 
-mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.21"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
   integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
@@ -6965,6 +6970,19 @@ serialize-javascript@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
   integrity sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==
+
+serve-index@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
+  integrity sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=
+  dependencies:
+    accepts "~1.3.4"
+    batch "0.6.1"
+    debug "2.6.9"
+    escape-html "~1.0.3"
+    http-errors "~1.6.2"
+    mime-types "~2.1.17"
+    parseurl "~1.3.2"
 
 serve-static@1.13.2:
   version "1.13.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/cheerio@^0.22.9":
+  version "0.22.9"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.9.tgz#b5990152604c2ada749b7f88cab3476f21f39d7b"
+  integrity sha512-q6LuBI0t5u04f0Q4/R+cGBqIbZMtJkVvCSF+nTfFBBdQqQvJR/mNHeWjRkszyLl7oyf2rDoKUYMEjTw5AV0hiw==
+
 "@types/chokidar@^1.7.5":
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/@types/chokidar/-/chokidar-1.7.5.tgz#1fa78c8803e035bed6d98e6949e514b133b0c9b6"
@@ -1251,6 +1256,18 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
   integrity sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==
 
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  integrity sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
@@ -1679,6 +1696,16 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-selector-tokenizer@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz#a177271a8bca5019172f4f891fc6eed9cbf68d5d"
@@ -1714,7 +1741,7 @@ css-url-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/css-url-regex/-/css-url-regex-1.1.0.tgz#83834230cc9f74c457de59eebd1543feeb83b7ec"
   integrity sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=
 
-css-what@^2.1.2:
+css-what@2.1, css-what@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
   integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
@@ -2067,7 +2094,7 @@ doctypes@^1.1.0:
   resolved "https://registry.yarnpkg.com/doctypes/-/doctypes-1.1.0.tgz#ea80b106a87538774e8a3a4a5afe293de489e0a9"
   integrity sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   integrity sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=
@@ -2097,6 +2124,14 @@ domhandler@^2.3.0:
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
     domelementtype "1"
 
 domutils@^1.5.1, domutils@^1.7.0:
@@ -3053,7 +3088,7 @@ html-tags@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
   integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
 
-htmlparser2@^3.9.2:
+htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
   integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
@@ -4392,7 +4427,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -5030,7 +5065,7 @@ npm-run-path@^2.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^1.0.2:
+nth-check@^1.0.2, nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
@@ -5302,6 +5337,13 @@ parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2:
   version "1.3.2"


### PR DESCRIPTION
Current server mode is bit difficult to use because it requires to access file URL manually. This PR will provide served file list as [the directory index](https://en.wikipedia.org/wiki/Webserver_directory_index). By accessing http://localhost:8080/, marp-cli shows the list of served markdown files.

## Screenshot

![](https://user-images.githubusercontent.com/3993388/48710610-3f642f00-ec4c-11e8-8396-85604d960065.png)

Currently CLI provides the super-simple file list by using `serve-index`, but we can improve by our Pug template and SCSS.

I'm going to add a checkbox whether to toggle showing served static files (non-markdown files) in another PR.

## `?pdf` query parameter

The improved server mode no longer recognize the conversion type option like `--pdf`. We always serve the deck as HTML by default.

Instead, we recognize `?pdf` query parameter in accessed URL. You can execute the on-demand PDF conversion while serving HTML. The added directory index has the "PDF" link to trigger it.

```
http://localhost:8080/index.md?pdf
```

## Default file (`index.md` or `PITCHME.md`)

As like as several web server, we recognize `index.md` as the default page of directory index. It means that you can see the slide deck by accessing `http://localhost:8080/` if `index.md` is placed into the served directory.

If you are familiar to [GitPitch](https://gitpitch.com/), you can also place [`PITCHME.md`](https://gitpitch.com/docs/getting-started/pitchme/) to the directory.

## ToDo

- [x] Fix test about server mode