### PR TITLE
Override engine html option only if defined in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Override engine html option only if defined in CLI ([#83](https://github.com/marp-team/marp-cli/pull/83))
+
 ## v0.8.0 - 2019-04-09
 
 ### Added

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -207,7 +207,7 @@ export class Converter {
     if (typeof engine.render !== 'function')
       error('Specified engine has not implemented render() method.')
 
-    engine.markdown.set({ html })
+    if (html !== undefined) engine.markdown.set({ html })
 
     // Plugins
     engine.use(metaPlugin, engine)

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -108,6 +108,9 @@ describe('Converter', () => {
     })
 
     it("overrides html option by converter's html option", async () => {
+      const defaultHtml = (await instance().convert('<i><br></i>')).rendered
+      expect(defaultHtml.html).toContain('&lt;i&gt;<br />&lt;/i&gt;')
+
       const enabled = (await instance({ html: true }).convert(md)).rendered
       expect(enabled.html).toContain('<i>Hello!</i>')
 


### PR DESCRIPTION
By default, Marp Core allows whitelisted HTML element `<br>`. But Marp CLI has always overridden Marp Core's html option wrongly.

We have fixed the converter to override only if defined html option.