### PR TITLE
Add a touch-friendly OSD to bespoke template

### DIFF
--- a/src/assets/osd-fullscreen-exit.svg
+++ b/src/assets/osd-fullscreen-exit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><style>.a{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;stroke-width:5px}</style></defs><rect class="a" x="10" y="20" width="80" height="60" rx="5.67"/><path class="a" d="M20 50h20v20M20 70l20-20M80 50H60V30M80 30L60 50"/></svg>

--- a/src/assets/osd-fullscreen.svg
+++ b/src/assets/osd-fullscreen.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><style>.a{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;stroke-width:5px}</style></defs><rect class="a" x="10" y="20" width="80" height="60" rx="5.67"/><path class="a" d="M40 70H20V50M40 50L20 70M60 30h20v20M60 50l20-20"/></svg>

--- a/src/assets/osd-next.svg
+++ b/src/assets/osd-next.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5" d="M32 90l40-40-40-40"/></svg>

--- a/src/assets/osd-prev.svg
+++ b/src/assets/osd-prev.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5" d="M68 90L28 50l40-40"/></svg>

--- a/src/templates/bespoke/bespoke.pug
+++ b/src/templates/bespoke/bespoke.pug
@@ -15,11 +15,11 @@ html(lang=lang)
       .bespoke-progress-parent
         .bespoke-progress-bar
 
-    .bespoke-marp-osd(tabindex=-1)
-      button(data-bespoke-marp-osd="prev" title="Previous slide") Previous slide
+    .bespoke-marp-osd
+      button(data-bespoke-marp-osd="prev" tabindex=-1 title="Previous slide") Previous slide
       span(data-bespoke-marp-osd="page")
-      button(data-bespoke-marp-osd="next" title="Next slide") Next slide
-      button(data-bespoke-marp-osd="fullscreen" title="Toggle fullscreen (f)") Toggle fullscreen
+      button(data-bespoke-marp-osd="next" tabindex=-1 title="Next slide") Next slide
+      button(data-bespoke-marp-osd="fullscreen" tabindex=-1 title="Toggle fullscreen (f)") Toggle fullscreen
 
     != html
     != readyScript

--- a/src/templates/bespoke/bespoke.pug
+++ b/src/templates/bespoke/bespoke.pug
@@ -15,10 +15,11 @@ html(lang=lang)
       .bespoke-progress-parent
         .bespoke-progress-bar
 
-    .bespoke-marp-osd
-      button(data-bespoke-marp-osd="prev") &lt;
-      button(data-bespoke-marp-osd="next") &gt;
-      button(data-bespoke-marp-osd="fullscreen") Fullscreen
+    .bespoke-marp-osd(tabindex=-1)
+      button(data-bespoke-marp-osd="prev" title="Previous slide") Previous slide
+      span(data-bespoke-marp-osd="page")
+      button(data-bespoke-marp-osd="next" title="Next slide") Next slide
+      button(data-bespoke-marp-osd="fullscreen" title="Toggle fullscreen (f)") Toggle fullscreen
 
     != html
     != readyScript

--- a/src/templates/bespoke/bespoke.pug
+++ b/src/templates/bespoke/bespoke.pug
@@ -15,6 +15,11 @@ html(lang=lang)
       .bespoke-progress-parent
         .bespoke-progress-bar
 
+    .bespoke-marp-osd
+      button(data-bespoke-marp-osd="prev") &lt;
+      button(data-bespoke-marp-osd="next") &gt;
+      button(data-bespoke-marp-osd="fullscreen") Fullscreen
+
     != html
     != readyScript
     script!= bespoke.js

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -22,32 +22,100 @@ $progressHeight: 5px;
     top: 0;
 
     > .bespoke-marp-osd {
-      background: rgba(0, 0, 0, 0.65);
+      background: rgba(#000, 0.65);
       border-radius: 7px;
       bottom: 50px;
       color: #fff;
       display: block;
+      font-family: Helvetica, Arial, sans-serif;
+      font-size: 16px;
       left: 50%;
       line-height: 0;
       opacity: 1;
+      outline: none;
       padding: 12px;
-      pointer-events: none;
       position: absolute;
       touch-action: manipulation;
       transform: translateX(-50%);
       transition: opacity 0.2s linear;
       user-select: none;
+      white-space: nowrap;
       z-index: 1;
 
-      button {
-        appearance: none;
-        background: transparent;
-        border: 0;
-        color: inherit;
+      > * {
+        margin-left: 6px;
+
+        &:first-child {
+          margin-left: 0;
+        }
       }
 
-      [data-bespoke-marp-osd] {
-        pointer-events: auto;
+      > span {
+        opacity: 0.8;
+
+        &[data-bespoke-marp-osd='page'] {
+          display: inline-block;
+          min-width: 140px;
+          text-align: center;
+        }
+      }
+
+      > button {
+        appearance: none;
+        background-color: transparent;
+        border: 0;
+        color: inherit;
+        cursor: pointer;
+        font-size: inherit;
+        opacity: 0.8;
+        outline: none;
+        padding: 0;
+        transition: opacity 0.2s linear;
+
+        -webkit-tap-highlight-color: transparent;
+
+        &:hover {
+          opacity: 1;
+
+          &:active {
+            opacity: 0.6;
+          }
+
+          &:not(:disabled) {
+            transition: none;
+          }
+        }
+
+        &:disabled {
+          cursor: not-allowed;
+          opacity: 0.15 !important;
+        }
+
+        @mixin icon-button($icon, $size: 32px) {
+          background-size: contain;
+          background: transparent url($icon) no-repeat center center;
+          height: $size;
+          overflow: hidden;
+          text-indent: 100%;
+          white-space: nowrap;
+          width: $size;
+        }
+
+        &[data-bespoke-marp-osd='prev'] {
+          @include icon-button('../../assets/osd-prev.svg');
+        }
+
+        &[data-bespoke-marp-osd='next'] {
+          @include icon-button('../../assets/osd-next.svg');
+        }
+
+        &[data-bespoke-marp-osd='fullscreen'] {
+          @include icon-button('../../assets/osd-fullscreen.svg');
+
+          &.exit {
+            background-image: url('../../assets//osd-fullscreen-exit.svg');
+          }
+        }
       }
     }
 
@@ -56,10 +124,7 @@ $progressHeight: 5px;
 
       > .bespoke-marp-osd {
         opacity: 0;
-
-        [data-bespoke-marp-osd] {
-          pointer-events: none;
-        }
+        pointer-events: none;
       }
     }
   }

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -32,7 +32,6 @@ $progressHeight: 5px;
       left: 50%;
       line-height: 0;
       opacity: 1;
-      outline: none;
       padding: 12px;
       position: absolute;
       touch-action: manipulation;

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -22,17 +22,21 @@ $progressHeight: 5px;
     top: 0;
 
     > .bespoke-marp-osd {
-      background: rgba(0, 0, 0, 0.5);
-      border-radius: 10px;
+      background: rgba(0, 0, 0, 0.65);
+      border-radius: 7px;
       bottom: 50px;
       color: #fff;
       display: block;
       left: 50%;
-      opacity: 0.75;
-      padding: 0.5em;
+      line-height: 0;
+      opacity: 1;
+      padding: 12px;
+      pointer-events: none;
       position: absolute;
+      touch-action: manipulation;
       transform: translateX(-50%);
       transition: opacity 0.2s linear;
+      user-select: none;
       z-index: 1;
 
       button {
@@ -41,6 +45,10 @@ $progressHeight: 5px;
         border: 0;
         color: inherit;
       }
+
+      [data-bespoke-marp-osd] {
+        pointer-events: auto;
+      }
     }
 
     &.bespoke-marp-inactive {
@@ -48,7 +56,10 @@ $progressHeight: 5px;
 
       > .bespoke-marp-osd {
         opacity: 0;
-        pointer-events: none;
+
+        [data-bespoke-marp-osd] {
+          pointer-events: none;
+        }
       }
     }
   }

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -43,7 +43,7 @@ $progressHeight: 5px;
       }
     }
 
-    &.bespoke-marp-cursor-inactive {
+    &.bespoke-marp-inactive {
       cursor: none;
 
       > .bespoke-marp-osd {

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -9,6 +9,11 @@ $progressHeight: 5px;
     overflow: hidden;
   }
 
+  .bespoke-marp-osd {
+    display: none;
+    opacity: 0;
+  }
+
   .bespoke-marp-parent {
     bottom: 0;
     left: 0;
@@ -16,8 +21,35 @@ $progressHeight: 5px;
     right: 0;
     top: 0;
 
+    > .bespoke-marp-osd {
+      background: rgba(0, 0, 0, 0.5);
+      border-radius: 10px;
+      bottom: 50px;
+      color: #fff;
+      display: block;
+      left: 50%;
+      opacity: 0.75;
+      padding: 0.5em;
+      position: absolute;
+      transform: translateX(-50%);
+      transition: opacity 0.2s linear;
+      z-index: 1;
+
+      button {
+        appearance: none;
+        background: transparent;
+        border: 0;
+        color: inherit;
+      }
+    }
+
     &.bespoke-marp-cursor-inactive {
       cursor: none;
+
+      > .bespoke-marp-osd {
+        opacity: 0;
+        pointer-events: none;
+      }
     }
   }
 
@@ -55,8 +87,10 @@ $progressHeight: 5px;
 }
 
 @media print {
+  .bespoke-marp-osd,
   .bespoke-progress-parent {
-    display: none;
+    display: none !important;
+    transition: none !important;
   }
 
   .bespoke-marp-parent {

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -70,8 +70,12 @@ $progressHeight: 5px;
         outline: none;
         padding: 0;
         transition: opacity 0.2s linear;
-
         -webkit-tap-highlight-color: transparent;
+
+        &:disabled {
+          cursor: not-allowed;
+          opacity: 0.15 !important;
+        }
 
         &:hover {
           opacity: 1;
@@ -83,11 +87,6 @@ $progressHeight: 5px;
           &:not(:disabled) {
             transition: none;
           }
-        }
-
-        &:disabled {
-          cursor: not-allowed;
-          opacity: 0.15 !important;
         }
 
         @mixin icon-button($icon, $size: 32px) {

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -1,7 +1,7 @@
 import bespoke from 'bespoke'
 import bespokeForms from 'bespoke-forms'
 import bespokeClasses from './classes'
-import bespokeCursor from './cursor'
+import bespokeInactive from './inactive'
 import bespokeFullscreen from './fullscreen'
 import bespokeHash from './hash'
 import bespokeNavigation from './navigation'
@@ -13,7 +13,7 @@ export default function() {
   return bespoke.from(document.getElementById('presentation'), [
     bespokeForms(),
     bespokeClasses,
-    bespokeCursor(),
+    bespokeInactive(),
     bespokeHash({ history: false }),
     bespokeNavigation(),
     bespokeFullscreen,

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -5,6 +5,7 @@ import bespokeCursor from './cursor'
 import bespokeFullscreen from './fullscreen'
 import bespokeHash from './hash'
 import bespokeNavigation from './navigation'
+import bespokeOSD from './osd'
 import bespokeProgress from './progress'
 import bespokeTouch from './touch'
 
@@ -18,5 +19,6 @@ export default function() {
     bespokeFullscreen,
     bespokeProgress,
     bespokeTouch(),
+    bespokeOSD(),
   ])
 }

--- a/src/templates/bespoke/fullscreen.ts
+++ b/src/templates/bespoke/fullscreen.ts
@@ -1,7 +1,12 @@
 import screenfull from 'screenfull'
 
 export default function bespokeFullscreen(deck) {
-  deck.fullscreen = () => screenfull.toggle(document.body)
+  deck.fullscreen = () => {
+    screenfull
+      .toggle(document.body)
+      .then(() => deck.fire('fullscreen', screenfull.isEnabled))
+      .catch(e => console.error(e))
+  }
 
   document.addEventListener('keydown', e => {
     // `f` or F11 without modifier key Alt, Control, and Command

--- a/src/templates/bespoke/fullscreen.ts
+++ b/src/templates/bespoke/fullscreen.ts
@@ -1,6 +1,8 @@
 import screenfull from 'screenfull'
 
-export default function bespokeFullscreen() {
+export default function bespokeFullscreen(deck) {
+  deck.fullscreen = () => screenfull.toggle(document.body)
+
   document.addEventListener('keydown', e => {
     // `f` or F11 without modifier key Alt, Control, and Command
     if (
@@ -10,7 +12,7 @@ export default function bespokeFullscreen() {
       !e.metaKey &&
       screenfull.enabled
     ) {
-      screenfull.toggle(document.body)
+      deck.fullscreen()
       e.preventDefault()
     }
   })

--- a/src/templates/bespoke/inactive.ts
+++ b/src/templates/bespoke/inactive.ts
@@ -1,4 +1,4 @@
-export default function bespokeCursor(timeout = 2000) {
+export default function bespokeInactive(timeout = 2000) {
   return deck => {
     let activeTimer
 
@@ -6,10 +6,10 @@ export default function bespokeCursor(timeout = 2000) {
       if (activeTimer) clearTimeout(activeTimer)
 
       activeTimer = setTimeout(() => {
-        deck.parent.classList.add('bespoke-marp-cursor-inactive')
+        deck.parent.classList.add('bespoke-marp-inactive')
       }, timeout)
 
-      deck.parent.classList.remove('bespoke-marp-cursor-inactive')
+      deck.parent.classList.remove('bespoke-marp-inactive')
     }
 
     document.addEventListener('mousedown', activate)

--- a/src/templates/bespoke/inactive.ts
+++ b/src/templates/bespoke/inactive.ts
@@ -14,6 +14,7 @@ export default function bespokeInactive(timeout = 2000) {
 
     document.addEventListener('mousedown', activate)
     document.addEventListener('mousemove', activate)
+    document.addEventListener('touchend', activate)
 
     setTimeout(activate, 0)
   }

--- a/src/templates/bespoke/osd.ts
+++ b/src/templates/bespoke/osd.ts
@@ -1,0 +1,29 @@
+export default function bespokeOSD(selector: string = '.bespoke-marp-osd') {
+  const osd = document.querySelector(selector)
+
+  if (!osd) {
+    console.error(
+      `Bespoke Marp OSD plugin cannot find target selector: ${selector}`
+    )
+    return () => {}
+  }
+
+  return deck => {
+    osd.addEventListener('click', e => {
+      if (e.target instanceof HTMLElement) {
+        switch (e.target.dataset.bespokeMarpOsd) {
+          case 'next':
+            deck.next()
+            break
+          case 'prev':
+            deck.prev()
+            break
+          case 'fullscreen':
+            if (typeof deck.fullscreen === 'function') deck.fullscreen()
+        }
+      }
+    })
+
+    deck.parent.appendChild(osd)
+  }
+}

--- a/src/templates/bespoke/osd.ts
+++ b/src/templates/bespoke/osd.ts
@@ -1,11 +1,21 @@
+import screenfull from 'screenfull'
+
 export default function bespokeOSD(selector: string = '.bespoke-marp-osd') {
   const osd = document.querySelector(selector)
 
   if (!osd) {
-    console.error(
-      `Bespoke Marp OSD plugin cannot find target selector: ${selector}`
+    return () =>
+      console.error(
+        `Bespoke Marp OSD plugin cannot find target selector: ${selector}`
+      )
+  }
+
+  // Hide fullscreen button in not-supported browser (e.g. phone device)
+  if (!screenfull.enabled) {
+    Array.from(
+      osd.querySelectorAll<HTMLElement>('[data-bespoke-marp-osd="fullscreen"]'),
+      btn => (btn.style.display = 'none')
     )
-    return () => {}
   }
 
   return deck => {
@@ -19,7 +29,8 @@ export default function bespokeOSD(selector: string = '.bespoke-marp-osd') {
             deck.prev()
             break
           case 'fullscreen':
-            if (typeof deck.fullscreen === 'function') deck.fullscreen()
+            if (typeof deck.fullscreen === 'function' && screenfull.enabled)
+              deck.fullscreen()
         }
       }
     })

--- a/src/templates/bespoke/touch.ts
+++ b/src/templates/bespoke/touch.ts
@@ -51,13 +51,14 @@ export default function bespokeTouch(opts: BespokeTouchOption = {}) {
       }
     })
 
-    parent.addEventListener('touchend', () => {
+    parent.addEventListener('touchend', e => {
       if (touchStart) {
         if (touchStart.delta && touchStart.delta >= options.swipeThreshold!) {
           let radian = touchStart.radian! - options.slope!
           radian = ((radian + Math.PI) % (Math.PI * 2)) - Math.PI
 
           deck[radian < 0 ? 'next' : 'prev']()
+          e.stopPropagation()
         }
         touchStart = undefined
       }

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -8,6 +8,7 @@ import bespoke from '../../src/templates/bespoke/bespoke'
 jest.mock('screenfull')
 jest.useFakeTimers()
 
+beforeEach(() => jest.spyOn(console, 'error').mockImplementation())
 afterEach(() => jest.restoreAllMocks())
 
 describe("Bespoke template's browser context", () => {
@@ -42,17 +43,17 @@ describe("Bespoke template's browser context", () => {
     })
   })
 
-  describe('Cursor', () => {
-    it('adds bespoke-marp-cursor-inactive class after 2000ms', () => {
+  describe('Inactive', () => {
+    it('adds bespoke-marp-inactive class after 2000ms', () => {
       const parent = render()
       bespoke()
 
       // Add inactive class after 2000 ms
       jest.advanceTimersByTime(1999)
-      expect(parent.className).not.toContain('bespoke-marp-cursor-inactive')
+      expect(parent.className).not.toContain('bespoke-marp-inactive')
 
       jest.advanceTimersByTime(1)
-      expect(parent.className).toContain('bespoke-marp-cursor-inactive')
+      expect(parent.className).toContain('bespoke-marp-inactive')
     })
 
     it('resets timer when mouse is activated', () => {
@@ -67,23 +68,23 @@ describe("Bespoke template's browser context", () => {
       document.dispatchEvent(mousedown)
 
       jest.advanceTimersByTime(1999)
-      expect(parent.className).not.toContain('bespoke-marp-cursor-inactive')
+      expect(parent.className).not.toContain('bespoke-marp-inactive')
 
       jest.advanceTimersByTime(1)
-      expect(parent.className).toContain('bespoke-marp-cursor-inactive')
+      expect(parent.className).toContain('bespoke-marp-inactive')
 
       // Trigger mousemove
       const mousemove = document.createEvent('MouseEvents')
       mousemove.initEvent('mousemove', true, true)
       document.dispatchEvent(mousemove)
 
-      expect(parent.className).not.toContain('bespoke-marp-cursor-inactive')
+      expect(parent.className).not.toContain('bespoke-marp-inactive')
 
       jest.advanceTimersByTime(1999)
-      expect(parent.className).not.toContain('bespoke-marp-cursor-inactive')
+      expect(parent.className).not.toContain('bespoke-marp-inactive')
 
       jest.advanceTimersByTime(1)
-      expect(parent.className).toContain('bespoke-marp-cursor-inactive')
+      expect(parent.className).toContain('bespoke-marp-inactive')
     })
   })
 
@@ -333,6 +334,7 @@ describe("Bespoke template's browser context", () => {
       return parent[type]({
         touches: touches.map(t => ({ pageX: t[0], pageY: t[1] })),
         preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
       })
     }
 


### PR DESCRIPTION
Add OSD (On-screen display) plugin to bespoke template, to control slide deck with touch-friendly UI.

[![screenshot_2019-01-25 https gistcdn githack com 1](https://user-images.githubusercontent.com/3993388/51751602-92e57400-20f8-11e9-89bc-374ad80b5d9e.png)](https://bit.ly/2UdErfS)

OSD will be shown when the cursor is active or screen touched. It can navigate slide deck, and toggle fullscreen without hitting key. OSD is not shown by navigating with keyboard and swipe, so you can focus the content of the deck when the real presentation.

You can test OSD on https://bit.ly/2UdErfS. In future, you would be able to toggle presenter mode from OSD.

### ToDo

- [ ] Toggle OSD by CLI option
- [ ] Add tests about OSD plugin
- [ ] Update docs