### PR TITLE
Support fragmented list from Marpit v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support [fragmented list](https://marpit.marp.app/fragmented-list) in bespoke template, from [Marpit v0.9.0](https://github.com/marp-team/marpit/releases/v0.9.0) ([#81](https://github.com/marp-team/marp-cli/pull/81))
+
 ### Fixed
 
 - Update a workaround for the stable chrome's crash in docker image ([#80](https://github.com/marp-team/marp-cli/pull/80))

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The `bespoke` template is using [Bespoke.js](https://github.com/bespokejs/bespok
 - **Navigation**: Navigate the deck through keyboard and swipe geasture.
 - **Fullscreen**: Toggle fullscreen by hitting <kbd>f</kbd> / <kbd>F11</kbd> key.
 - **On-screen controller**: There is a touch-friendly OSC. You may also disable by `--bespoke-osc=false` if unneccesary.
+- **Fragmented list**: Recognize [Marpit's fragmented list](https://github.com/marp-team/marpit/issues/145) and appear list one-by-one if used `*` and `1)` as the bullet marker.
 - **Progress bar** (optional): By setting `--bespoke-progress` option, you can add a progress bar on the top of the deck.
 
 ### `bare` template

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "autoprefixer": "^9.5.0",
     "bespoke": "^1.1.0",
     "bespoke-forms": "^1.0.0",
-    "bespoke-keys": "^1.1.0",
     "cheerio": "^1.0.0-rc.2",
     "codecov": "^3.2.0",
     "cssnano": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@marp-team/marp-core": "^0.7.1",
-    "@marp-team/marpit": "^0.8.0",
+    "@marp-team/marp-core": "^0.8.0",
+    "@marp-team/marpit": "^0.9.2",
     "carlo": "^0.9.43",
     "chalk": "^2.4.2",
     "chokidar": "^2.1.2",

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -9,6 +9,10 @@ $progressHeight: 5px;
     overflow: hidden;
   }
 
+  [data-bespoke-marp-fragment='inactive'] {
+    visibility: hidden;
+  }
+
   .bespoke-marp-osc {
     display: none;
     opacity: 0;

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -17,10 +17,10 @@ export default function() {
     bespokeInactive(),
     bespokeHash({ history: false }),
     bespokeNavigation(),
-    bespokeFragments,
     bespokeFullscreen,
     bespokeProgress,
     bespokeTouch(),
     bespokeOSC(),
+    bespokeFragments,
   ])
 }

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -2,6 +2,7 @@ import bespoke from 'bespoke'
 import bespokeForms from 'bespoke-forms'
 import bespokeClasses from './classes'
 import bespokeInactive from './inactive'
+import bespokeFragments from './fragments'
 import bespokeFullscreen from './fullscreen'
 import bespokeHash from './hash'
 import bespokeNavigation from './navigation'
@@ -16,6 +17,7 @@ export default function() {
     bespokeInactive(),
     bespokeHash({ history: false }),
     bespokeNavigation(),
+    bespokeFragments,
     bespokeFullscreen,
     bespokeProgress,
     bespokeTouch(),

--- a/src/templates/bespoke/fragments.ts
+++ b/src/templates/bespoke/fragments.ts
@@ -1,0 +1,89 @@
+// Based on https://github.com/bespokejs/bespoke-bullets
+
+export default function bespokeFragments(deck) {
+  let activeSlideIdx
+  let activeFragmentIdx
+
+  const fragments = deck.slides.map(slide => [
+    null,
+    ...slide.querySelectorAll('[data-marpit-fragment]'),
+  ])
+
+  const activeSlideHasFragmentByOffset = (offset: number) =>
+    fragments[activeSlideIdx][activeFragmentIdx + offset] !== undefined
+
+  const activate = (slideIdx, fragmentIdx) => {
+    activeSlideIdx = slideIdx
+    activeFragmentIdx = fragmentIdx
+
+    fragments.forEach(
+      (slideFragments: (HTMLElement | null)[], slideCurrentIdx: number) => {
+        slideFragments.forEach((fragment, fragmentCurrentIdx) => {
+          if (fragment == null) return
+
+          const active =
+            slideCurrentIdx < slideIdx ||
+            (slideCurrentIdx === slideIdx && fragmentCurrentIdx <= fragmentIdx)
+
+          fragment.setAttribute(
+            'data-bespoke-marp-fragment',
+            active ? 'active' : 'inactive'
+          )
+
+          if (
+            slideCurrentIdx === slideIdx &&
+            fragmentCurrentIdx === fragmentIdx
+          ) {
+            fragment.setAttribute(
+              'data-bespoke-marp-current-fragment',
+              'current'
+            )
+          } else {
+            fragment.removeAttribute('data-bespoke-marp-current-fragment')
+          }
+        })
+      }
+    )
+  }
+
+  const parseFragmentEvent = (
+    targetIndex: number,
+    fragmentValue: string | number | undefined
+  ): number | undefined => {
+    if (fragmentValue !== undefined && fragments[targetIndex]) {
+      if (fragmentValue === 'last') return fragments[targetIndex].length - 1
+      if (typeof fragmentValue === 'number') {
+        return Math.min(
+          Math.max(0, fragmentValue),
+          fragments[targetIndex].length - 1
+        )
+      }
+    }
+  }
+
+  deck.on('next', () => {
+    if (activeSlideHasFragmentByOffset(1)) {
+      activate(activeSlideIdx, activeFragmentIdx + 1)
+      return false
+    }
+
+    const nextIdx = activeSlideIdx + 1
+    if (fragments[nextIdx]) activate(nextIdx, 0)
+  })
+
+  deck.on('prev', () => {
+    if (activeSlideHasFragmentByOffset(-1)) {
+      activate(activeSlideIdx, activeFragmentIdx - 1)
+      return false
+    }
+
+    const prevIdx = activeSlideIdx - 1
+    if (fragments[prevIdx]) activate(prevIdx, fragments[prevIdx].length - 1)
+  })
+
+  deck.on('slide', e =>
+    activate(e.index, parseFragmentEvent(e.index, e.fragment) || 0)
+  )
+
+  activate(0, 0)
+}

--- a/src/templates/bespoke/navigation.ts
+++ b/src/templates/bespoke/navigation.ts
@@ -33,12 +33,11 @@ export default function bespokeNavigation(opts: BespokeNavigationOption = {}) {
       )
         deck.next()
 
-      // END: Jump to last page/fragment
-      if (e.which === 35)
-        deck.slide(deck.slides.length - 1, { fragment: 'last' })
+      // END: Jump to last page
+      if (e.which === 35) deck.slide(deck.slides.length - 1, { fragment: -1 })
 
-      // HOME: Jump to first page/fragment
-      if (e.which === 36) deck.slide(0, { fragment: 0 })
+      // HOME: Jump to first page
+      if (e.which === 36) deck.slide(0)
     })
 
     let lastWheelNavigationAt = 0

--- a/src/templates/bespoke/navigation.ts
+++ b/src/templates/bespoke/navigation.ts
@@ -1,5 +1,3 @@
-import keys from 'bespoke-keys'
-
 export interface BespokeNavigationOption {
   interval?: number
 }
@@ -16,13 +14,31 @@ export default function bespokeNavigation(opts: BespokeNavigationOption = {}) {
   }
 
   return deck => {
-    keys()(deck)
-
     document.addEventListener('keydown', e => {
-      if (e.which === 35) deck.slide(deck.slides.length - 1) // END
-      if (e.which === 36) deck.slide(0) // HOME
-      if (e.which === 38) deck.prev() // UP
-      if (e.which === 40) deck.next() // DOWN
+      // Space + Shift | Page Up | LEFT | UP: Previous page
+      if (
+        (e.which === 32 && e.shiftKey) ||
+        e.which === 33 ||
+        e.which === 37 ||
+        e.which === 38
+      )
+        deck.prev()
+
+      // Space | Page Down | RIGHT | DOWN: Next page
+      if (
+        (e.which === 32 && !e.shiftKey) ||
+        e.which === 34 ||
+        e.which === 39 ||
+        e.which === 40
+      )
+        deck.next()
+
+      // END: Jump to last page/fragment
+      if (e.which === 35)
+        deck.slide(deck.slides.length - 1, { fragment: 'last' })
+
+      // HOME: Jump to first page/fragment
+      if (e.which === 36) deck.slide(0, { fragment: 0 })
     })
 
     let lastWheelNavigationAt = 0

--- a/src/templates/bespoke/osc.ts
+++ b/src/templates/bespoke/osc.ts
@@ -42,16 +42,20 @@ export default function bespokeOSC(selector: string = '.bespoke-marp-osc') {
         page =>
           (page.textContent = `Page ${index + 1} of ${deck.slides.length}`)
       )
+    })
 
-      // TODO: Support fragments
+    deck.on('fragment', ({ index, fragments, fragmentIndex }) => {
       oscElements<HTMLButtonElement>(
         'prev',
-        prev => (prev.disabled = index === 0)
+        prev => (prev.disabled = index === 0 && fragmentIndex === 0)
       )
 
       oscElements<HTMLButtonElement>(
         'next',
-        next => (next.disabled = index === deck.slides.length - 1)
+        next =>
+          (next.disabled =
+            index === deck.slides.length - 1 &&
+            fragmentIndex === fragments.length - 1)
       )
     })
 

--- a/src/templates/bespoke/osc.ts
+++ b/src/templates/bespoke/osc.ts
@@ -43,6 +43,7 @@ export default function bespokeOSC(selector: string = '.bespoke-marp-osc') {
           (page.textContent = `Page ${index + 1} of ${deck.slides.length}`)
       )
 
+      // TODO: Support fragments
       oscElements<HTMLButtonElement>(
         'prev',
         prev => (prev.disabled = index === 0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,20 +295,20 @@
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
 
-"@marp-team/marp-core@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.7.1.tgz#2dda763d2181c4105186237b8860dce2faa40c0d"
-  integrity sha512-/vSqEpIchvXr1Gtc9J54L02L9Shb0TfCuZJ7OYN1MfKhSr50MGoQXuyNJmF6N5qscA7SaGPPHcAMiRtCK1gOSw==
+"@marp-team/marp-core@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-0.8.0.tgz#ab898cd28ecfad800e77d575681d9fed526c3ad2"
+  integrity sha512-PLoRlLGvCxIr2j2lQ0s10SgDUDcA8VilpcuK3eQT34Y5vtgrVdtWx1+ybnACmES8igbZ8ix3F1toBVIi3OQ1fA==
   dependencies:
-    "@marp-team/marpit" "^0.8.0"
+    "@marp-team/marpit" "^0.9.2"
     "@marp-team/marpit-svg-polyfill" "^0.3.0"
     emoji-regex "^8.0.0"
     highlight.js "^9.15.6"
     katex "^0.10.1"
     markdown-it "^8.4.2"
     markdown-it-emoji "^1.4.0"
-    twemoji "^11.3.0"
-    xss "^1.0.3"
+    twemoji "^12.0.0"
+    xss "^1.0.6"
 
 "@marp-team/marpit-svg-polyfill@^0.3.0":
   version "0.3.0"
@@ -317,13 +317,14 @@
   dependencies:
     detect-browser "^4.1.0"
 
-"@marp-team/marpit@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.8.0.tgz#f53ea265290c5f6d245eb04da5d425013306207f"
-  integrity sha512-ge2KTKHYkOhtLXRoy9R0dq1jJ9MrmCjVtnYmqhniLNNakVW/32+hXOK6FdgZqNQAe2m9smfTsXT2eBKUgLsxyg==
+"@marp-team/marpit@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.9.2.tgz#a01df483f0b8cc85c7939e504a17ba5f805a0227"
+  integrity sha512-3k5UvKkAuT76kBWi/wUbihMlFRH4NVc7xTL9sY77fap6cQLuPTry4vy1v1RB3+i+HU0Hz27so4w605H+JqGcSw==
   dependencies:
     color-string "^1.5.3"
-    js-yaml "^3.12.2"
+    js-yaml "^3.13.0"
+    lodash.get "^4.4.2"
     lodash.kebabcase "^4.1.1"
     markdown-it "^8.4.2"
     markdown-it-front-matter "^0.1.2"
@@ -3883,10 +3884,10 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.12.0, js-yaml@^3.12.2, js-yaml@^3.7.0, js-yaml@^3.9.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
-  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -7377,10 +7378,17 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twemoji@^11.3.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-11.3.0.tgz#8c520094fe94849db10fd5687f50c936183c4fad"
-  integrity sha512-xN/vlR6+gDmfjt6LInAqwGAv3Agwrmzx5TD1jEFwKS19IOGDrX0/3OB8GP1wUYPVIdkaer5hw6qd+52jzvz0Lg==
+twemoji-parser@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-12.0.0.tgz#870ea374b495595baa3bddb719e902b39ea7ccd1"
+  integrity sha512-JWZHBY32zKXo6GQ/JIQGLbbSQ5a3k+NHh5VkQ5AJFA++6cr+EtErj1aG8H4K7x8GwQ9/YzArNBQ06ryvKZL+WQ==
+
+twemoji@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-12.0.0.tgz#ccd1f67769711d3fa3a332ef9a860c52dd85fe5f"
+  integrity sha512-WX7ItaFagsZW9YEPNlVf9w50FdwxZK2Bdj3Y0XcDjZ4uLhr3qt/iUoRaLO2/getMhqumhFLR2gVoPLpSBtamJg==
+  dependencies:
+    twemoji-parser "12.0.0"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -7796,10 +7804,10 @@ xml@^1.0.1:
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
-xss@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.3.tgz#d04bd2558fd6c29c46113824d5e8b2a910054e23"
-  integrity sha512-LTpz3jXPLUphMMmyufoZRSKnqMj41OVypZ8uYGzvjkMV9C1EdACrhQl/EM8Qfh5htSAuMIQFOejmKAZGkJfaCg==
+xss@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.6.tgz#eaf11e9fc476e3ae289944a1009efddd8a124b51"
+  integrity sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==
   dependencies:
     commander "^2.9.0"
     cssfilter "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,11 +1037,6 @@ bespoke-forms@^1.0.0:
   resolved "https://registry.yarnpkg.com/bespoke-forms/-/bespoke-forms-1.0.0.tgz#fccdc60a1f7b598ed7df7c8efe554a4c4d8ce158"
   integrity sha1-/M3GCh97WY7X33yO/lVKTE2M4Vg=
 
-bespoke-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/bespoke-keys/-/bespoke-keys-1.1.0.tgz#64c0418e532ae1c5c5966a9ea0ac60e8f28ecb22"
-  integrity sha1-ZMBBjlMq4cXFlmqeoKxg6PKOyyI=
-
 bespoke@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/bespoke/-/bespoke-1.1.0.tgz#7b0fb3cfff580220a0da4020138365a55f063b3c"


### PR DESCRIPTION
Fragmented list is a new feature of Marpit v0.9.0. It's easy to write the list to be appeared one-by-one. Just use `*` bullet and `1)` bracket style index.

This PR supports fragmented list parsed by Marpit v0.9.0 in bespoke template. Our implementation is based on bespoke-bullet plugin, but we have extra feature for jumping to the beginning page and the ending page with considering fragments by hitting <kbd>Home</kbd> and <kbd>End</kbd> key.

Currently we are not using the stored value in `data-marpit-fragment` parsed by Marpit. Fragments plugin will only recognize whether it has data attribute.

If you familiar to reveal.js, you can use `<div data-marpit-fragment>` HTML element as a fragmented block with `--html` option.

### Example

- Deck: https://gistcdn.githack.com/yhatt/efc4ba8999274112072f97c7d48d37df/raw/b01eae1128579ed6be7b447950a256156c49dcaa/fragment.html
- Source on Gist: https://gist.github.com/yhatt/efc4ba8999274112072f97c7d48d37df

### ToDo

- [x] Set correct disabled state in OSC navigation button
- [x] Fill unit test
- [x] Update README.md