### PR TITLE
Support functional engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support functional engine [#42](https://github.com/marp-team/marp-cli/pull/42)
+
 ## v0.0.14 - 2018-11-24
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support functional engine [#42](https://github.com/marp-team/marp-cli/pull/42)
+- Support functional engine ([#42](https://github.com/marp-team/marp-cli/pull/42))
 
 ## v0.0.14 - 2018-11-24
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -167,7 +167,12 @@ export class Converter {
     // for marp-core
     if (html !== undefined) opts.html = html
 
-    const engine = new this.options.engine(opts)
+    const { prototype } = this.options.engine
+
+    const engine =
+      prototype && prototype.hasOwnProperty('constructor')
+        ? new this.options.engine(opts)
+        : (<any>this.options.engine)(opts)
 
     if (typeof engine.render !== 'function')
       error('Specified engine has not implemented render() method.')

--- a/test/_configs/custom-engine/anonymous.js
+++ b/test/_configs/custom-engine/anonymous.js
@@ -1,0 +1,6 @@
+const { Marpit } = require('@marp-team/marpit')
+
+module.exports = {
+  engine: jest.fn(opts => new Marpit(opts)),
+  options: { customOption: true },
+}

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -454,7 +454,7 @@ describe('Marp CLI', () => {
           expect(html).toContain('@theme a')
         })
 
-        it('allows custom engine specified in js config', async () => {
+        it('allows custom engine class specified in js config', async () => {
           const stdout = jest
             .spyOn(process.stdout, 'write')
             .mockImplementation()
@@ -469,6 +469,20 @@ describe('Marp CLI', () => {
           const html = stdout.mock.calls[0][0].toString()
           expect(html).toContain('<b>custom</b>')
           expect(html).toContain('/* custom */')
+        })
+
+        it('allows custom engine function specified in js config', async () => {
+          jest.spyOn(process.stdout, 'write').mockImplementation()
+          jest.spyOn(console, 'warn').mockImplementation()
+
+          const conf = assetFn('_configs/custom-engine/anonymous.js')
+          const md = assetFn('_configs/custom-engine/md.md')
+          const { engine } = require(conf)
+
+          expect(await marpCli(['-c', conf, md, '-o', '-'])).toBe(0)
+          expect(engine).toBeCalledWith(
+            expect.objectContaining({ customOption: true })
+          )
         })
       })
     })


### PR DESCRIPTION
This PR will support the functional engine by passing `engine` option through JS configuration. It would become to customize Marp or Marpit engine easily by a lot of markdown-it plugins.

For example, you can use `==mark==` syntax by [markdown-it-mark](https://www.npmjs.com/package/markdown-it-mark). It will turn into `<mark>mark</mark>`.

```javascript
// marp.config.js
const { Marp } = require('@marp-team/marp-core')
const markdownItMark = require('markdown-it-mark')

module.exports = {
  engine: opts => {
    const core = new Marp(opts)
    core.markdown.use(markdownItMark)

    return core
  },
}
```