### PR TITLE
Add -p alias to --preview option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Support `--preview` option in regular conversion and multiple files ([#47](https://github.com/marp-team/marp-cli/pull/47))
+- Add `-p` alias to `--preview` option ([#48](https://github.com/marp-team/marp-cli/pull/48))
 
 ## v0.0.15 - 2018-12-06
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -78,6 +78,7 @@ export default async function(argv: string[] = []): Promise<number> {
           ? {}
           : {
               preview: {
+                alias: 'p',
                 describe: 'Open preview window (EXPERIMENTAL)',
                 group: OptionGroup.Basic,
                 type: 'boolean',

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -607,7 +607,7 @@ describe('Marp CLI', () => {
       })
     })
 
-    context('with --preview option', () => {
+    context('with --preview / -p option', () => {
       let warn: jest.SpyInstance<Console['warn']>
 
       beforeEach(() => {
@@ -616,7 +616,7 @@ describe('Marp CLI', () => {
       })
 
       it('opens preview window through Preview.open()', async () => {
-        await marpCli([onePath, '--preview', '-o', '-'])
+        await marpCli([onePath, '-p', '-o', '-'])
         expect(Preview.prototype.open).toBeCalledTimes(1)
 
         // Simualte opening event


### PR DESCRIPTION
Until merging #47, We had not provided shorthand option for preview because it was not supported regular conversion. And now, the preview option is working in regular conversion. So we add `-p` alias to preview option.