### PR TITLE
Fix hanging PDF conversion within Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix hanging PDF conversion within Docker image ([#73](https://github.com/marp-team/marp-cli/issues/73), [#74](https://github.com/marp-team/marp-cli/pull/74))
+
 ## v0.6.1 - 2019-02-04
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.14.1-alpine
+FROM node:10.15.1-alpine
 LABEL maintainer "Marp team"
 
 RUN apk update && apk upgrade && \
@@ -27,7 +27,7 @@ ENV IS_DOCKER true
 
 WORKDIR /home/marp/.cli
 COPY --chown=marp:marp . /home/marp/.cli/
-RUN yarn install && yarn build \
+RUN yarn install && yarn add puppeteer-core@chrome-71 && yarn build \
     && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean
 
 WORKDIR /home/marp/app


### PR DESCRIPTION
Chromium versions are not matched between alpine build and supported in Puppeteer. We should downgrade Puppeteer to Chrome 71 supported version in Docker image.

Fix #73.