### PR TITLE
Output the configured engine in version option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support functional engine ([#42](https://github.com/marp-team/marp-cli/pull/42))
+- Output the configured engine in `version` (`-v`) option ([#43](https://github.com/marp-team/marp-cli/pull/43))
 
 ## v0.0.14 - 2018-11-24
 

--- a/src/__mocks__/engine.ts
+++ b/src/__mocks__/engine.ts
@@ -1,7 +1,0 @@
-const engine = require.requireActual('../engine')
-
-export const { ResolvedEngine } = engine
-
-ResolvedEngine.prototype.findClassPath = jest.fn()
-
-export default ResolvedEngine.resolve

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import osLocale from 'os-locale'
 import promisify from 'util.promisify'
 import { info, warn } from './cli'
 import { ConverterOption, ConvertType } from './converter'
-import resolveEngine, { ResolvableEngine } from './engine'
+import resolveEngine, { ResolvableEngine, ResolvedEngine } from './engine'
 import { CLIError } from './error'
 import { Theme, ThemeSet } from './theme'
 
@@ -47,6 +47,7 @@ export class MarpCLIConfig {
   args: IMarpCLIArguments = {}
   conf: IMarpCLIConfig = {}
   confPath?: string
+  engine!: ResolvedEngine
 
   static moduleName = 'marp'
 
@@ -55,18 +56,21 @@ export class MarpCLIConfig {
     conf.args = args
 
     await conf.loadConf(args.configFile)
-    return conf
-  }
 
-  async converterOption(): Promise<ConverterOption> {
-    const engine = await (() => {
-      if (this.args.engine) return resolveEngine(this.args.engine)
-      if (this.conf.engine)
-        return resolveEngine(this.conf.engine, this.confPath)
+    conf.engine = await (() => {
+      if (conf.args.engine) return resolveEngine(conf.args.engine)
+      if (conf.conf.engine)
+        return resolveEngine(conf.conf.engine, conf.confPath)
 
       return resolveEngine(['@marp-team/marp-core', Marp])
     })()
 
+    return conf
+  }
+
+  private constructor() {}
+
+  async converterOption(): Promise<ConverterOption> {
     const inputDir = await this.inputDir()
     const output =
       this.args.output ||
@@ -112,12 +116,12 @@ export class MarpCLIConfig {
           this.args.allowLocalFiles,
           this.conf.allowLocalFiles
         ) || false,
-      engine: engine.klass,
+      engine: this.engine.klass,
       html: this.pickDefined(this.args.html, this.conf.html),
       lang: this.conf.lang || (await osLocale()).replace(/[_@]/g, '-'),
       options: this.conf.options || {},
-      readyScript: engine.browserScript
-        ? `<script>${engine.browserScript}</script>`
+      readyScript: this.engine.browserScript
+        ? `<script>${this.engine.browserScript}</script>`
         : undefined,
       template: this.args.template || this.conf.template || 'bespoke',
       theme: theme instanceof Theme ? theme.name : theme,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,6 +14,7 @@ export type ResolvableEngine = Engine | string
 export class ResolvedEngine {
   browserScript?: string
   klass: Engine
+  package?: { [key: string]: any }
 
   private static browserScriptKey = 'marpBrowser'
 
@@ -62,7 +63,8 @@ export class ResolvedEngine {
     const pkgPath = await pkgUp(path.dirname(classPath))
     if (!pkgPath) return
 
-    const scriptPath = require(pkgPath)[ResolvedEngine.browserScriptKey]
+    this.package = require(pkgPath)
+    const scriptPath = this.package![ResolvedEngine.browserScriptKey]
     if (!scriptPath) return undefined
 
     this.browserScript = (await readFile(

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -1,4 +1,3 @@
-import { version as coreVersion } from '@marp-team/marp-core/package.json'
 import chalk from 'chalk'
 import { Argv } from 'yargs'
 import yargs from 'yargs/yargs'
@@ -9,8 +8,8 @@ import { CLIError, error } from './error'
 import { File, FileType } from './file'
 import { Server } from './server'
 import templates from './templates'
+import version from './version'
 import watcher, { Watcher } from './watcher'
-import { name, version } from '../package.json'
 
 enum OptionGroup {
   Basic = 'Basic Options:',
@@ -30,14 +29,14 @@ export default async function(argv: string[] = []): Promise<number> {
     const program = base
       .usage(usage)
       .help(false)
-      .version(
-        'version',
-        'Show package versions',
-        `${name} v${version} (/w @marp-team/marp-core v${coreVersion})`
-      )
-      .alias('version', 'v')
-      .group('version', OptionGroup.Basic)
+      .version(false)
       .options({
+        version: {
+          alias: 'v',
+          describe: 'Show versions',
+          group: OptionGroup.Basic,
+          type: 'boolean',
+        },
         help: {
           alias: 'h',
           describe: 'Show help',
@@ -121,8 +120,10 @@ export default async function(argv: string[] = []): Promise<number> {
       return 0
     }
 
-    // Initialize converter
     const config = await fromArguments(args)
+    if (args.version) return await version(config)
+
+    // Initialize converter
     const converter = new Converter(await config.converterOption())
     const cvtOpts = converter.options
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,22 @@
+import { Marp } from '@marp-team/marp-core'
+import { version as bundledCoreVer } from '@marp-team/marp-core/package.json'
+import { MarpCLIConfig } from './config'
+import { name, version } from '../package.json'
+
+export default async function outputVersion(config: MarpCLIConfig): Promise<0> {
+  let message = `${name} v${version} `
+  const { engine } = config
+
+  if (engine.klass === Marp) {
+    message += `(/w bundled @marp-team/marp-core v${bundledCoreVer})`
+  } else if (engine.package) {
+    message += `(/w customized engine in ${engine.package.name} v${
+      engine.package.version
+    })`
+  } else {
+    message += `(/w customized engine)`
+  }
+
+  console.log(message)
+  return 0
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,7 +9,7 @@ export default async function outputVersion(config: MarpCLIConfig): Promise<0> {
 
   if (engine.klass === Marp) {
     message += `(/w bundled @marp-team/marp-core v${bundledCoreVer})`
-  } else if (engine.package) {
+  } else if (engine.package && engine.package.name && engine.package.version) {
     message += `(/w customized engine in ${engine.package.name} v${
       engine.package.version
     })`

--- a/test/_configs/custom-engine/custom-engine.js
+++ b/test/_configs/custom-engine/custom-engine.js
@@ -1,0 +1,13 @@
+module.exports = class CustomEngine {
+  constructor() {
+    this.markdown = {
+      set: jest.fn(),
+    }
+
+    this.themeSet = {}
+  }
+
+  render() {
+    return { html: '<b>custom</b>', css: '/* custom */' }
+  }
+}

--- a/test/_configs/custom-engine/file.js
+++ b/test/_configs/custom-engine/file.js
@@ -1,0 +1,1 @@
+module.exports = { engine: './custom-engine.js' }

--- a/test/_configs/custom-engine/marp.config.js
+++ b/test/_configs/custom-engine/marp.config.js
@@ -1,17 +1,1 @@
-class CustomEngine {
-  constructor() {
-    this.markdown = {
-      set: jest.fn(),
-    }
-
-    this.themeSet = {}
-  }
-
-  render() {
-    return { html: '<b>custom</b>', css: '/* custom */' }
-  }
-}
-
-module.exports = {
-  engine: CustomEngine,
-}
+module.exports = { engine: require('./custom-engine') }

--- a/test/_configs/custom-engine/package.json
+++ b/test/_configs/custom-engine/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "custom-project",
+  "version": "0.1.2"
+}

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -1,8 +1,6 @@
 import Marp from '@marp-team/marp-core'
 import resolve, { ResolvedEngine } from '../src/engine'
 
-jest.mock('../src/engine')
-
 describe('Engine', () => {
   const coreModule = '@marp-team/marp-core'
   const marpitModule = '@marp-team/marpit'
@@ -17,7 +15,7 @@ describe('Engine', () => {
     })
 
     it("loads browser script from defined in module's marpBrowser section", async () => {
-      const finder = <jest.Mock>(<any>ResolvedEngine.prototype).findClassPath
+      const finder = jest.spyOn(<any>ResolvedEngine.prototype, 'findClassPath')
 
       // Core (defined marpBrowser)
       finder.mockImplementation(() => require.resolve(coreModule))

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -6,6 +6,7 @@ import marpCli from '../src/marp-cli'
 import * as cli from '../src/cli'
 import { File } from '../src/file'
 import { Converter, ConvertType } from '../src/converter'
+import { ResolvedEngine } from '../src/engine'
 import { CLIError } from '../src/error'
 import { Server } from '../src/server'
 import { ThemeSet } from '../src/theme'
@@ -13,9 +14,11 @@ import { Watcher } from '../src/watcher'
 
 const { version } = require('../package.json')
 const coreVersion = require('@marp-team/marp-core/package.json').version
+const marpitVersion = require('@marp-team/marpit/package.json').version
 
 jest.mock('fs')
 jest.mock('mkdirp')
+jest.mock('../src/engine')
 jest.mock('../src/watcher', () => jest.genMockFromModule('../src/watcher'))
 
 afterEach(() => jest.restoreAllMocks())
@@ -23,37 +26,84 @@ afterEach(() => jest.restoreAllMocks())
 describe('Marp CLI', () => {
   const assetFn = fn => path.resolve(__dirname, fn)
 
-  const confirmVersion = (...cmd: string[]) => {
-    it('outputs package versions about cli and core', async () => {
-      const log = jest.spyOn(console, 'log').mockImplementation()
+  for (const cmd of ['--version', '-v'])
+    context(`with ${cmd} option`, () => {
+      const { findClassPath } = <any>ResolvedEngine.prototype
+      let log: jest.SpyInstance<Console['log']>
 
-      jest.spyOn(console, 'error').mockImplementation()
-      jest.spyOn(process, 'exit').mockImplementationOnce(code => {
-        throw new CLIError('EXIT', code)
+      beforeEach(() => {
+        findClassPath.mockReset()
+        log = jest.spyOn(console, 'log').mockImplementation()
       })
 
-      expect(await marpCli(cmd)).toBe(0)
+      const mockEnginePath = path =>
+        findClassPath.mockImplementation(() => path)
 
-      const [logged] = log.mock.calls[0]
-      expect(logged).toContain(`@marp-team/marp-cli v${version}`)
-      expect(logged).toContain(`@marp-team/marp-core v${coreVersion}`)
+      it('outputs package versions about cli and bundled core', async () => {
+        expect(await marpCli([cmd])).toBe(0)
+        expect(log).toBeCalledWith(
+          expect.stringContaining(`@marp-team/marp-cli v${version}`)
+        )
+        expect(log).toBeCalledWith(
+          expect.stringContaining(
+            `bundled @marp-team/marp-core v${coreVersion}`
+          )
+        )
+      })
+
+      context('with specified Marpit engine', () => {
+        const cmds = [cmd, '--engine', '@marp-team/marpit']
+
+        beforeEach(() =>
+          mockEnginePath(
+            assetFn('../node_modules/@marp-team/marpit/lib/index.js')
+          )
+        )
+
+        it('outputs using engine name and version', async () => {
+          expect(await marpCli(cmds)).toBe(0)
+          expect(log).toBeCalledWith(
+            expect.stringContaining(`@marp-team/marpit v${marpitVersion}`)
+          )
+        })
+      })
+
+      context('with custom engine in project', () => {
+        const cmds = [cmd, '-c', assetFn('_configs/custom-engine/file.js')]
+
+        beforeEach(() =>
+          mockEnginePath(assetFn('_configs/custom-engine/custom-engine.js'))
+        )
+
+        it('outputs project name and version', async () => {
+          expect(await marpCli(cmds)).toBe(0)
+          expect(log).toBeCalledWith(
+            expect.stringContaining('custom-project v0.1.2')
+          )
+        })
+      })
+
+      context('with functional engine in config file directly', () => {
+        const cmds = [cmd, '-c', assetFn('_configs/custom-engine/anonymous.js')]
+
+        it('outputs using the customized engine', async () => {
+          expect(await marpCli(cmds)).toBe(0)
+          expect(log).toBeCalledWith(
+            expect.stringContaining('customized engine')
+          )
+        })
+      })
     })
-  }
-  ;['--version', '-v'].forEach(cmd =>
-    context(`with ${cmd} option`, () => confirmVersion(cmd))
-  )
 
-  const confirmHelp = (...cmd: string[]) => {
-    it('outputs help to stderr', async () => {
-      const error = jest.spyOn(console, 'error').mockImplementation()
+  for (const cmd of [null, '--help', '-h'])
+    context(`with ${cmd || 'empty'} option`, () => {
+      it('outputs help to stderr', async () => {
+        const error = jest.spyOn(console, 'error').mockImplementation()
 
-      expect(await marpCli(cmd)).toBe(0)
-      expect(error).toHaveBeenCalledWith(expect.stringContaining('Usage'))
+        expect(await marpCli(cmd ? [cmd] : [])).toBe(0)
+        expect(error).toHaveBeenCalledWith(expect.stringContaining('Usage'))
+      })
     })
-  }
-  ;[null, ['--help'], ['-h']].forEach(cmd =>
-    context(`with ${cmd || 'empty'} option`, () => confirmHelp(...(cmd || [])))
-  )
 
   const confirmPDF = (...cmd: string[]) => {
     it('converts file by Converter with PDF type', async () => {

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -18,7 +18,6 @@ const marpitVersion = require('@marp-team/marpit/package.json').version
 
 jest.mock('fs')
 jest.mock('mkdirp')
-jest.mock('../src/engine')
 jest.mock('../src/watcher', () => jest.genMockFromModule('../src/watcher'))
 
 afterEach(() => jest.restoreAllMocks())
@@ -28,12 +27,14 @@ describe('Marp CLI', () => {
 
   for (const cmd of ['--version', '-v'])
     context(`with ${cmd} option`, () => {
-      const { findClassPath } = <any>ResolvedEngine.prototype
       let log: jest.SpyInstance<Console['log']>
+      let findClassPath: jest.SpyInstance<ResolvedEngine['findClassPath']>
 
       beforeEach(() => {
-        findClassPath.mockReset()
         log = jest.spyOn(console, 'log').mockImplementation()
+        findClassPath = jest
+          .spyOn(<any>ResolvedEngine.prototype, 'findClassPath')
+          .mockImplementation()
       })
 
       const mockEnginePath = path =>


### PR DESCRIPTION
Improve `--version` (`-v`) option to output the version of engine based on the current configuration / arguments.

## Cases

### Default

```
$ marp -v
@marp-team/marp-cli v0.0.14 (/w bundled @marp-team/marp-core v0.2.1)
```

### Use engine specified by package name

```
$ npm install @marp-team/marpit --save-dev
$ marp -v --engine @marp-team/marpit
@marp-team/marp-cli v0.0.14 (/w customized engine in @marp-team/marpit v0.3.3)
```

### Use engine specified by JS file in your project

```
$ marp -v --engine ./your-engine.js
@marp-team/marp-cli v0.0.14 (/w customized engine in your-project v1.0.0)
```

### Use functional engine

```
$ npm install @marp-team/marp-core --save-dev
$ echo "const { Marp } = require('@marp-team/marp-core'); module.exports={engine: opts => new Marp(opts)}" > conf.js
$ marp -v -c ./conf.js
@marp-team/marp-cli v0.0.14 (/w customized engine)
```

## ToDo

- [x] Add test
  - [x] Specify the installed engine (=> show package name and version)
  - [x] Specify the functional engine (=> show as using customized engine)