### PR TITLE
Support full screen in bespoke template

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "rollup-plugin-terser": "^3.0.0",
     "rollup-plugin-typescript": "^1.0.0",
     "rollup-plugin-url": "^2.1.0",
+    "screenfull": "^4.0.0",
     "strip-ansi": "^5.0.0",
     "stylelint": "^9.9.0",
     "stylelint-config-prettier": "^4.0.0",

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -1,6 +1,7 @@
 import bespoke from 'bespoke'
 import bespokeClasses from './classes'
 import bespokeCursor from './cursor'
+import bespokeFullscreen from './fullscreen'
 import bespokeHash from './hash'
 import bespokeNavigation from './navigation'
 import bespokeProgress from './progress'
@@ -12,6 +13,7 @@ export default function() {
     bespokeCursor(),
     bespokeHash({ history: false }),
     bespokeNavigation(),
+    bespokeFullscreen,
     bespokeProgress,
     bespokeTouch(),
   ])

--- a/src/templates/bespoke/fullscreen.ts
+++ b/src/templates/bespoke/fullscreen.ts
@@ -3,7 +3,9 @@ import screenfull from 'screenfull'
 export default function bespokeFullscreen({ parent }) {
   document.addEventListener('keydown', e => {
     // `f` or F11
-    if ((e.which === 70 || e.which === 122) && screenfull.enabled)
+    if ((e.which === 70 || e.which === 122) && screenfull.enabled) {
       screenfull.toggle(parent)
+      e.preventDefault()
+    }
   })
 }

--- a/src/templates/bespoke/fullscreen.ts
+++ b/src/templates/bespoke/fullscreen.ts
@@ -1,0 +1,9 @@
+import screenfull from 'screenfull'
+
+export default function bespokeFullscreen({ parent }) {
+  document.addEventListener('keydown', e => {
+    // `f` or F11
+    if ((e.which === 70 || e.which === 122) && screenfull.enabled)
+      screenfull.toggle(parent)
+  })
+}

--- a/test/__mocks__/screenfull.ts
+++ b/test/__mocks__/screenfull.ts
@@ -1,0 +1,4 @@
+module.exports = {
+  enabled: true,
+  toggle: jest.fn(() => Promise.resolve()),
+}

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -1,9 +1,11 @@
 /** @jest-environment jsdom */
 import Marp from '@marp-team/marp-core'
 import { Element as MarpitElement } from '@marp-team/marpit'
+import screenfull from 'screenfull'
 import { Key } from 'ts-keycode-enum'
 import bespoke from '../../src/templates/bespoke/bespoke'
 
+jest.mock('screenfull')
 jest.useFakeTimers()
 
 afterEach(() => jest.restoreAllMocks())
@@ -19,6 +21,9 @@ describe("Bespoke template's browser context", () => {
     document.body.innerHTML = marp.render(md).html
     return document.getElementById('presentation')!
   }
+
+  const keydown = (opts, target = document) =>
+    target.dispatchEvent(new KeyboardEvent('keydown', opts))
 
   describe('Classes', () => {
     it('adds bespoke classes to #presentation', () => {
@@ -82,6 +87,23 @@ describe("Bespoke template's browser context", () => {
     })
   })
 
+  describe('Fullscreen', () => {
+    beforeEach(() => {
+      render()
+      bespoke()
+    })
+
+    it('toggles fullscreen by hitting f key', () => {
+      keydown({ which: Key.F })
+      expect(screenfull.toggle).toBeCalled()
+    })
+
+    it('toggles fullscreen by hitting F11 key', () => {
+      keydown({ which: Key.F11 })
+      expect(screenfull.toggle).toBeCalled()
+    })
+  })
+
   describe('Hash', () => {
     it('activates initial page by hash index', () => {
       location.href = 'http://localhost/#2'
@@ -112,9 +134,6 @@ describe("Bespoke template's browser context", () => {
     })
 
     it('navigates page by keyboard', () => {
-      const keydown = opts =>
-        document.dispatchEvent(new KeyboardEvent('keydown', opts))
-
       // bespoke-keys
       keydown({ which: Key.RightArrow })
       expect(deck.slide()).toBe(1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6891,6 +6891,11 @@ sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+screenfull@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-4.0.0.tgz#86f3c26a2e516c8143884d8af16d07f0cb653394"
+  integrity sha512-b5e07aVR219hkfKqKsBpUqGrR4JCB8UeHT3RiocIf/fXE9TMSkadO5H83r7XYSV05w2uRF9gWvZYiLgOHS6O5g==
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"


### PR DESCRIPTION
This PR will add supporting full screen in bespoke template.

You can toggle full screen by hitting <kbd>f</kbd> or <kbd>F11</kbd> key. These shortcuts have a compatibillity with the other slide frameworks. (reveal.js, remark.js, etc.)

As an edge case, hitting `f` key for text input may misrecognize to toggle full screen when the deck has an inputable element like `<input />`, `<textarea />`, and so on. Thus, we added [bespoke-forms](https://github.com/bespokejs/bespoke-forms) to prevent key events on forms.

