### PR TITLE
convertFileToPDF: Use base64 string as URL

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -132,7 +132,7 @@ export class Converter {
 
     const uri = tmpFile
       ? `file://${tmpFile.path}`
-      : `data:text/html,${file.buffer!.toString()}`
+      : `data:text/html;base64,${file.buffer!.toString('base64')}`
 
     try {
       const browser = await Converter.runBrowser()


### PR DESCRIPTION
### about

- there is a problem that PDF is not generated in Chrome Canary.
- it's generate a blank page.

### changes

- change output URL from plain-text to base64

### environment

```
Chrome Version: 73.0.3683.0 (Official Build) canary (64 bit)
```


