### PR TITLE
[Experimental] Support opening preview window provided by Carlo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support functional engine ([#42](https://github.com/marp-team/marp-cli/pull/42))
 - Output the configured engine in `version` (`-v`) option ([#43](https://github.com/marp-team/marp-cli/pull/43))
+- Experimental support `--preview` option to open preview window provided by [Carlo](https://github.com/GoogleChromeLabs/carlo) ([#44](https://github.com/marp-team/marp-cli/pull/44))
 
 ## v0.0.14 - 2018-11-24
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
   "dependencies": {
     "@marp-team/marp-core": "^0.2.1",
     "@marp-team/marpit": "^0.3.1",
-    "carlo": "^0.9.41",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
     "chrome-launcher": "^0.10.5",
@@ -117,5 +116,8 @@
     "util.promisify": "^1.0.0",
     "ws": "^6.1.2",
     "yargs": "^12.0.5"
+  },
+  "optionalDependencies": {
+    "carlo": "^0.9.41"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "dependencies": {
     "@marp-team/marp-core": "^0.2.1",
     "@marp-team/marpit": "^0.3.1",
+    "carlo": "^0.9.41",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
     "chrome-launcher": "^0.10.5",

--- a/src/__mocks__/preview.ts
+++ b/src/__mocks__/preview.ts
@@ -1,17 +1,21 @@
+import { EventEmitter } from 'events'
+
 const preview = require.requireActual('../preview')
 const { carlo } = preview
 
+class CarloAppMock extends EventEmitter {
+  load = jest.fn().mockResolvedValue(0)
+  exit = jest.fn().mockResolvedValue(0)
+}
+
 preview.carloMock = () => {
-  const app = {
-    load: jest.fn().mockResolvedValue(0),
-    on: jest.fn(),
-    exit: jest.fn().mockResolvedValue(0),
-  }
+  const app = new CarloAppMock()
   const mockedCarlo = { launch: jest.fn(() => app) }
 
   preview.carlo = mockedCarlo
   return { app, carlo: mockedCarlo }
 }
+
 preview.carloOriginal = () => (preview.carlo = carlo)
 preview.carloUndefined = () => (preview.carlo = undefined)
 

--- a/src/__mocks__/preview.ts
+++ b/src/__mocks__/preview.ts
@@ -1,0 +1,8 @@
+const preview = require.requireActual('../preview')
+const { carlo } = preview
+
+preview.carloMock = () => (preview.carlo = jest.fn())
+preview.carloOriginal = () => (preview.carlo = carlo)
+preview.carloUndefined = () => (preview.carlo = undefined)
+
+export = preview

--- a/src/__mocks__/preview.ts
+++ b/src/__mocks__/preview.ts
@@ -1,7 +1,17 @@
 const preview = require.requireActual('../preview')
 const { carlo } = preview
 
-preview.carloMock = () => (preview.carlo = jest.fn())
+preview.carloMock = () => {
+  const app = {
+    load: jest.fn().mockResolvedValue(0),
+    on: jest.fn(),
+    exit: jest.fn().mockResolvedValue(0),
+  }
+  const mockedCarlo = { launch: jest.fn(() => app) }
+
+  preview.carlo = mockedCarlo
+  return { app, carlo: mockedCarlo }
+}
 preview.carloOriginal = () => (preview.carlo = carlo)
 preview.carloUndefined = () => (preview.carlo = undefined)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import { info, warn } from './cli'
 import { ConverterOption, ConvertType } from './converter'
 import resolveEngine, { ResolvableEngine, ResolvedEngine } from './engine'
 import { CLIError } from './error'
+import { carlo } from './preview'
 import { Theme, ThemeSet } from './theme'
 
 const lstat = promisify(fs.lstat)
@@ -84,7 +85,7 @@ export class MarpCLIConfig {
 
     const server = this.pickDefined(this.args.server, this.conf.server) || false
     const preview =
-      this.pickDefined(this.args.preview, this.conf.preview) || false
+      carlo && (this.pickDefined(this.args.preview, this.conf.preview) || false)
 
     const theme = await this.loadTheme()
     const initialThemes = theme instanceof Theme ? [theme] : []

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,8 +84,6 @@ export class MarpCLIConfig {
         : undefined)
 
     const server = this.pickDefined(this.args.server, this.conf.server) || false
-    const preview =
-      this.pickDefined(this.args.preview, this.conf.preview) || false
 
     const theme = await this.loadTheme()
     const initialThemes = theme instanceof Theme ? [theme] : []
@@ -104,10 +102,22 @@ export class MarpCLIConfig {
       initialThemes
     )
 
-    if (!carlo && preview)
-      warn(
-        'Preview window is available only in Node >= 7.6. preview option was ignored.'
-      )
+    const preview = (() => {
+      const p = this.pickDefined(this.args.preview, this.conf.preview) || false
+      let warnMes: string | undefined
+
+      if (p) {
+        if (!carlo) warnMes = 'Preview window is available only in Node >= 7.6.'
+        if (process.env.IS_DOCKER)
+          warnMes = 'Preview window cannot show in an official docker image.'
+      }
+      if (warnMes) {
+        warn(`${warnMes} preview option was ignored.`)
+        return false
+      }
+
+      return p
+    })()
 
     if (
       themeSet.themes.size <= initialThemes.length &&

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,7 +85,7 @@ export class MarpCLIConfig {
 
     const server = this.pickDefined(this.args.server, this.conf.server) || false
     const preview =
-      carlo && (this.pickDefined(this.args.preview, this.conf.preview) || false)
+      this.pickDefined(this.args.preview, this.conf.preview) || false
 
     const theme = await this.loadTheme()
     const initialThemes = theme instanceof Theme ? [theme] : []
@@ -104,6 +104,11 @@ export class MarpCLIConfig {
       initialThemes
     )
 
+    if (!carlo && preview)
+      warn(
+        'Preview window is available only in Node >= 7.6. preview option was ignored.'
+      )
+
     if (
       themeSet.themes.size <= initialThemes.length &&
       themeSetPathes.length > 0
@@ -113,7 +118,6 @@ export class MarpCLIConfig {
     return {
       inputDir,
       output,
-      preview,
       server,
       themeSet,
       allowLocalFiles:
@@ -125,6 +129,7 @@ export class MarpCLIConfig {
       html: this.pickDefined(this.args.html, this.conf.html),
       lang: this.conf.lang || (await osLocale()).replace(/[_@]/g, '-'),
       options: this.conf.options || {},
+      preview: carlo && preview,
       readyScript: this.engine.browserScript
         ? `<script>${this.engine.browserScript}</script>`
         : undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export interface IMarpCLIArguments {
   inputDir?: string
   output?: string
   pdf?: boolean
+  preview?: boolean
   server?: boolean
   template?: string
   theme?: string
@@ -82,6 +83,8 @@ export class MarpCLIConfig {
         : undefined)
 
     const server = this.pickDefined(this.args.server, this.conf.server) || false
+    const preview =
+      this.pickDefined(this.args.preview, this.conf.preview) || false
 
     const theme = await this.loadTheme()
     const initialThemes = theme instanceof Theme ? [theme] : []
@@ -109,6 +112,7 @@ export class MarpCLIConfig {
     return {
       inputDir,
       output,
+      preview,
       server,
       themeSet,
       allowLocalFiles:
@@ -132,7 +136,10 @@ export class MarpCLIConfig {
           ? ConvertType.pdf
           : ConvertType.html,
       watch:
-        this.pickDefined(this.args.watch, this.conf.watch) || server || false,
+        this.pickDefined(this.args.watch, this.conf.watch) ||
+        preview ||
+        server ||
+        false,
     }
   }
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -23,6 +23,7 @@ export interface ConverterOption {
   lang: string
   options: MarpitOptions
   output?: string
+  preview?: boolean
   readyScript?: string
   server?: boolean
   template: string

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -74,15 +74,13 @@ export default async function(argv: string[] = []): Promise<number> {
           group: OptionGroup.Basic,
           type: 'boolean',
         },
-        ...(carlo
-          ? {
-              preview: {
-                describe: 'Open preview window (EXPERIMENTAL)',
-                group: OptionGroup.Basic,
-                type: 'boolean',
-              },
-            }
-          : {}),
+        preview: {
+          describe: `Open preview window (EXPERIMENTAL)${
+            carlo ? '' : ` ${chalk.red('[Requires Node >= 7.6]')}`
+          }`,
+          group: OptionGroup.Basic,
+          type: 'boolean',
+        },
         pdf: {
           describe: 'Convert slide deck into PDF',
           group: OptionGroup.Converter,

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -24,56 +24,52 @@ Usage:
   marp [options] -I <dir>
 `.trim()
 
-export default async function(argv: string[] = []): Promise<number> {
-  try {
-    const base: Argv = yargs(argv)
-    const program = base
-      .usage(usage)
-      .help(false)
-      .version(false)
-      .options({
-        version: {
-          alias: 'v',
-          describe: 'Show versions',
-          group: OptionGroup.Basic,
-          type: 'boolean',
-        },
-        help: {
-          alias: 'h',
-          describe: 'Show help',
-          group: OptionGroup.Basic,
-          type: 'boolean',
-        },
-        output: {
-          alias: 'o',
-          describe: 'Output file path (or directory when input-dir is passed)',
-          group: OptionGroup.Basic,
-          type: 'string',
-        },
-        'input-dir': {
-          alias: 'I',
-          describe: 'The base directory to find markdown and theme CSS',
-          group: OptionGroup.Basic,
-          type: 'string',
-        },
-        'config-file': {
-          alias: 'c',
-          describe: 'Specify path to configuration file',
-          group: OptionGroup.Basic,
-          type: 'string',
-        },
-        watch: {
-          alias: 'w',
-          describe: 'Watch input markdowns for changes',
-          group: OptionGroup.Basic,
-          type: 'boolean',
-        },
-        server: {
-          alias: 's',
-          describe: 'Enable server mode',
-          group: OptionGroup.Basic,
-          type: 'boolean',
-        },
+const options: { [k: string]: any } = {
+  version: {
+    alias: 'v',
+    describe: 'Show versions',
+    group: OptionGroup.Basic,
+    type: 'boolean',
+  },
+  help: {
+    alias: 'h',
+    describe: 'Show help',
+    group: OptionGroup.Basic,
+    type: 'boolean',
+  },
+  output: {
+    alias: 'o',
+    describe: 'Output file path (or directory when input-dir is passed)',
+    group: OptionGroup.Basic,
+    type: 'string',
+  },
+  'input-dir': {
+    alias: 'I',
+    describe: 'The base directory to find markdown and theme CSS',
+    group: OptionGroup.Basic,
+    type: 'string',
+  },
+  'config-file': {
+    alias: 'c',
+    describe: 'Specify path to configuration file',
+    group: OptionGroup.Basic,
+    type: 'string',
+  },
+  watch: {
+    alias: 'w',
+    describe: 'Watch input markdowns for changes',
+    group: OptionGroup.Basic,
+    type: 'boolean',
+  },
+  server: {
+    alias: 's',
+    describe: 'Enable server mode',
+    group: OptionGroup.Basic,
+    type: 'boolean',
+  },
+  ...(process.env.IS_DOCKER
+    ? {}
+    : {
         preview: {
           describe: `Open preview window (EXPERIMENTAL)${
             carlo ? '' : ` ${chalk.red('[Requires Node >= 7.6]')}`
@@ -81,45 +77,55 @@ export default async function(argv: string[] = []): Promise<number> {
           group: OptionGroup.Basic,
           type: 'boolean',
         },
-        pdf: {
-          describe: 'Convert slide deck into PDF',
-          group: OptionGroup.Converter,
-          type: 'boolean',
-        },
-        template: {
-          describe: 'Choose template',
-          group: OptionGroup.Converter,
-          choices: Object.keys(templates),
-          type: 'string',
-        },
-        'allow-local-files': {
-          describe:
-            'Allow to access local files from Markdown while converting PDF (NOT SECURE)',
-          group: OptionGroup.Converter,
-          type: 'boolean',
-        },
-        engine: {
-          describe: 'Select Marpit based engine by module name or path',
-          group: OptionGroup.Marp,
-          type: 'string',
-        },
-        html: {
-          describe: 'Enable or disable HTML tag',
-          group: OptionGroup.Marp,
-          type: 'boolean',
-        },
-        theme: {
-          describe: 'Override theme by name or CSS file',
-          group: OptionGroup.Marp,
-          type: 'string',
-        },
-        'theme-set': {
-          array: true,
-          describe: 'Path to additional theme CSS files',
-          group: OptionGroup.Marp,
-          type: 'string',
-        },
-      })
+      }),
+  pdf: {
+    describe: 'Convert slide deck into PDF',
+    group: OptionGroup.Converter,
+    type: 'boolean',
+  },
+  template: {
+    describe: 'Choose template',
+    group: OptionGroup.Converter,
+    choices: Object.keys(templates),
+    type: 'string',
+  },
+  'allow-local-files': {
+    describe:
+      'Allow to access local files from Markdown while converting PDF (NOT SECURE)',
+    group: OptionGroup.Converter,
+    type: 'boolean',
+  },
+  engine: {
+    describe: 'Select Marpit based engine by module name or path',
+    group: OptionGroup.Marp,
+    type: 'string',
+  },
+  html: {
+    describe: 'Enable or disable HTML tag',
+    group: OptionGroup.Marp,
+    type: 'boolean',
+  },
+  theme: {
+    describe: 'Override theme by name or CSS file',
+    group: OptionGroup.Marp,
+    type: 'string',
+  },
+  'theme-set': {
+    array: true,
+    describe: 'Path to additional theme CSS files',
+    group: OptionGroup.Marp,
+    type: 'string',
+  },
+}
+
+export default async function(argv: string[] = []): Promise<number> {
+  try {
+    const base: Argv = yargs(argv)
+    const program = base
+      .usage(usage)
+      .help(false)
+      .version(false)
+      .options(options)
 
     const args = program.argv
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -6,7 +6,7 @@ import fromArguments from './config'
 import { Converter, ConvertedCallback } from './converter'
 import { CLIError, error } from './error'
 import { File, FileType } from './file'
-import { Preview, FilePreview, ServerPreview } from './preview'
+import { carlo, Preview, ServerPreview } from './preview'
 import { Server } from './server'
 import templates from './templates'
 import version from './version'
@@ -74,11 +74,15 @@ export default async function(argv: string[] = []): Promise<number> {
           group: OptionGroup.Basic,
           type: 'boolean',
         },
-        preview: {
-          describe: 'Open preview window (EXPERIMENTAL)',
-          group: OptionGroup.Basic,
-          type: 'boolean',
-        },
+        ...(carlo
+          ? {
+              preview: {
+                describe: 'Open preview window (EXPERIMENTAL)',
+                group: OptionGroup.Basic,
+                type: 'boolean',
+              },
+            }
+          : {}),
         pdf: {
           describe: 'Convert slide deck into PDF',
           group: OptionGroup.Converter,

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -24,100 +24,6 @@ Usage:
   marp [options] -I <dir>
 `.trim()
 
-const options: { [k: string]: any } = {
-  version: {
-    alias: 'v',
-    describe: 'Show versions',
-    group: OptionGroup.Basic,
-    type: 'boolean',
-  },
-  help: {
-    alias: 'h',
-    describe: 'Show help',
-    group: OptionGroup.Basic,
-    type: 'boolean',
-  },
-  output: {
-    alias: 'o',
-    describe: 'Output file path (or directory when input-dir is passed)',
-    group: OptionGroup.Basic,
-    type: 'string',
-  },
-  'input-dir': {
-    alias: 'I',
-    describe: 'The base directory to find markdown and theme CSS',
-    group: OptionGroup.Basic,
-    type: 'string',
-  },
-  'config-file': {
-    alias: 'c',
-    describe: 'Specify path to configuration file',
-    group: OptionGroup.Basic,
-    type: 'string',
-  },
-  watch: {
-    alias: 'w',
-    describe: 'Watch input markdowns for changes',
-    group: OptionGroup.Basic,
-    type: 'boolean',
-  },
-  server: {
-    alias: 's',
-    describe: 'Enable server mode',
-    group: OptionGroup.Basic,
-    type: 'boolean',
-  },
-  ...(process.env.IS_DOCKER
-    ? {}
-    : {
-        preview: {
-          describe: `Open preview window (EXPERIMENTAL)${
-            carlo ? '' : ` ${chalk.red('[Requires Node >= 7.6]')}`
-          }`,
-          group: OptionGroup.Basic,
-          type: 'boolean',
-        },
-      }),
-  pdf: {
-    describe: 'Convert slide deck into PDF',
-    group: OptionGroup.Converter,
-    type: 'boolean',
-  },
-  template: {
-    describe: 'Choose template',
-    group: OptionGroup.Converter,
-    choices: Object.keys(templates),
-    type: 'string',
-  },
-  'allow-local-files': {
-    describe:
-      'Allow to access local files from Markdown while converting PDF (NOT SECURE)',
-    group: OptionGroup.Converter,
-    type: 'boolean',
-  },
-  engine: {
-    describe: 'Select Marpit based engine by module name or path',
-    group: OptionGroup.Marp,
-    type: 'string',
-  },
-  html: {
-    describe: 'Enable or disable HTML tag',
-    group: OptionGroup.Marp,
-    type: 'boolean',
-  },
-  theme: {
-    describe: 'Override theme by name or CSS file',
-    group: OptionGroup.Marp,
-    type: 'string',
-  },
-  'theme-set': {
-    array: true,
-    describe: 'Path to additional theme CSS files',
-    group: OptionGroup.Marp,
-    type: 'string',
-  },
-}
-
 export default async function(argv: string[] = []): Promise<number> {
   try {
     const base: Argv = yargs(argv)
@@ -125,7 +31,99 @@ export default async function(argv: string[] = []): Promise<number> {
       .usage(usage)
       .help(false)
       .version(false)
-      .options(options)
+      .options({
+        version: {
+          alias: 'v',
+          describe: 'Show versions',
+          group: OptionGroup.Basic,
+          type: 'boolean',
+        },
+        help: {
+          alias: 'h',
+          describe: 'Show help',
+          group: OptionGroup.Basic,
+          type: 'boolean',
+        },
+        output: {
+          alias: 'o',
+          describe: 'Output file path (or directory when input-dir is passed)',
+          group: OptionGroup.Basic,
+          type: 'string',
+        },
+        'input-dir': {
+          alias: 'I',
+          describe: 'The base directory to find markdown and theme CSS',
+          group: OptionGroup.Basic,
+          type: 'string',
+        },
+        'config-file': {
+          alias: 'c',
+          describe: 'Specify path to configuration file',
+          group: OptionGroup.Basic,
+          type: 'string',
+        },
+        watch: {
+          alias: 'w',
+          describe: 'Watch input markdowns for changes',
+          group: OptionGroup.Basic,
+          type: 'boolean',
+        },
+        server: {
+          alias: 's',
+          describe: 'Enable server mode',
+          group: OptionGroup.Basic,
+          type: 'boolean',
+        },
+        ...(process.env.IS_DOCKER
+          ? {}
+          : {
+              preview: {
+                describe: `Open preview window (EXPERIMENTAL)${
+                  carlo ? '' : ` ${chalk.red('[Requires Node >= 7.6.x]')}`
+                }`,
+                group: OptionGroup.Basic,
+                type: 'boolean',
+              },
+            }),
+        pdf: {
+          describe: 'Convert slide deck into PDF',
+          group: OptionGroup.Converter,
+          type: 'boolean',
+        },
+        template: {
+          describe: 'Choose template',
+          group: OptionGroup.Converter,
+          choices: Object.keys(templates),
+          type: 'string',
+        },
+        'allow-local-files': {
+          describe:
+            'Allow to access local files from Markdown while converting PDF (NOT SECURE)',
+          group: OptionGroup.Converter,
+          type: 'boolean',
+        },
+        engine: {
+          describe: 'Select Marpit based engine by module name or path',
+          group: OptionGroup.Marp,
+          type: 'string',
+        },
+        html: {
+          describe: 'Enable or disable HTML tag',
+          group: OptionGroup.Marp,
+          type: 'boolean',
+        },
+        theme: {
+          describe: 'Override theme by name or CSS file',
+          group: OptionGroup.Marp,
+          type: 'string',
+        },
+        'theme-set': {
+          array: true,
+          describe: 'Path to additional theme CSS files',
+          group: OptionGroup.Marp,
+          type: 'string',
+        },
+      })
 
     const args = program.argv
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -25,7 +25,8 @@ export abstract class Preview {
       title: 'Marp CLI',
       args: ['--enable-blink-gen-property-trees'],
     })
-    this.carlo.load(this.file.path)
+
+    await this.carlo.load(this.file.path)
   }
 
   async close() {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,0 +1,53 @@
+import carlo from 'carlo'
+import { File } from './file'
+
+export abstract class Preview {
+  private carlo: any
+  readonly file: File
+
+  constructor(file: File) {
+    this.file = file
+  }
+
+  async open() {
+    await this.close()
+
+    this.carlo = await carlo.launch({
+      channel: ['canary', 'stable'],
+      title: 'Marp CLI',
+      args: ['--enable-blink-gen-property-trees'],
+    })
+    this.carlo.load(this.file.path)
+  }
+
+  async close() {
+    if (this.carlo) await this.carlo.exit()
+  }
+
+  on(event: string, callback: Function): void {
+    if (!this.carlo) throw new Error('Preview window is not yet initialized.')
+    this.carlo.on(event, callback)
+  }
+}
+
+export class FilePreview extends Preview {
+  // TODO: Support multiple windows through regular file conversions if Carlo
+  // could support to hide main window.
+  //
+  // @see https://github.com/GoogleChromeLabs/carlo/issues/53
+}
+
+export class ServerPreview extends Preview {
+  private static encodeURIComponentRFC3986 = url =>
+    encodeURIComponent(url).replace(
+      /[!'()*]/g,
+      c => `%${c.charCodeAt(0).toString(16)}`
+    )
+
+  constructor(url: string) {
+    const encodedUrl = ServerPreview.encodeURIComponentRFC3986(url)
+    const serverFile = `data:text/html,<html><head><meta http-equiv="refresh" content="0;URL='${encodedUrl}'" /></head></html>`
+
+    super(new File(serverFile))
+  }
+}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,5 +1,13 @@
-import carlo from 'carlo'
 import { File } from './file'
+
+export const carlo = (() => {
+  try {
+    // tslint:disable-next-line:no-implicit-dependencies
+    return require('carlo')
+  } catch (e) {
+    return undefined
+  }
+})()
 
 export abstract class Preview {
   private carlo: any

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -30,9 +30,6 @@ $progressHeight: 5px;
     width: 100%;
     z-index: -1;
 
-    /* Hack for incorrect rendering on Chrome */
-    transform: translateZ(0);
-
     &.bespoke-marp-active {
       pointer-events: auto;
       z-index: 0;

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -277,6 +277,22 @@ describe('Marp CLI', () => {
           })
         )
       })
+
+      context('with --preview option', () => {
+        afterEach(() => previewMock.carloOriginal())
+
+        it('opens preview window through ServerPreview.open()', async () => {
+          jest.spyOn(cli, 'info').mockImplementation()
+          jest.spyOn(Server.prototype, 'start').mockResolvedValue(0)
+
+          const open = jest.spyOn(preview.ServerPreview.prototype, 'open')
+          const { app } = previewMock.carloMock()
+
+          await marpCli(['--input-dir', files, '--server', '--preview'])
+          expect(open).toBeCalledTimes(1)
+          expect(app.load).toBeCalledTimes(1)
+        })
+      })
     })
 
     context('with specified by configuration file', () => {
@@ -584,6 +600,21 @@ describe('Marp CLI', () => {
             expect.objectContaining({ customOption: true })
           )
         })
+      })
+    })
+
+    context('with --preview option', () => {
+      it('outputs warning and starts watching', async () => {
+        const warn = jest.spyOn(cli, 'warn').mockImplementation()
+
+        jest.spyOn(cli, 'info').mockImplementation()
+        ;(<any>fs).__mockWriteFile()
+
+        expect(await marpCli([onePath, '--preview'])).toBe(0)
+        expect(warn).toBeCalledWith(
+          expect.stringContaining('only in server mode')
+        )
+        expect(Watcher.watch).toBeCalledWith([onePath], expect.anything())
       })
     })
   })

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -604,10 +604,13 @@ describe('Marp CLI', () => {
     })
 
     context('with --preview option', () => {
+      afterEach(() => previewMock.carloOriginal())
+
       it('outputs warning and starts watching', async () => {
         const warn = jest.spyOn(cli, 'warn').mockImplementation()
 
         jest.spyOn(cli, 'info').mockImplementation()
+        previewMock.carloMock()
         ;(<any>fs).__mockWriteFile()
 
         expect(await marpCli([onePath, '--preview'])).toBe(0)

--- a/test/preview.ts
+++ b/test/preview.ts
@@ -1,0 +1,81 @@
+import path from 'path'
+import { File } from '../src/file'
+import * as preview from '../src/preview'
+
+let carloMock
+
+const { FilePreview, ServerPreview } = preview
+const previewMock: any = preview
+
+jest.mock('../src/preview')
+
+beforeEach(() => (carloMock = previewMock.carloMock()))
+afterEach(() => previewMock.carloOriginal())
+
+const assetFn = fn => path.resolve(__dirname, fn)
+const assetFile = fn => new File(assetFn(fn))
+
+const previewTestCase = (factory: () => preview.Preview) => {
+  it('extends Preview abstract class', () =>
+    expect(factory()).toBeInstanceOf(preview.Preview))
+
+  describe('#open', () => {
+    it('launches Chrome instance and load registered file', async () => {
+      const instance = factory()
+      await instance.open()
+
+      expect(carloMock.carlo.launch).toBeCalledWith(
+        expect.objectContaining({ title: 'Marp CLI' })
+      )
+      expect(carloMock.app.load).toBeCalledWith(instance.file.path)
+    })
+  })
+
+  describe('#close', () => {
+    it("closes Chrome through Carlo's App.exit() while opening", async () => {
+      const instance = factory()
+      await instance.close()
+      expect(carloMock.app.exit).not.toBeCalled()
+
+      await instance.open()
+      await instance.close()
+      expect(carloMock.app.exit).toBeCalled()
+    })
+  })
+
+  describe('#on', () => {
+    it('adds callback to carlo app emitter while opening', async () => {
+      const instance = factory()
+      const callback = jest.fn()
+      expect(() => instance.on('exit', callback)).toThrow()
+
+      await instance.open()
+      expect(() => instance.on('exit', callback)).not.toThrow()
+
+      carloMock.app.emit('exit')
+      expect(callback).toBeCalled()
+    })
+  })
+}
+
+describe('FilePreview', () => {
+  const instance = (file = assetFile('_files/1.md')) => new FilePreview(file)
+  previewTestCase(instance)
+})
+
+describe('ServerPreview', () => {
+  const instance = (url = 'http://localhost:8080') => new ServerPreview(url)
+  previewTestCase(instance)
+
+  it('registers file instance to redirect with data URI format', () => {
+    expect(instance().file.path).toMatch(/^data:text\/html/)
+    expect(instance().file.path).toContain('meta http-equiv="refresh"')
+  })
+
+  context('with passing malicious URL', () => {
+    const maliciousURL = '\'" /><leaked-tag /><meta data-x="'
+
+    it('encodes to formatted URI to prevent XSS', () =>
+      expect(instance(maliciousURL).file.path).not.toContain('<leaked-tag />'))
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,6 +1165,14 @@ capture-exit@^1.2.0:
   dependencies:
     rsvp "^3.3.3"
 
+carlo@^0.9.41:
+  version "0.9.41"
+  resolved "https://registry.yarnpkg.com/carlo/-/carlo-0.9.41.tgz#5c31bfc132437dffdd1ec121abbeddb4844da32c"
+  integrity sha512-4iiaJqrHnOl9GP/UTi9K5rjAlolbEkvmzwzSsf5jHyZ83xjbxL5dtGw5Lbv1hJLp+rJ37xRkSaRKSKpM3Oy50Q==
+  dependencies:
+    debug "^4.1.0"
+    puppeteer-core "^1.9.0"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -6084,6 +6092,11 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
   integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
 
+progress@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.2.tgz#db9476f916bcc9ebe8a04efb22b18b0740376c61"
+  integrity sha512-/OLz5F9beZUWwSHZDreXgap1XShX6W+DCHQCqwCF7uZ88s6uTlD2cR3JBE77SegCmNtb1Idst+NfmwcdU6KVhw==
+
 promise.series@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/promise.series/-/promise.series-0.2.0.tgz#2cc7ebe959fc3a6619c04ab4dbdc9e452d864bbd"
@@ -6255,6 +6268,20 @@ puppeteer-core@^1.10.0:
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
     ws "^5.1.1"
+
+puppeteer-core@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-1.11.0.tgz#34ad606115f2b1299aeec3cf68cd0dc4e2f26aa9"
+  integrity sha512-JTsJKCQdrk1RqEGZN3l2TyW7Rhy7GWRRzd3PftYyA3B35l0t0lLU+gdF7czemnpSVVMiAgHpM1Uk/iO6jLreMA==
+  dependencies:
+    debug "^4.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^6.1.0"
 
 q@^1.1.2:
   version "1.5.1"
@@ -8180,7 +8207,7 @@ ws@^5.1.1, ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.1.2:
+ws@^6.1.0, ws@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
   integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==


### PR DESCRIPTION
Support an experimental `--preview` option to open a preview window provided by [Carlo](https://github.com/GoogleChromeLabs/carlo). Marp CLI can open a mini window to show a preview of editing Markdown by using Chrome instance.

<img width="671" alt="preview" src="https://user-images.githubusercontent.com/3993388/49495207-a0734000-f8a5-11e8-9f5b-f901ef0e49f2.png">
<img width="1176" alt="preview2" src="https://user-images.githubusercontent.com/3993388/49498955-1086c380-f8b0-11e8-99b8-483338cb815c.png">

If you turned on `--preview` option, `--watch` option is enabled automatically too. It would provide a better experience while writing the Marp presentation in your favorite editor as like as [Deckset](https://www.deckset.com/features/).

Of course you can use it to the actual presentation by maximize window.

## Restrictions

It is marked as *an experimental support* because of some restrictions.

- Marp CLI is still supporting Node v6, but Carlo is not supported, requires Node >= 7. You can not use `--preview` option if Marp CLI is running in Node 6.
- `--preview` is available only together with `--server` option. For regular conversion, we need to handle multiple windows against found files specified by file paths, glob, and `--input-dir` option.

## Tasks

### for this PR

- [x] Add tests

### In future

- `--preview` option for regular conversion
  - Handle multiple files
- `-p` alias
- Toggle some features
  - Fullscreen
  - Always on top (It might be impossible currently)