### PR TITLE
Run yarn audit only in beginning of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,13 +154,13 @@ workflows:
   build:
     jobs:
       - audit
-      - current
+      - current:
           requires:
             - audit
-      - carbon
+      - carbon:
           requires:
             - audit
-      - erbium
+      - erbium:
           requires:
             - audit
       - docker-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ references:
             - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-
 
       - run: yarn install
-      - run: yarn audit
 
       - save_cache:
           key: dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
@@ -64,6 +63,26 @@ references:
 
 version: 2
 jobs:
+  audit:
+    <<: *base
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+            - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
+            - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-
+
+      - run: yarn install
+      - run: yarn audit
+
+      - save_cache:
+          key: dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+          paths:
+            - node_modules
+            - ~/.cache/yarn
+
   current:
     <<: *base
 
@@ -134,9 +153,16 @@ workflows:
   version: 2
   build:
     jobs:
+      - audit
       - current
+          requires:
+            - audit
       - carbon
+          requires:
+            - audit
       - erbium
+          requires:
+            - audit
       - docker-image:
           requires:
             - current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Output warning if detected blocking local resources while rendering by Chrome ([#84](https://github.com/marp-team/marp-cli/issues/84), [#98](https://github.com/marp-team/marp-cli/pull/98))
 
+### Changed
+
+- Update CircleCI workflow to run `yarn audit` at the beginning ([#97](https://github.com/marp-team/marp-cli/pull/97))
+
 ## v0.9.2 - 2019-05-10
 
 ### Added


### PR DESCRIPTION
Sometime CircleCI fails by returning error in `yarn audit` with 503 status code even if test has not any problems.

```
#!/bin/bash -eo pipefail
yarn audit

yarn audit v1.13.0
/opt/yarn-v1.13.0/lib/cli.js:66237
            throw new (_errors || _load_errors()).ResponseError(_this3.reporter.lang('requestFailed', description), res.statusCode);
            ^

Error: Request failed "503 Service Unavailable"
    at ResponseError.ExtendableBuiltin (/opt/yarn-v1.13.0/lib/cli.js:702:66)
    at new ResponseError (/opt/yarn-v1.13.0/lib/cli.js:808:124)
    at Request.params.callback [as _callback] (/opt/yarn-v1.13.0/lib/cli.js:66237:19)
    at Request.self.callback (/opt/yarn-v1.13.0/lib/cli.js:129397:22)
    at Request.emit (events.js:189:13)
    at Request.<anonymous> (/opt/yarn-v1.13.0/lib/cli.js:130369:10)
    at Request.emit (events.js:189:13)
    at IncomingMessage.<anonymous> (/opt/yarn-v1.13.0/lib/cli.js:130291:12)
    at Object.onceWrapper (events.js:277:13)
    at IncomingMessage.emit (events.js:194:15)
Exited with code 1
```

In background, 3 audit requests are running at the same time. They may be overloading npm's API. So I updated CircleCI workflow to run only `yarn audit` at first.

![yarn-audit](https://user-images.githubusercontent.com/3993388/58259530-b7541300-7daf-11e9-9e3c-55ea35716057.png)

It would give a feedback to the other Marp Team projects too.