### PR TITLE
Automate GitHub release with uploading standalone binary assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - persist_to_workspace:
           root: ./bin
           paths:
-            - "*"
+            - '*'
 
       - store_artifacts:
           path: ./bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,13 @@ references:
     cmd:
       - /bin/sh
 
+  on-tagged-version: &on-tagged-version
+    filters:
+      branches:
+        ignore: /.*/
+      tags:
+        only: /^v.*/
+
   base: &base
     docker:
       - image: circleci/node:10.15.3-browsers
@@ -105,9 +112,31 @@ jobs:
       - run: yarn install
       - run: yarn build:standalone
 
+      - persist_to_workspace:
+          root: ./bin
+          paths:
+            - *
+
       - store_artifacts:
           path: ./bin
           destination: bin
+
+  github-release:
+    <<: *base
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: ./bin
+
+      - run:
+          name: Create release and upload binaries on GitHub
+          command: |
+            RELEASE_ID=$(curl -sS https://raw.githubusercontent.com/marp-team/marp/master/github-release.js | node) && \
+            ENDPOINT="https://uploads.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/${RELEASE_ID}/assets" && \
+            curl -sS --data-binary @"bin/marp-cli-linux" -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" ${ENDPOINT}?name=marp-${CIRCLE_TAG}-linux && \
+            curl -sS --data-binary @"bin/marp-cli-macos" -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" ${ENDPOINT}?name=marp-${CIRCLE_TAG}-mac && \
+            curl -sS --data-binary @"bin/marp-cli-win.exe" -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" ${ENDPOINT}?name=marp-${CIRCLE_TAG}-win
 
 workflows:
   version: 2
@@ -123,8 +152,9 @@ workflows:
             branches:
               only: master
       - standalone-build:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+          <<: *on-tagged-version
+      - github-release:
+          <<: *on-tagged-version
+          context: github-release
+          requires:
+            - standalone-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - persist_to_workspace:
           root: ./bin
           paths:
-            - *
+            - "*"
 
       - store_artifacts:
           path: ./bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 
 - Shorthand for setting text color via image syntax, from [Marpit v1.0.0](https://github.com/marp-team/marpit/releases/v1.0.0) ([#86](https://github.com/marp-team/marp-cli/pull/86))
-- Build standalone executable binaries _(Experimental)_ ([#87](https://github.com/marp-team/marp-cli/pull/87))
+- Standalone executable binaries _(Experimental)_ ([#87](https://github.com/marp-team/marp-cli/pull/87), [#88](https://github.com/marp-team/marp-cli/pull/88))
+- Automate GitHub release ([#88](https://github.com/marp-team/marp-cli/pull/88))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ You can install with `-g` option if you want to use `marp` command globally.
 npm install -g @marp-team/marp-cli
 ```
 
+### Standalone binary _(EXPERIMENTAL)_
+
+Do you never want to install any dependent tools? we also provide executable binaries for Linux, macOS, and Windows. [:fast_forward: Download the latest standalone binary for your OS from release page.](https://github.com/marp-team/marp-cli/releases)
+
 ## Basic usage
 
 ### Convert to HTML


### PR DESCRIPTION
Automate GitHub release by using common script added to entrance repository. (marp-team/marp#15).

Essentialy the purpose is as same as marp-team/marpit#161 and marp-team/marp-core#87, but Marp CLI has standalone binaries (#87) as assets on GitHub release.

- I had a bit change to common script in https://github.com/marp-team/marp/commit/1ea47d766cdcceeb8c9f84499c677e49696ac973: Outputs ID number for GitHub release API.
- The outputted ID uses to upload assets in CircleCI job.

I've tested scripts partially, but nobody knows whether it really works till trying. (CircleCI cannot test the whole of workflow on local environment)

### ToDo

- Update README.md
  - [x] Add "Standalone binaries" section to "Install"