### PR TITLE
Support setting HTML metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support setting HTML metadata via global directives and CLI options ([#66](https://github.com/marp-team/marp-cli/pull/66))
+
 ### Fixed
 
 - Reflect the correct fullscreen icon in bespoke template ([#65](https://github.com/marp-team/marp-cli/pull/65))
+
+### Changed
+
+- Upgrade to [Marpit v0.7.0](https://github.com/marp-team/marpit/releases/tag/v0.7.0) and [Marp Core v0.5.2](https://github.com/marp-team/marp-core/releases/tag/v0.5.2) ([#66](https://github.com/marp-team/marp-cli/pull/66))
 
 ## v0.4.0 - 2019-01-26
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,43 @@ When [the conversion engine is changed to Marpit framework by setting `engine` o
 marp --template bare --engine @marp-team/marpit slide-deck.md
 ```
 
+## Metadata
+
+We recommend setting metadata of the slide deck if you want to host the outputted HTML on the web. To optimize the converted web page for SEO and social sharing, passed meta values will use in `<title>`, `<link>`, and `<meta>` tags.
+
+| [Global directives] |   CLI option    | Description                           | Metadata                                      |
+| :-----------------: | :-------------: | :------------------------------------ | :-------------------------------------------- |
+|       `title`       |    `--title`    | Define title of the slide deck.       | `<title>`, `og:title`                         |
+|    `description`    | `--description` | Define description of the slide deck. | `<meta name="description">`, `og:description` |
+|        `url`        |     `--url`     | Define [canonical URL].               | `<link rel="canonical">`, `og:url`            |
+|       `image`       |  `--og-image`   | Define [Open Graph] image URL.        | `og:image`                                    |
+
+[canonical url]: https://en.wikipedia.org/wiki/Canonical_link_element
+[open graph]: http://ogp.me/
+
+> :information_source: The passed canonical URL will be ignored when cannot parse as valid URL.
+
+### By [global directives]
+
+Marp CLI supports _additional [global directives]_ to specify metadata in Markdown. You can define meta values in Markdown front-matter.
+
+```markdown
+---
+title: Marp slide deck
+description: An example slide deck created by Marp CLI
+url: https://marp.app/
+image: https://marp.app/og-image.jpg
+---
+
+# Marp slide deck
+```
+
+[global directives]: https://marpit.marp.app/directives?id=global-directives-1
+
+### By CLI option
+
+Marp CLI prefers CLI option to global directives. You can override metadata values by `--title`, `--description`, `--url`, and `--og-image`.
+
 ## Theme
 
 ### Override theme
@@ -310,10 +347,12 @@ By default we use configuration file that is placed on current directory, but yo
 |     `bespoke`      |           object            |                       | Setting options for `bespoke` template                                                                 |
 |   `bespoke.osc`    |           boolean           |    `--bespoke-osc`    | \[Bespoke\] Use on-screen controller (`true` by default)                                               |
 | `bespoke.progress` |           boolean           | `--bespoke-progress`  | \[Bespoke\] Use progress bar (`false` by default)                                                      |
+|   `description`    |           string            |    `--description`    | Define description of the slide deck                                                                   |
 |      `engine`      | string \| Class \| Function |      `--engine`       | Specify Marpit based engine                                                                            |
 |       `html`       |      boolean \| object      |       `--html`        | Enable or disable HTML (Configuration file can pass [the whitelist object] if you are using Marp Core) |
 |     `inputDir`     |           string            |  `--input-dir` `-I`   | The base directory to find markdown and theme CSS                                                      |
 |       `lang`       |           string            |                       | Define the language of converted HTML                                                                  |
+|     `ogImage`      |           string            |     `--og-image`      | Define [Open Graph] image URL                                                                          |
 |     `options`      |           object            |                       | The base options for the constructor of engine                                                         |
 |      `output`      |           string            |    `--output` `-o`    | Output file path (or directory when input-dir is passed)                                               |
 |       `pdf`        |           boolean           |        `--pdf`        | Convert slide deck into PDF                                                                            |
@@ -322,6 +361,8 @@ By default we use configuration file that is placed on current directory, but yo
 |     `template`     |           string            |     `--template`      | Choose template                                                                                        |
 |      `theme`       |           string            |       `--theme`       | Override theme by name or CSS file                                                                     |
 |     `themeSet`     |     string \| string[]      |     `--theme-set`     | Path to additional theme CSS files                                                                     |
+|      `title`       |           string            |       `--title`       | Define title of the slide deck                                                                         |
+|       `url`        |           string            |        `--url`        | Define [canonical URL]                                                                                 |
 |      `watch`       |           boolean           |    `--watch` `-w`     | Watch input markdowns for changes                                                                      |
 
 [the whitelist object]: https://github.com/marp-team/marp-core#html-boolean--object

--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@marp-team/marp-core": "^0.5.1",
-    "@marp-team/marpit": "^0.6.1",
+    "@marp-team/marp-core": "^0.5.2",
+    "@marp-team/marpit": "^0.7.0",
     "carlo": "^0.9.43",
     "chalk": "^2.4.2",
     "chokidar": "^2.0.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,18 @@
 import chalk from 'chalk'
 
+let silent = false
+
+export function silence(value: boolean) {
+  silent = value
+}
+
 export function info(message: string): void {
   // Use console.warn to output into stderr
-  console.warn(`${chalk.bgCyan.black('[  INFO ]')} ${message}`)
+  if (!silent) console.warn(`${chalk.bgCyan.black('[  INFO ]')} ${message}`)
 }
 
 export function warn(message: string): void {
-  console.warn(`${chalk.bgYellow.black('[  WARN ]')} ${message}`)
+  if (!silent) console.warn(`${chalk.bgYellow.black('[  WARN ]')} ${message}`)
 }
 
 export function error(message: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,9 +23,11 @@ interface IMarpCLIBaseArguments {
   _?: string[]
   allowLocalFiles?: boolean
   configFile?: string
+  description?: string
   engine?: string
   html?: boolean
   inputDir?: string
+  ogImage?: string
   output?: string
   pdf?: boolean
   preview?: boolean
@@ -33,6 +35,8 @@ interface IMarpCLIBaseArguments {
   template?: string
   theme?: string
   themeSet?: string[]
+  title?: string
+  url?: string
   watch?: boolean
 }
 
@@ -162,13 +166,22 @@ export class MarpCLIConfig {
           this.conf.allowLocalFiles
         ) || false,
       engine: this.engine.klass,
+      globalDirectives: {
+        description: this.pickDefined(
+          this.args.description,
+          this.conf.description
+        ),
+        image: this.pickDefined(this.args.ogImage, this.conf.ogImage),
+        theme: theme instanceof Theme ? theme.name : theme,
+        title: this.pickDefined(this.args.title, this.conf.title),
+        url: this.pickDefined(this.args.url, this.conf.url),
+      },
       html: this.pickDefined(this.args.html, this.conf.html),
       lang: this.conf.lang || (await osLocale()).replace(/[_@]/g, '-'),
       options: this.conf.options || {},
       readyScript: this.engine.browserScript
         ? `<script>${this.engine.browserScript}</script>`
         : undefined,
-      theme: theme instanceof Theme ? theme.name : theme,
       type:
         this.args.pdf ||
         this.conf.pdf ||

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -86,21 +86,23 @@ export class Converter {
       renderer: tplOpts => {
         const engine = this.generateEngine(tplOpts)
         const ret = engine.render(`${markdown}${additionals}`)
+
         const { themeSet, lastGlobalDirectives } = <any>engine
+        const globalDirectives = lastGlobalDirectives || {}
 
         if (isFile) {
           const themeDir: string | undefined =
-            (lastGlobalDirectives || {}).theme || (themeSet.default || {}).name
+            globalDirectives.theme || (themeSet.default || {}).name
 
           this.options.themeSet.observe(file!.absolutePath, themeDir)
         }
 
         return {
           ...ret,
-          description: lastGlobalDirectives.marpCLIDescription,
-          image: lastGlobalDirectives.marpCLIImage,
-          title: lastGlobalDirectives.marpCLITitle,
-          url: lastGlobalDirectives.marpCLIURL,
+          description: globalDirectives.marpCLIDescription,
+          image: globalDirectives.marpCLIImage,
+          title: globalDirectives.marpCLITitle,
+          url: globalDirectives.marpCLIURL,
         }
       },
     })

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -97,8 +97,10 @@ export class Converter {
 
         return {
           ...ret,
-          title: lastGlobalDirectives.marpCLITitle,
           description: lastGlobalDirectives.marpCLIDescription,
+          image: lastGlobalDirectives.marpCLIImage,
+          title: lastGlobalDirectives.marpCLITitle,
+          url: lastGlobalDirectives.marpCLIURL,
         }
       },
     })

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -9,6 +9,7 @@ import { error } from './error'
 import { File, FileType } from './file'
 import templates, {
   Template,
+  TemplateMeta,
   TemplateOption,
   TemplateResult,
 } from './templates/'
@@ -23,6 +24,7 @@ export enum ConvertType {
 export interface ConverterOption {
   allowLocalFiles: boolean
   engine: Engine
+  globalDirectives: { theme?: string } & Partial<TemplateMeta>
   html?: MarpOptions['html']
   inputDir?: string
   lang: string
@@ -33,7 +35,6 @@ export interface ConverterOption {
   server?: boolean
   template: string
   templateOption?: TemplateOption
-  theme?: string
   themeSet: ThemeSet
   type: ConvertType
   watch: boolean
@@ -67,12 +68,18 @@ export class Converter {
   }
 
   async convert(markdown: string, file?: File): Promise<TemplateResult> {
-    const { lang, readyScript, theme, type } = this.options
-
+    const { lang, readyScript, globalDirectives, type } = this.options
     const isFile = file && file.type === FileType.File
-    const additionals = theme
-      ? `\n<!-- theme: ${JSON.stringify(theme)} -->`
-      : ''
+
+    let additionals = ''
+
+    for (const directive of Object.keys(globalDirectives)) {
+      if (globalDirectives[directive] !== undefined) {
+        additionals += `\n<!-- ${directive}: ${JSON.stringify(
+          globalDirectives[directive]
+        )} -->`
+      }
+    }
 
     return await this.template({
       ...(this.options.templateOption || {}),

--- a/src/engine/meta-plugin.ts
+++ b/src/engine/meta-plugin.ts
@@ -1,0 +1,8 @@
+import { Marpit } from '@marp-team/marpit'
+
+export default function metaPlugin(_, marpit: Marpit) {
+  marpit.customDirectives.global.title = v => ({ marpCLITitle: v })
+  marpit.customDirectives.global.description = v => ({ marpCLIDescription: v })
+
+  // TODO: Add rule to fill meta from content of slide deck when directives are not defined.
+}

--- a/src/engine/meta-plugin.ts
+++ b/src/engine/meta-plugin.ts
@@ -1,11 +1,23 @@
 import { Marpit } from '@marp-team/marpit'
+import { URL } from 'url'
+import { warn } from '../cli'
 
 export default function metaPlugin(_, marpit: Marpit) {
   Object.assign(marpit.customDirectives.global, {
     description: v => ({ marpCLIDescription: v }),
     image: v => ({ marpCLIImage: v }),
     title: v => ({ marpCLITitle: v }),
-    url: v => ({ marpCLIURL: v }),
+    url: v => {
+      // URL validation
+      try {
+        new URL(v)
+      } catch (e) {
+        warn(`Specified canonical URL is ignored since invalid URL: ${v}`)
+        return {}
+      }
+
+      return { marpCLIURL: v }
+    },
   })
 
   // TODO: Add rule to fill meta from content of slide deck when directives are not defined.

--- a/src/engine/meta-plugin.ts
+++ b/src/engine/meta-plugin.ts
@@ -10,7 +10,7 @@ export default function metaPlugin(_, marpit: Marpit) {
     url: v => {
       // URL validation
       try {
-        new URL(v)
+        if (v) new URL(v)
       } catch (e) {
         warn(`Specified canonical URL is ignored since invalid URL: ${v}`)
         return {}

--- a/src/engine/meta-plugin.ts
+++ b/src/engine/meta-plugin.ts
@@ -1,8 +1,12 @@
 import { Marpit } from '@marp-team/marpit'
 
 export default function metaPlugin(_, marpit: Marpit) {
-  marpit.customDirectives.global.title = v => ({ marpCLITitle: v })
-  marpit.customDirectives.global.description = v => ({ marpCLIDescription: v })
+  Object.assign(marpit.customDirectives.global, {
+    description: v => ({ marpCLIDescription: v }),
+    image: v => ({ marpCLIImage: v }),
+    title: v => ({ marpCLITitle: v }),
+    url: v => ({ marpCLIURL: v }),
+  })
 
   // TODO: Add rule to fill meta from content of slide deck when directives are not defined.
 }

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -16,6 +16,7 @@ enum OptionGroup {
   Basic = 'Basic Options:',
   Converter = 'Converter Options:',
   Template = 'Template Options:',
+  Meta = 'Meta Options:',
   Marp = 'Marp / Marpit Options:',
 }
 
@@ -114,6 +115,26 @@ export default async function(argv: string[] = []): Promise<number> {
           defaultDescription: 'false',
           group: OptionGroup.Template,
           type: 'boolean',
+        },
+        title: {
+          describe: 'Define title of the slide deck',
+          group: OptionGroup.Meta,
+          type: 'string',
+        },
+        description: {
+          describe: 'Define description of the slide deck',
+          group: OptionGroup.Meta,
+          type: 'string',
+        },
+        url: {
+          describe: 'Define canonical URL',
+          group: OptionGroup.Meta,
+          type: 'string',
+        },
+        'og-image': {
+          describe: 'Define Open Graph image URL',
+          group: OptionGroup.Meta,
+          type: 'string',
         },
         engine: {
           describe: 'Select Marpit based engine by module name or path',

--- a/src/templates/bare/bare.pug
+++ b/src/templates/bare/bare.pug
@@ -4,10 +4,19 @@ html(lang=lang)
     if base
       base(href=base)
 
+    if title
+      title= title
+      meta(property="og:title", content=title)
+
+    if description
+      meta(name="description", content=description)
+      meta(property="og:description", content=description)
+
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
     meta(name="apple-mobile-web-app-capable", content="yes")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
+    meta(property="og:type", content="website")
     style(media="screen")!= bare.css
     style!= css
   body

--- a/src/templates/bare/bare.pug
+++ b/src/templates/bare/bare.pug
@@ -8,15 +8,27 @@ html(lang=lang)
       title= title
       meta(property="og:title", content=title)
 
+      if image
+        meta(property="og:image:alt", content=title)
+
     if description
       meta(name="description", content=description)
       meta(property="og:description", content=description)
+
+    if url
+      link(rel="canonical", href=url)
+      meta(property="og:url", content=url)
+
+    if image
+      meta(property="og:image", content=image)
 
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
     meta(name="apple-mobile-web-app-capable", content="yes")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
     meta(property="og:type", content="website")
+    meta(name="twitter:card", content=image ? "summary_large_image" : "summary")
+
     style(media="screen")!= bare.css
     style!= css
   body

--- a/src/templates/bare/bare.pug
+++ b/src/templates/bare/bare.pug
@@ -1,38 +1,4 @@
-doctype
-html(lang=lang)
-  head
-    if base
-      base(href=base)
+extends ../layout.pug
 
-    if title
-      title= title
-      meta(property="og:title", content=title)
-
-      if image
-        meta(property="og:image:alt", content=title)
-
-    if description
-      meta(name="description", content=description)
-      meta(property="og:description", content=description)
-
-    if url
-      link(rel="canonical", href=url)
-      meta(property="og:url", content=url)
-
-    if image
-      meta(property="og:image", content=image)
-
-    meta(charset="UTF-8")
-    meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
-    meta(name="apple-mobile-web-app-capable", content="yes")
-    meta(http-equiv="X-UA-Compatible", content="ie=edge")
-    meta(property="og:type", content="website")
-    meta(name="twitter:card", content=image ? "summary_large_image" : "summary")
-
-    style(media="screen")!= bare.css
-    style!= css
-  body
-    != html
-    != readyScript
-    if watchJs
-      script!= watchJs
+prepend head
+  style(media="screen")!= bare.css

--- a/src/templates/bespoke/bespoke.pug
+++ b/src/templates/bespoke/bespoke.pug
@@ -4,10 +4,19 @@ html(lang=lang)
     if base
       base(href=base)
 
+    if title
+      title= title
+      meta(property="og:title", content=title)
+
+    if description
+      meta(name="description", content=description)
+      meta(property="og:description", content=description)
+
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
     meta(name="apple-mobile-web-app-capable", content="yes")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
+    meta(property="og:type", content="website")
     style!= bespoke.css
     style!= css
   body

--- a/src/templates/bespoke/bespoke.pug
+++ b/src/templates/bespoke/bespoke.pug
@@ -8,15 +8,27 @@ html(lang=lang)
       title= title
       meta(property="og:title", content=title)
 
+      if image
+        meta(property="og:image:alt", content=title)
+
     if description
       meta(name="description", content=description)
       meta(property="og:description", content=description)
+
+    if url
+      link(rel="canonical", href=url)
+      meta(property="og:url", content=url)
+
+    if image
+      meta(property="og:image", content=image)
 
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
     meta(name="apple-mobile-web-app-capable", content="yes")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
     meta(property="og:type", content="website")
+    meta(name="twitter:card", content=image ? "summary_large_image" : "summary")
+
     style!= bespoke.css
     style!= css
   body

--- a/src/templates/bespoke/bespoke.pug
+++ b/src/templates/bespoke/bespoke.pug
@@ -1,50 +1,19 @@
-doctype
-html(lang=lang)
-  head
-    if base
-      base(href=base)
+extends ../layout.pug
 
-    if title
-      title= title
-      meta(property="og:title", content=title)
+prepend head
+  style!= bespoke.css
 
-      if image
-        meta(property="og:image:alt", content=title)
+prepend deck
+  if bespoke.progress
+    .bespoke-progress-parent
+      .bespoke-progress-bar
 
-    if description
-      meta(name="description", content=description)
-      meta(property="og:description", content=description)
+  if bespoke.osc
+    .bespoke-marp-osc
+      button(data-bespoke-marp-osc="prev" tabindex=-1 title="Previous slide") Previous slide
+      span(data-bespoke-marp-osc="page")
+      button(data-bespoke-marp-osc="next" tabindex=-1 title="Next slide") Next slide
+      button(data-bespoke-marp-osc="fullscreen" tabindex=-1 title="Toggle fullscreen (f)") Toggle fullscreen
 
-    if url
-      link(rel="canonical", href=url)
-      meta(property="og:url", content=url)
-
-    if image
-      meta(property="og:image", content=image)
-
-    meta(charset="UTF-8")
-    meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
-    meta(name="apple-mobile-web-app-capable", content="yes")
-    meta(http-equiv="X-UA-Compatible", content="ie=edge")
-    meta(property="og:type", content="website")
-    meta(name="twitter:card", content=image ? "summary_large_image" : "summary")
-
-    style!= bespoke.css
-    style!= css
-  body
-    if bespoke.progress
-      .bespoke-progress-parent
-        .bespoke-progress-bar
-
-    if bespoke.osc
-      .bespoke-marp-osc
-        button(data-bespoke-marp-osc="prev" tabindex=-1 title="Previous slide") Previous slide
-        span(data-bespoke-marp-osc="page")
-        button(data-bespoke-marp-osc="next" tabindex=-1 title="Next slide") Next slide
-        button(data-bespoke-marp-osc="fullscreen" tabindex=-1 title="Toggle fullscreen (f)") Toggle fullscreen
-
-    != html
-    != readyScript
-    script!= bespoke.js
-    if watchJs
-      script!= watchJs
+block script
+  script!= bespoke.js

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -20,8 +20,10 @@ interface TemplateCoreOption {
 }
 
 interface TemplateExtraRenderResult {
-  title: string | undefined
   description: string | undefined
+  image: string | undefined
+  title: string | undefined
+  url: string | undefined
 }
 
 export type TemplateOption = TemplateBareOption | TemplateBespokeOption

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -14,7 +14,14 @@ interface TemplateCoreOption {
   lang: string
   notifyWS?: string
   readyScript?: string
-  renderer: (tplOpts: MarpitOptions) => MarpitRenderResult
+  renderer: (
+    tplOpts: MarpitOptions
+  ) => MarpitRenderResult & TemplateExtraRenderResult
+}
+
+interface TemplateExtraRenderResult {
+  title: string | undefined
+  description: string | undefined
 }
 
 export type TemplateOption = TemplateBareOption | TemplateBespokeOption
@@ -31,7 +38,9 @@ export interface TemplateResult {
   result: string
 }
 
-type Template<T> = (locals: TemplateCoreOption & T) => Promise<TemplateResult>
+export type Template<T = TemplateOption> = (
+  locals: TemplateCoreOption & T
+) => Promise<TemplateResult>
 
 export const bare: Template<TemplateBareOption> = async opts => {
   const rendered = opts.renderer({

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -14,12 +14,10 @@ interface TemplateCoreOption {
   lang: string
   notifyWS?: string
   readyScript?: string
-  renderer: (
-    tplOpts: MarpitOptions
-  ) => MarpitRenderResult & TemplateExtraRenderResult
+  renderer: (tplOpts: MarpitOptions) => MarpitRenderResult & TemplateMeta
 }
 
-interface TemplateExtraRenderResult {
+export interface TemplateMeta {
   description: string | undefined
   image: string | undefined
   title: string | undefined

--- a/src/templates/layout.pug
+++ b/src/templates/layout.pug
@@ -27,7 +27,7 @@ html(lang=lang)
     meta(name="apple-mobile-web-app-capable", content="yes")
     meta(http-equiv="X-UA-Compatible", content="ie=edge")
     meta(property="og:type", content="website")
-    meta(name="twitter:card", content=image ? "summary_large_image" : "summary")
+    meta(name="twitter:card", content=title && image ? "summary_large_image" : "summary")
 
     block head
       style!= css

--- a/src/templates/layout.pug
+++ b/src/templates/layout.pug
@@ -1,0 +1,42 @@
+doctype
+html(lang=lang)
+  head
+    if base
+      base(href=base)
+
+    if title
+      title= title
+      meta(property="og:title", content=title)
+
+      if image
+        meta(property="og:image:alt", content=title)
+
+    if description
+      meta(name="description", content=description)
+      meta(property="og:description", content=description)
+
+    if url
+      link(rel="canonical", href=url)
+      meta(property="og:url", content=url)
+
+    if image
+      meta(property="og:image", content=image)
+
+    meta(charset="UTF-8")
+    meta(name="viewport", content="width=device-width,height=device-height,initial-scale=1.0")
+    meta(name="apple-mobile-web-app-capable", content="yes")
+    meta(http-equiv="X-UA-Compatible", content="ie=edge")
+    meta(property="og:type", content="website")
+    meta(name="twitter:card", content=image ? "summary_large_image" : "summary")
+
+    block head
+      style!= css
+  body
+    block deck
+      != html
+      != readyScript
+
+    block script
+
+    if watchJs
+      script!= watchJs

--- a/test/_configs/custom-engine/custom-engine.js
+++ b/test/_configs/custom-engine/custom-engine.js
@@ -5,6 +5,7 @@ module.exports = class CustomEngine {
     }
 
     this.themeSet = {}
+    this.use = jest.fn()
   }
 
   render() {

--- a/test/_transformers/pug.js
+++ b/test/_transformers/pug.js
@@ -1,10 +1,10 @@
 const pug = require('pug')
 
 module.exports = {
-  process: src => `
+  process: (src, filename) => `
 module.exports = (locals) => {
   const pug = require('pug').runtime;
-  ${pug.compile(src).toString()}
+  ${pug.compile(src, { filename }).toString()}
   return template(locals);
 };`,
 }

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -27,8 +27,9 @@ describe('Converter', () => {
     new Converter({
       themeSet,
       allowLocalFiles: false,
-      lang: 'en',
       engine: Marp,
+      globalDirectives: {},
+      lang: 'en',
       options: {},
       server: false,
       template: 'bare',
@@ -43,8 +44,9 @@ describe('Converter', () => {
       const options = {
         themeSet,
         allowLocalFiles: true,
-        lang: 'fr',
         engine: Marp,
+        globalDirectives: { theme: 'default' },
+        lang: 'fr',
         options: <MarpitOptions>{ html: true },
         server: false,
         template: 'test-template',
@@ -100,8 +102,11 @@ describe('Converter', () => {
       expect(result).toContain('<html lang="zh">')
     })
 
-    it("overrides theme by converter's theme option", async () => {
-      const { rendered } = await instance({ theme: 'gaia' }).convert(md)
+    it("overrides global directive by converter's globalDirectives option", async () => {
+      const { rendered } = await instance({
+        globalDirectives: { theme: 'gaia' },
+      }).convert(md)
+
       expect(rendered.css).toContain('@theme gaia')
     })
 

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -3,7 +3,7 @@ import { MarpitOptions } from '@marp-team/marpit'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { Converter, ConvertType } from '../src/converter'
+import { Converter, ConvertType, ConverterOption } from '../src/converter'
 import { CLIError } from '../src/error'
 import { File, FileType } from '../src/file'
 import { bare as bareTpl } from '../src/templates'
@@ -23,7 +23,7 @@ describe('Converter', () => {
   let themeSet: ThemeSet
   beforeEach(async () => (themeSet = await ThemeSet.initialize([])))
 
-  const instance = (opts = {}) =>
+  const instance = (opts: Partial<ConverterOption> = {}) =>
     new Converter({
       themeSet,
       allowLocalFiles: false,
@@ -75,20 +75,23 @@ describe('Converter', () => {
     const dummyFile = new File(process.cwd())
 
     it('returns the result of template', async () => {
-      const options = { html: true }
+      const options: any = { html: true }
       const readyScript = '<b>ready</b>'
-      const result = await instance({ options, readyScript }).convert(md)
+      const { result, rendered } = await instance({
+        options,
+        readyScript,
+      }).convert(md)
 
-      expect(result.result).toMatch(/^<!DOCTYPE html>[\s\S]+<\/html>$/)
-      expect(result.result).toContain(result.rendered.html)
-      expect(result.result).toContain(result.rendered.css)
-      expect(result.result).toContain(readyScript)
-      expect(result.result).not.toContain('<base')
-      expect(result.rendered.css).toContain('@theme default')
+      expect(result).toMatch(/^<!DOCTYPE html>[\s\S]+<\/html>$/)
+      expect(result).toContain(rendered.html)
+      expect(result).toContain(rendered.css)
+      expect(result).toContain(readyScript)
+      expect(result).not.toContain('<base')
+      expect(rendered.css).toContain('@theme default')
     })
 
     it('throws CLIError when selected engine is not implemented render() method', () => {
-      const subject = instance({ engine: function _() {} }).convert(md)
+      const subject = instance(<any>{ engine: function _() {} }).convert(md)
       expect(subject).rejects.toBeInstanceOf(CLIError)
     })
 
@@ -102,20 +105,72 @@ describe('Converter', () => {
       expect(result).toContain('<html lang="zh">')
     })
 
-    it("overrides global directive by converter's globalDirectives option", async () => {
-      const { rendered } = await instance({
-        globalDirectives: { theme: 'gaia' },
-      }).convert(md)
-
-      expect(rendered.css).toContain('@theme gaia')
-    })
-
     it("overrides html option by converter's html option", async () => {
       const enabled = (await instance({ html: true }).convert(md)).rendered
       expect(enabled.html).toContain('<i>Hello!</i>')
 
       const disabled = (await instance({ html: false }).convert(md)).rendered
       expect(disabled.html).toContain('&lt;i&gt;Hello!&lt;/i&gt;')
+    })
+
+    context('with globalDirectives option', () => {
+      it('overrides theme directive', async () => {
+        const { rendered } = await instance({
+          globalDirectives: { theme: 'gaia' },
+        }).convert(md)
+
+        expect(rendered.css).toContain('@theme gaia')
+      })
+
+      it('overrides global directives for meta', async () => {
+        const { result } = await instance({
+          globalDirectives: {
+            title: 'Title',
+            description: 'Desc',
+            url: 'https://example.com/canonical',
+            image: 'https://example.com/image.jpg',
+          },
+        }).convert('---\ntitle: original\n---')
+
+        expect(result).toContain('<title>Title</title>')
+        expect(result).toContain('<meta name="description" content="Desc">')
+        expect(result).toContain(
+          '<link rel="canonical" href="https://example.com/canonical">'
+        )
+        expect(result).toContain(
+          '<meta property="og:image" content="https://example.com/image.jpg">'
+        )
+      })
+
+      it('allows reset meta values by empty string', async () => {
+        const { result } = await instance({
+          globalDirectives: { title: '', description: '', url: '', image: '' },
+        }).convert(
+          '---\ntitle: A\ndescription: B\nurl: https://example.com/\nimage: /hello.jpg\n---'
+        )
+
+        expect(result).not.toContain('<title>')
+        expect(result).not.toContain('<meta name="description"')
+        expect(result).not.toContain('<link rel="canonical"')
+        expect(result).not.toContain('<meta property="og:image"')
+      })
+
+      context('when given URL is invalid', () => {
+        it('outputs warning and does not override URL', async () => {
+          const warn = jest.spyOn(console, 'warn').mockImplementation()
+          const { result } = await instance({
+            globalDirectives: { url: '[INVALID]' },
+          }).convert('---\nurl: https://example.com/\n---')
+
+          expect(warn).toBeCalledWith(
+            expect.stringContaining('Specified canonical URL is ignored')
+          )
+          expect(warn).toBeCalledWith(expect.stringContaining('[INVALID]'))
+          expect(result).toContain(
+            '<link rel="canonical" href="https://example.com/">'
+          )
+        })
+      })
     })
 
     context('with PDF convert type', () => {

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -357,7 +357,9 @@ describe('Marp CLI', () => {
         const theme = themeSet.themes.get(cssFile)!
 
         expect(theme.overridenName).not.toBeUndefined()
-        expect(converter.options.theme).toBe(theme.overridenName)
+        expect(converter.options.globalDirectives.theme).toBe(
+          theme.overridenName
+        )
         expect(themeSet.fnForWatch).toContain(cssFile)
       })
     })

--- a/test/server.ts
+++ b/test/server.ts
@@ -24,14 +24,15 @@ describe('Server', () => {
     new Converter({
       themeSet,
       allowLocalFiles: false,
-      lang: 'en',
       engine: Marp,
+      globalDirectives: {},
       inputDir: path.resolve(__dirname, '_files'),
+      lang: 'en',
       options: {},
+      server: true,
       template: 'bare',
       templateOption: {},
       type: ConvertType.html,
-      server: true,
       watch: true,
       ...opts,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,15 +150,15 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marp-core@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.5.1.tgz#1654ad821196903c0834e7cf658a43390ef38bc1"
-  integrity sha512-kR4B4DS091IaXJ14jMu+saEKmv+9V63A52iA9Yown5oZSUcytIBVBUuhsQ0IdO6DZ03rkhp4djoHq+lXD0ScDQ==
+"@marp-team/marp-core@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.5.2.tgz#3fff02d94f16c9142b2e0fe692de1d9f471c4fa3"
+  integrity sha512-SgPX9GcSFqdRzbUvmbiwjv1529RysUsni9iwxCVbhwQXGUFcLRzRxjpGgu0GP3QTh14gZuJjc+px5mouGEKiVg==
   dependencies:
-    "@marp-team/marpit" "^0.6.1"
+    "@marp-team/marpit" "^0.7.0"
     "@marp-team/marpit-svg-polyfill" "^0.2.0"
     emoji-regex "^7.0.3"
-    highlight.js "^9.13.1"
+    highlight.js "^9.14.1"
     katex "^0.10.0"
     markdown-it "^8.4.2"
     markdown-it-emoji "^1.4.0"
@@ -173,17 +173,17 @@
   dependencies:
     detect-browser "^3.0.1"
 
-"@marp-team/marpit@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.6.1.tgz#8cf2b91ee27ba9fe401bced8dc142486ab851932"
-  integrity sha512-LeYb+18GjpXm0ffWcs6nuE5nxDESNR+dcUTVUcCxr+c8qCGIy/NupB+6j1jui3uEZqg4ZGqCm7qdbBnlySm0lw==
+"@marp-team/marpit@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.7.0.tgz#bd54a3b531fd1eebe9f243f96130f8593de3148b"
+  integrity sha512-j1kNhvyZjsdV4UpO+DtcHSPiVgtNx03BP+hiYXsiTbzFAL641FSBt70QngT1nvWXmglERbp/izVcC9excbkgZQ==
   dependencies:
     color-string "^1.5.3"
     js-yaml "^3.12.1"
     lodash.kebabcase "^4.1.1"
     markdown-it "^8.4.2"
     markdown-it-front-matter "^0.1.2"
-    postcss "^7.0.13"
+    postcss "^7.0.14"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -2902,10 +2902,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^9.13.1:
-  version "9.13.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
-  integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
+highlight.js@^9.14.1:
+  version "9.14.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.14.1.tgz#62bc7945692a0feb2e2f0cf7c97b6a00411d7ba0"
+  integrity sha512-UpSrdhp5jHPbrf9+/bE1p8kxZlh9QHWD24zp2jMxCP1Po9be7XH7GiK5Q00OvCBlji1FVa+nTYOkZqrBE1pcHw==
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR adds the support to recognize HTML metadata from Markdown front-matter, powered by custom directives support in [Marpit v0.7.0](https://github.com/marp-team/marpit/releases/v0.7.0).

```markdown
---
title: Slide deck
description: A beautiful slide deck created by Marp
url: https://marp.app/example
image: https://marp.app/ogp.jpg

theme: default
---

# Hello!
```

Marp CLI will recognize 4 new global directives.

- `title`: Setting title for `<title>` tag and OGP title.
- `description`: Setting description for `<meta name="description">` and OGP description.
- `url`: Setting canonical URL for `<link rel="canonical">` and OGP URL.
- `image`: Setting OGP image URL. [Twitter's Summary Card will be used the large image](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image) by setting `image` and `title`.

> You can also use HTML comment like Marpit global directive for setting meta values, but it would not common usage.

We also added CLI options for setting these values. It is useful within building HTML in CI and Netlify, to use canonical URL getting from environment variables.

```
marp --url $URL slide-deck.md
```

```javascript
// marp.config.js
module.exports = {
  url: process.env.URL,
}
```

### ToDo

- [x] Add tests
- [x] Update docs