### PR TITLE
Test with Node 12 (Erbium)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,12 @@ jobs:
       - image: circleci/node:carbon-browsers
         <<: *docker-init
 
+  erbium:
+    <<: *base
+    docker:
+      - image: circleci/node:12-browsers
+        <<: *docker-init
+
   docker-image:
     docker:
       - image: docker:git
@@ -130,10 +136,12 @@ workflows:
     jobs:
       - current
       - carbon
+      - erbium
       - docker-image:
           requires:
             - current
             - carbon
+            - erbium
           filters:
             branches:
               only: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-### Change
+### Added
+
+- Test with Node 12 (Erbium) ([#91](https://github.com/marp-team/marp-cli/pull/91))
+
+### Changed
 
 - Pack built standalone binaries ([#90](https://github.com/marp-team/marp-cli/pull/90))
 


### PR DESCRIPTION
I've confirmed Marp CLI is also working on Node 12 (Erbium) now. As same as https://github.com/marp-team/marpit/pull/160, we added the test environment of CircleCI with Node 12.