### PR TITLE
Improve WebKit browser support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve WebKit browser support ([#55](https://github.com/marp-team/marp-cli/pull/55))
+
 ## v0.1.0 - 2018-12-23
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "typescript": "^3.2.2"
   },
   "dependencies": {
-    "@marp-team/marp-core": "^0.4.0",
+    "@marp-team/marp-core": "^0.4.1",
     "@marp-team/marpit": "^0.5.0",
     "carlo": "^0.9.43",
     "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
     "typescript": "^3.2.2"
   },
   "dependencies": {
-    "@marp-team/marp-core": "^0.3.1",
-    "@marp-team/marpit": "^0.4.1",
+    "@marp-team/marp-core": "^0.4.0",
+    "@marp-team/marpit": "^0.5.0",
     "carlo": "^0.9.43",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",

--- a/src/templates/bare/bare.pug
+++ b/src/templates/bare/bare.pug
@@ -5,7 +5,8 @@ html(lang=lang)
       base(href=base)
 
     meta(charset="UTF-8")
-    meta(name="viewport", content="width=device-width, initial-scale=1.0")
+    meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
+    meta(name="apple-mobile-web-app-capable", content="yes")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
     style(media="screen")!= bare.css
     style!= css

--- a/src/templates/bespoke/bespoke.pug
+++ b/src/templates/bespoke/bespoke.pug
@@ -5,7 +5,8 @@ html(lang=lang)
       base(href=base)
 
     meta(charset="UTF-8")
-    meta(name="viewport", content="width=device-width, initial-scale=1.0")
+    meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
+    meta(name="apple-mobile-web-app-capable", content="yes")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
     style!= bespoke.css
     style!= css

--- a/src/templates/bespoke/fullscreen.ts
+++ b/src/templates/bespoke/fullscreen.ts
@@ -1,10 +1,16 @@
 import screenfull from 'screenfull'
 
-export default function bespokeFullscreen({ parent }) {
+export default function bespokeFullscreen() {
   document.addEventListener('keydown', e => {
-    // `f` or F11
-    if ((e.which === 70 || e.which === 122) && screenfull.enabled) {
-      screenfull.toggle(parent)
+    // `f` or F11 without modifier key Alt, Control, and Command
+    if (
+      (e.which === 70 || e.which === 122) &&
+      !e.altKey &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      screenfull.enabled
+    ) {
+      screenfull.toggle(document.body)
       e.preventDefault()
     }
   })

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -58,7 +58,9 @@ export const bespoke: Template = async opts => {
       readyScript:
         opts.readyScript ||
         `<script>${await libJs(
-          '../node_modules/@marp-team/marpit-svg-polyfill/lib/polyfill.browser.js'
+          require.resolve(
+            '@marp-team/marpit-svg-polyfill/lib/polyfill.browser.js'
+          )
         )}</script>`,
       bespoke: {
         css: bespokeScss,

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -55,6 +55,11 @@ export const bespoke: Template = async opts => {
     result: bespokePug({
       ...opts,
       ...rendered,
+      readyScript:
+        opts.readyScript ||
+        `<script>${await libJs(
+          '../node_modules/@marp-team/marpit-svg-polyfill/lib/polyfill.browser.js'
+        )}</script>`,
       bespoke: {
         css: bespokeScss,
         js: await libJs('bespoke.js'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,13 +138,13 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marp-core@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.4.0.tgz#46f6e29d6bce01021b75342ffd6d39c6513646f2"
-  integrity sha512-O88XBnW4tSCnGX0xL91iguONprIA+KQELthmi5n/Fe+b2qj26ZK1H+Zmd6jYb7T37HxesxTLZwh1lSaWDz+rgQ==
+"@marp-team/marp-core@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.4.1.tgz#c731fc5ae279116738db134d49eef85094748260"
+  integrity sha512-TIJ9sbz9GzgM4NDNqz0j864uamHMJYS7qvMGhXt5lUWSUgkOSlDrmeqWfpuj4MZX55JcXnZE/3WuzUe2w1rHJA==
   dependencies:
     "@marp-team/marpit" "^0.5.0"
-    "@marp-team/marpit-svg-polyfill" "^0.1.0"
+    "@marp-team/marpit-svg-polyfill" "^0.2.0"
     emoji-regex "^7.0.3"
     highlight.js "^9.13.1"
     katex "^0.10.0"
@@ -154,10 +154,10 @@
     twemoji "^11.2.0"
     xss "^1.0.3"
 
-"@marp-team/marpit-svg-polyfill@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-0.1.0.tgz#91a52bbbe1833520bf7727dd6828a7c5b43def4c"
-  integrity sha512-LL3v5jzKHk2bcVduGHFC80y9jyTXDpg0q78ZSvsrVVvfbYxVBAKGNcZ4UysJcNb6p6SiLsGf/uNHBYaU1A479g==
+"@marp-team/marpit-svg-polyfill@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-0.2.0.tgz#e5bbf2ea9cc6ac21068019d88816fc5cd87410e4"
+  integrity sha512-OczYQQYUGPVuPPD/vQa0gS8UutIo5QOa1WiXgh80D8K8hBiSAJfKxViz0HKUUhwyURJRYiTioNYFcKQ1Ikjuww==
   dependencies:
     detect-browser "^3.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,12 +138,13 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marp-core@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.3.1.tgz#b9817cfbb25d1aa4fb89573fa6cf043cd24b95e2"
-  integrity sha512-LBfPSAo6sPm5Oumhe4ANLb4GKIxLvGBFvpFnevUSDHz8meXz/hzF3BL6dUK6fla8ZBkrzl8IqSRSNv0thPkhWQ==
+"@marp-team/marp-core@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.4.0.tgz#46f6e29d6bce01021b75342ffd6d39c6513646f2"
+  integrity sha512-O88XBnW4tSCnGX0xL91iguONprIA+KQELthmi5n/Fe+b2qj26ZK1H+Zmd6jYb7T37HxesxTLZwh1lSaWDz+rgQ==
   dependencies:
-    "@marp-team/marpit" "^0.4.1"
+    "@marp-team/marpit" "^0.5.0"
+    "@marp-team/marpit-svg-polyfill" "^0.1.0"
     emoji-regex "^7.0.3"
     highlight.js "^9.13.1"
     katex "^0.10.0"
@@ -153,11 +154,19 @@
     twemoji "^11.2.0"
     xss "^1.0.3"
 
-"@marp-team/marpit@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.4.1.tgz#46d311ec3bebc799841c61b80a83be9e26ca3bf4"
-  integrity sha512-AvlOADhRjoGezbumlt3RzX9Fh+DKWM8Wpp+CKa4/dmAgoyFVGqzthrP6ezLH3ZiY1Tt/308RkJgGYj6Ql/0mMw==
+"@marp-team/marpit-svg-polyfill@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-0.1.0.tgz#91a52bbbe1833520bf7727dd6828a7c5b43def4c"
+  integrity sha512-LL3v5jzKHk2bcVduGHFC80y9jyTXDpg0q78ZSvsrVVvfbYxVBAKGNcZ4UysJcNb6p6SiLsGf/uNHBYaU1A479g==
   dependencies:
+    detect-browser "^3.0.1"
+
+"@marp-team/marpit@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.5.0.tgz#4e519bd46c03dfb82c162e000457f49d6e43e47f"
+  integrity sha512-AV1Hixvx9adcrr2MQu2FdUrsNULXeV5GTP+Zeqsouu0vPQfjQ+zaZTn/UMat46AK7Er9bJO6iTDQb+l2OQOVLA==
+  dependencies:
+    color-string "^1.5.3"
     js-yaml "^3.12.0"
     lodash.kebabcase "^4.1.1"
     markdown-it "^8.4.2"
@@ -1447,7 +1456,7 @@ color-string@^0.3.0:
   dependencies:
     color-name "^1.0.0"
 
-color-string@^1.5.2:
+color-string@^1.5.2, color-string@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
   integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
@@ -2023,6 +2032,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-browser@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-3.0.1.tgz#39beead014347a8a2be1f3c4cb30a0aef2127c44"
+  integrity sha512-L6b76EfUxnoxGHM5Vz7nrshQPIbOHtitDWpGufrp5srQdJrEYi1xpUVZeFbfssWAJvUWo/iDIVlz8hOP4Z8OCw==
 
 detect-indent@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
By [long standing bug](https://bugs.webkit.org/show_bug.cgi?id=23113), the outputted HTML could not present slide deck in WebKit based browser. (Safari, iOS Chrome, iOS Firefox, etc..)

![](https://raw.githubusercontent.com/marp-team/marpit-svg-polyfill/master/docs/webkit-bug.png)

But recently we have created [@marp-team/marpit-svg-polyfill](https://github.com/marp-team/marpit-svg-polyfill) to fix the unstable rendering. It includes polyfill for WebKit based browser, and its applied slide deck can present correctly even if in WebKit.

![](https://user-images.githubusercontent.com/3993388/50543080-a7287500-0c0f-11e9-97de-71af8de225fb.png)

This PR will improve WebKit browser support. It includes:

- Update Marpit framework and Marp Core to apply polyfill
- Use polyfill in bespoke template when engine has not provided browser JS (e.g. Marpit)