### PR TITLE
Add main entry point and type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/
 lib/
 tmp/
+types/
 node_modules/**
 !/test/_files/node_modules/ignore.*
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .git/
 coverage/
 lib/
+types/
 node_modules
 package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Test with Node 12 (Erbium) ([#91](https://github.com/marp-team/marp-cli/pull/91))
+- Add main entry point and type definitions ([#92](https://github.com/marp-team/marp-cli/pull/92))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "node": ">=8.9.0"
   },
   "main": "lib/marp-cli.js",
+  "types": "types/marp-cli.d.ts",
   "files": [
     "marp-cli.js",
-    "lib/"
+    "lib/",
+    "types/"
   ],
   "bin": {
     "marp": "./marp-cli.js"
@@ -50,13 +52,14 @@
     "format:write": "yarn -s format --write",
     "lint:ts": "tslint \"{src,test}/**/*.ts\"",
     "lint:css": "stylelint \"src/**/*.{css,scss}\"",
-    "prepack": "npm-run-all --parallel check:* lint:* test:coverage --sequential build",
+    "prepack": "npm-run-all --parallel check:* lint:* test:coverage --parallel build types",
     "preversion": "run-p check:* format:check lint:* test:coverage",
     "standalone": "rimraf bin && pkg --out-path ./bin .",
     "standalone:pack": "node ./scripts/pack.js",
     "standalone:pack:upload": "node ./scripts/upload.js",
     "test": "jest",
     "test:coverage": "jest --coverage",
+    "types": "rimraf types && tsc --declaration --emitDeclarationOnly --outDir types",
     "version": "curl https://raw.githubusercontent.com/marp-team/marp/master/version.js | node && git add -A CHANGELOG.md",
     "watch": "rollup -w -c"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=8.9.0"
   },
   "main": "lib/marp-cli.js",
-  "types": "types/marp-cli.d.ts",
+  "types": "types/src/marp-cli.d.ts",
   "files": [
     "marp-cli.js",
     "lib/",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "@marp-team/marp-cli",
   "version": "0.9.0",
   "description": "A CLI interface for Marp and Marpit based converters",
-  "repository": "https://github.com/marp-team/marp-cli",
-  "engines": {
-    "node": ">=8.9.0"
-  },
+  "license": "MIT",
   "author": {
     "name": "Marp team",
     "url": "https://github.com/marp-team"
@@ -16,17 +13,29 @@
       "url": "https://github.com/yhatt"
     }
   ],
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
+  "keywords": [
+    "marp",
+    "markdown",
+    "cli",
+    "slide",
+    "deck",
+    "presentation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marp-team/marp-cli"
   },
-  "bin": {
-    "marp": "./marp-cli.js"
+  "engines": {
+    "node": ">=8.9.0"
   },
+  "main": "lib/marp-cli.js",
   "files": [
     "marp-cli.js",
     "lib/"
   ],
+  "bin": {
+    "marp": "./marp-cli.js"
+  },
   "pkg": {
     "scripts": "lib/**/*.js"
   },
@@ -129,5 +138,8 @@
     "tmp": "^0.1.0",
     "ws": "^7.0.0",
     "yargs": "^13.2.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Update `package.json` to add main entry point and type definitions. 

Basically Marp CLI has not provided internal API for Node because we want to focus a behavior in the scope of CLI/CUI. However, an exported function from entry point is useful as a minimum interface to use CLI via Node.

```javascript
const marp = require('@marp-team/marp-cli')

(async () => {
  const exitCode = await marp(['marp.md', '-o', 'marp.html'])
  if (exitCode === 0) {
    // succeeded
  } else {
    // error
  }
})()
```

This function may be used in Marp for VS Code: https://github.com/marp-team/marp-vscode/issues/4