### PR TITLE
Add hidden stdin option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- A hidden `--stdin` option to allow to disable reading from stdin as a workaround of hang up ([#93](https://github.com/marp-team/marp-cli/issues/93), [#94](https://github.com/marp-team/marp-cli/pull/94))
+
 ## v0.9.1 - 2019-05-08
 
 ### Added

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -83,6 +83,13 @@ export default async function(argv: string[] = []): Promise<number> {
           group: OptionGroup.Basic,
           type: 'boolean',
         },
+        stdin: {
+          default: true,
+          describe: 'Read Markdown from stdin',
+          hidden: true, // It is an escape-hatch for advanced user
+          group: OptionGroup.Basic,
+          type: 'boolean',
+        },
         pdf: {
           conflicts: ['image'],
           describe: 'Convert slide deck into PDF',
@@ -197,11 +204,14 @@ export default async function(argv: string[] = []): Promise<number> {
         return File.findDir(cvtOpts.inputDir)
       }
 
+      // Read from stdio
+      // (May disable by --no-stdin option to avoid hung up while reading)
+      // @see https://github.com/marp-team/marp-cli/issues/93
+      const stdin = args.stdin ? await File.stdin() : undefined
+
       // Regular file finding powered by globby
       return <File[]>(
-        [await File.stdin(), ...(await File.find(...config.files))].filter(
-          f => f
-        )
+        [stdin, ...(await File.find(...config.files))].filter(f => f)
       )
     }
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -204,7 +204,7 @@ export default async function(argv: string[] = []): Promise<number> {
         return File.findDir(cvtOpts.inputDir)
       }
 
-      // Read from stdio
+      // Read from stdin
       // (May disable by --no-stdin option to avoid hung up while reading)
       // @see https://github.com/marp-team/marp-cli/issues/93
       const stdin = args.stdin ? await File.stdin() : undefined

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -758,9 +758,12 @@ describe('Marp CLI', () => {
   })
 
   context('with passing from stdin', () => {
-    it('converts markdown came from stdin and outputs to stdout', async () => {
-      const cliInfo = jest.spyOn(cli, 'info').mockImplementation()
-      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
+    let cliInfo: jest.Mock
+    let stdout: jest.Mock
+
+    beforeEach(() => {
+      cliInfo = jest.spyOn(cli, 'info').mockImplementation()
+      stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
 
       jest
         .spyOn(getStdin, 'buffer')
@@ -768,12 +771,24 @@ describe('Marp CLI', () => {
 
       // reset cached stdin buffer
       ;(<any>File).stdinBuffer = undefined
+    })
 
+    it('converts markdown came from stdin and outputs to stdout', async () => {
       expect(await marpCli()).toBe(0)
       expect(cliInfo).toHaveBeenCalledWith(
         expect.stringContaining('<stdin> => <stdout>')
       )
-      expect(stdout).toHaveBeenCalled()
+      expect(stdout).toHaveBeenCalledWith(expect.any(Buffer))
+    })
+
+    context('with --stdin option as false', () => {
+      it('does not convert stdin even if passed', async () => {
+        expect(await marpCli(['--stdin=false'])).toBe(0)
+        expect(cliInfo).not.toHaveBeenCalledWith(
+          expect.stringContaining('<stdin> => <stdout>')
+        )
+        expect(stdout).not.toHaveBeenCalledWith(expect.any(Buffer))
+      })
     })
   })
 })


### PR DESCRIPTION
Add `--stdin` boolean option for enable or disable reading Markdown from stdin (`true` by default). By setting `--stdin=false` or `--no-stdin`, Marp CLI won't read content from stdin. It allows to avoid hang up while reading stdin in several environments.

`--stdin` is a hidden option because reading stdin is an expected behavior for most users using CLI. User can see help with `--show-hidden` if necessary. (It's a built-in option of yargs)

```
$ marp --help --show-hidden
...
Basic Options:
  ...
  --stdin            Read Markdown from stdin     [boolean] [default: true]
```

`--no-stdin` helps to resolve the problem for Now deploy environment and Marp for VS Code. Close #93.

### ToDo

- [x] Add tests