### PR TITLE
Fix failed test in other platform by Windows workaround for Carlo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix blank PDF generated in Chrome >= 73 ([#61](https://github.com/marp-team/marp-cli/pull/61) by [@kamijin-fanta](https://github.com/kamijin-fanta))
+- Fix failed test in other platform by Windows workaround for Carlo ([#63](https://github.com/marp-team/marp-cli/pull/63))
 
 ## v0.3.0 - 2019-01-21
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -33,7 +33,7 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
 
       // Workaround for unresolved close event in Windows
       // @see https://github.com/GoogleChromeLabs/carlo/issues/108
-      if (this.carlo.windows().length === 0) {
+      if (process.platform === 'win32' && this.carlo.windows().length === 0) {
         const browser = this.carlo.browserForTest()
         terminate(browser.process().pid)
       }


### PR DESCRIPTION
In macOS, Carlo's workaround for Windows implemented in #47 would cause failing test.

I updated to execute workaround only in Windows.