### PR TITLE
Reflect the correct fullscreen icon in bespoke template

### DIFF
--- a/src/templates/bespoke/fullscreen.ts
+++ b/src/templates/bespoke/fullscreen.ts
@@ -1,11 +1,7 @@
 import screenfull from 'screenfull'
 
 export default function bespokeFullscreen(deck) {
-  deck.fullscreen = () =>
-    screenfull
-      .toggle(document.body)
-      .then(() => deck.fire('fullscreen', screenfull.isEnabled))
-      .catch(e => console.error(e))
+  deck.fullscreen = () => screenfull.toggle(document.body)
 
   document.addEventListener('keydown', e => {
     // `f` or F11 without modifier key Alt, Control, and Command

--- a/src/templates/bespoke/osc.ts
+++ b/src/templates/bespoke/osc.ts
@@ -54,8 +54,10 @@ export default function bespokeOSC(selector: string = '.bespoke-marp-osc') {
       )
     })
 
-    deck.on('fullscreen', enabled =>
-      oscElements('fullscreen', fs => fs.classList.toggle('exit', enabled))
+    screenfull.onchange(() =>
+      oscElements('fullscreen', fs =>
+        fs.classList.toggle('exit', screenfull.isFullscreen)
+      )
     )
   }
 }

--- a/test/__mocks__/screenfull.ts
+++ b/test/__mocks__/screenfull.ts
@@ -2,5 +2,6 @@ module.exports = {
   get enabled() {
     return true
   },
+  onchange: jest.fn(),
   toggle: jest.fn(() => Promise.resolve()),
 }

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -50,13 +50,9 @@ describe("Bespoke template's browser context", () => {
       deck = bespoke()
     })
 
-    it('injects deck.fullscreen() to toggle fullscreen and emit event', async () => {
-      const event = jest.fn()
-      deck.on('fullscreen', event)
-
+    it('injects deck.fullscreen() to toggle fullscreen', async () => {
       await deck.fullscreen()
       expect(screenfull.toggle).toBeCalled()
-      expect(event).toBeCalled()
     })
 
     it('toggles fullscreen by hitting f key', () => {


### PR DESCRIPTION
Fullscreen button on bespoke template's OSD is sometimes not reflected the correct state. When the fullscreen was toggled by browser native feature, the fullscreen icon would not change.

![incorrect-fullscreen-icon](https://user-images.githubusercontent.com/3993388/51789852-c267af80-21d0-11e9-9a51-b080ae07d06d.png)

We are improved handling the fullscreen icon by using `fullscreenchange` browser event through `screenfull` helper module (`screenfull.onchange()`), not using our custom event.