### PR TITLE
Remove ts-ignore magic comments from test

### DIFF
--- a/test/converter.ts
+++ b/test/converter.ts
@@ -199,8 +199,7 @@ describe('Converter', () => {
         it('converts into PDF by using temporally file', async () => {
           const file = new File(onePath)
 
-          // @ts-ignore to check cleanup tmpfile
-          const fileCleanup = jest.spyOn(File.prototype, 'cleanup')
+          const fileCleanup = jest.spyOn(<any>File.prototype, 'cleanup')
           const fileSave = jest
             .spyOn(File.prototype, 'save')
             .mockImplementation()

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -17,8 +17,7 @@ describe('Engine', () => {
     })
 
     it("loads browser script from defined in module's marpBrowser section", async () => {
-      // @ts-ignore: #findClassPath is mocked
-      const finder = <jest.Mock>ResolvedEngine.prototype.findClassPath
+      const finder = <jest.Mock>(<any>ResolvedEngine.prototype).findClassPath
 
       // Core (defined marpBrowser)
       finder.mockImplementation(() => require.resolve(coreModule))

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -530,8 +530,8 @@ describe('Marp CLI', () => {
         .spyOn(getStdin, 'buffer')
         .mockResolvedValue(Buffer.from('# markdown'))
 
-      // @ts-ignore: reset cached stdin buffer
-      File.stdinBuffer = undefined
+      // reset cached stdin buffer
+      ;(<any>File).stdinBuffer = undefined
 
       expect(await marpCli()).toBe(0)
       expect(cliInfo).toHaveBeenCalledWith(


### PR DESCRIPTION
We had used the `@ts-ignore` magic comment in some tests for tracking and initializing private properties. But these cases are ugly usage because any compile error won't raise.

We will update to use `any` type casting instead of `@ts-ignore`. 