### PR TITLE
Output warning if detected blocking local resources while rendering by Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Output warning if detected blocking local resources while rendering by Chrome ([#84](https://github.com/marp-team/marp-cli/issues/84), [#98](https://github.com/marp-team/marp-cli/pull/98))
+
 ## v0.9.2 - 2019-05-10
 
 ### Added

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,5 @@
 const { enterTestMode } = require('carlo')
 
 enterTestMode()
+
+jest.mock('wrap-ansi')

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "rollup-plugin-url": "^2.2.1",
     "sass": "^1.20.1",
     "screenfull": "^4.2.0",
-    "strip-ansi": "^5.2.0",
     "stylelint": "^10.0.1",
     "stylelint-config-prettier": "^5.1.0",
     "stylelint-config-standard": "^18.3.0",
@@ -137,8 +136,10 @@
     "puppeteer-core": "^1.15.0",
     "rimraf": "^2.6.3",
     "serve-index": "^1.9.1",
+    "strip-ansi": "^5.2.0",
     "terminate": "^2.1.2",
     "tmp": "^0.1.0",
+    "wrap-ansi": "^5.1.0",
     "ws": "^7.0.0",
     "yargs": "^13.2.2"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,24 @@
 import chalk from 'chalk'
+import stripAnsi from 'strip-ansi'
+import wrapAnsi from 'wrap-ansi'
+import { terminalWidth } from 'yargs'
+
+interface CLIOption {
+  singleLine?: boolean
+}
+
+const width: number = terminalWidth() || 80
+
+const messageBlock = (
+  kind: string,
+  message: string,
+  opts: CLIOption
+): string => {
+  const indent = stripAnsi(kind).length + 1
+  const target = opts.singleLine ? message : wrapAnsi(message, width - indent)
+
+  return `${kind} ${target.split('\n').join(`\n${' '.repeat(indent)}`)}`
+}
 
 let silent = false
 
@@ -6,15 +26,17 @@ export function silence(value: boolean) {
   silent = value
 }
 
-export function info(message: string): void {
+export function info(message: string, opts: CLIOption = {}): void {
   // Use console.warn to output into stderr
-  if (!silent) console.warn(`${chalk.bgCyan.black('[  INFO ]')} ${message}`)
+  if (!silent)
+    console.warn(messageBlock(chalk.bgCyan.black('[  INFO ]'), message, opts))
 }
 
-export function warn(message: string): void {
-  if (!silent) console.warn(`${chalk.bgYellow.black('[  WARN ]')} ${message}`)
+export function warn(message: string, opts: CLIOption = {}): void {
+  if (!silent)
+    console.warn(messageBlock(chalk.bgYellow.black('[  WARN ]'), message, opts))
 }
 
-export function error(message: string): void {
-  console.error(`${chalk.bgRed.white('[ ERROR ]')} ${message}`)
+export function error(message: string, opts: CLIOption = {}): void {
+  console.error(messageBlock(chalk.bgRed.white('[ ERROR ]'), message, opts))
 }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -229,9 +229,9 @@ export class Converter {
     const tmpFile: File.TmpFileInterface | undefined = await (() => {
       if (!this.options.allowLocalFiles) return undefined
 
-      const warning = `Insecure local file accessing is enabled for conversion of ${file.relativePath()}.`
-      warn(warning)
-
+      warn(
+        `Insecure local file accessing is enabled for conversion of ${file.relativePath()}.`
+      )
       return file.saveTmpFile('.html')
     })()
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -252,8 +252,8 @@ export class Converter {
             `Marp CLI has detected accessing to local file${
               tracker.size > 1 ? 's' : ''
             }. ${
-              tracker.size > 1 ? 'They were' : 'That was'
-            } blocked by security reason. Instead we recommend using assets uploaded to online (Or you can use ${chalk.yellow(
+              tracker.size > 1 ? 'They are' : 'That is'
+            } blocked by security reason. Instead we recommend using assets uploaded to online. (Or you can use ${chalk.yellow(
               '--allow-local-files'
             )} option if you are understood of security risk)`
           )

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -92,7 +92,7 @@ export class Converter {
       readyScript,
       base:
         isFile && type !== ConvertType.html
-          ? file!.absoluteFileSchema
+          ? file!.absoluteFileScheme
           : undefined,
       notifyWS:
         isFile && this.options.watch && type === ConvertType.html

--- a/src/file.ts
+++ b/src/file.ts
@@ -34,7 +34,7 @@ export class File {
     return path.resolve(this.path)
   }
 
-  get absoluteFileSchema() {
+  get absoluteFileScheme() {
     // FIXME: Use url.pathToFileURL if it can be used
     return `file://${path.posix.resolve(this.path)}`
   }

--- a/src/file.ts
+++ b/src/file.ts
@@ -34,6 +34,11 @@ export class File {
     return path.resolve(this.path)
   }
 
+  get absoluteFileSchema() {
+    // FIXME: Use url.pathToFileURL if it can be used
+    return `file://${path.posix.resolve(this.path)}`
+  }
+
   convert(output: string | false | undefined, extension: string): File {
     switch (output) {
       case undefined:

--- a/src/file.ts
+++ b/src/file.ts
@@ -31,12 +31,13 @@ export class File {
     this.path = filepath
   }
 
-  get absolutePath() {
+  get absolutePath(): string {
     return path.resolve(this.path)
   }
 
-  get absoluteFileScheme() {
-    if (url.pathToFileURL) return url.pathToFileURL(this.absolutePath)
+  get absoluteFileScheme(): string {
+    if (url.pathToFileURL)
+      return url.pathToFileURL(this.absolutePath).toString()
 
     // Fallback for Node < v10.12.0
     return `file://${path.posix.resolve(this.path)}`

--- a/src/file.ts
+++ b/src/file.ts
@@ -3,6 +3,7 @@ import getStdin from 'get-stdin'
 import globby from 'globby'
 import mkdirp from 'mkdirp'
 import path from 'path'
+import * as url from 'url'
 import { tmpName } from 'tmp'
 import { promisify } from 'util'
 
@@ -35,7 +36,9 @@ export class File {
   }
 
   get absoluteFileScheme() {
-    // FIXME: Use url.pathToFileURL if it can be used
+    if (url.pathToFileURL) return url.pathToFileURL(this.absolutePath)
+
+    // Fallback for Node < v10.12.0
     return `file://${path.posix.resolve(this.path)}`
   }
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -237,7 +237,8 @@ export default async function(argv: string[] = []): Promise<number> {
       cli.info(
         `${fn(i, '<stdin>')} ${
           o.type === FileType.Null ? 'processed.' : `=> ${fn(o, '<stdout>')}`
-        }`
+        }`,
+        { singleLine: true }
       )
     }
 

--- a/test/__mocks__/wrap-ansi.ts
+++ b/test/__mocks__/wrap-ansi.ts
@@ -1,3 +1,1 @@
-const wrapAnsi = jest.fn().mockImplementation(m => m) // No ops
-
-export default wrapAnsi
+module.exports = jest.fn().mockImplementation(m => m) // No ops

--- a/test/__mocks__/wrap-ansi.ts
+++ b/test/__mocks__/wrap-ansi.ts
@@ -1,0 +1,3 @@
+const wrapAnsi = jest.fn().mockImplementation(m => m) // No ops
+
+export default wrapAnsi

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -3,6 +3,7 @@ import { MarpitOptions } from '@marp-team/marpit'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { URL } from 'url'
 import { Converter, ConvertType, ConverterOption } from '../src/converter'
 import { CLIError } from '../src/error'
 import { File, FileType } from '../src/file'
@@ -182,9 +183,14 @@ describe('Converter', () => {
       context(`with ${type} convert type`, () => {
         it('adds <base> element with specified base path from passed file', async () => {
           const converter = instance({ type })
-
           const { result } = await converter.convert(md, dummyFile)
-          expect(result).toContain(`<base href="${process.cwd()}">`)
+
+          const matched = result.match(/<base href="(.+?)">/)
+          expect(matched).toBeTruthy()
+
+          const url = new URL((matched && matched[1]) as string)
+          expect(url.protocol).toBe('file:')
+          expect(path.resolve(url.pathname)).toBe(path.resolve(process.cwd()))
         })
       })
     }

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -241,7 +241,7 @@ describe('Marp CLI', () => {
         serverStart.mockResolvedValue(0)
 
         await marpCli(['--input-dir', files, '--server'])
-        expect(info).toBeCalledWith(
+        expect(info.mock.calls.map(([m]) => m)).toContainEqual(
           expect.stringContaining('http://localhost:8080/')
         )
         expect(serverStart).toBeCalledTimes(1)
@@ -276,7 +276,7 @@ describe('Marp CLI', () => {
 
             await run()
             expect(Preview.prototype.open).not.toBeCalled()
-            expect(warn).toBeCalledWith(
+            expect(warn.mock.calls.map(([m]) => m)).toContainEqual(
               expect.stringContaining('Preview option was ignored')
             )
           })
@@ -356,7 +356,7 @@ describe('Marp CLI', () => {
         const args = [assetFn('_files/1.md'), '--theme', themesPath]
 
         expect(await marpCli(args)).toBe(1)
-        expect(cliError).toHaveBeenCalledWith(
+        expect(cliError.mock.calls.map(([m]) => m)).toContainEqual(
           expect.stringContaining('Directory cannot pass to theme option')
         )
         expect(info).toHaveBeenCalledTimes(1)
@@ -470,12 +470,10 @@ describe('Marp CLI', () => {
       ;(<any>fs).__mockWriteFile()
 
       expect(await marpCli([onePath])).toBe(0)
-      expect(cliInfo).toHaveBeenCalledWith(
-        expect.stringContaining('1 markdown')
-      )
-      expect(cliInfo).toHaveBeenCalledWith(
-        expect.stringMatching(/1\.md => .+1\.html/)
-      )
+
+      const logs = cliInfo.mock.calls.map(([m]) => m)
+      expect(logs).toContainEqual(expect.stringContaining('1 markdown'))
+      expect(logs).toContainEqual(expect.stringMatching(/1\.md => .+1\.html/))
     })
 
     it('prints error and return error code when CLIError is raised', async () => {
@@ -487,7 +485,9 @@ describe('Marp CLI', () => {
         .mockImplementation(() => Promise.reject(new CLIError('FAIL', 123)))
 
       expect(await marpCli([onePath])).toBe(123)
-      expect(cliError).toHaveBeenCalledWith(expect.stringContaining('FAIL'))
+      expect(cliError.mock.calls.map(([m]) => m)).toContainEqual(
+        expect.stringContaining('FAIL')
+      )
     })
 
     context('with --pdf option', () => {
@@ -698,7 +698,7 @@ describe('Marp CLI', () => {
         .mockImplementation(() => [])
 
       expect(await marpCli([assetFn('_files')])).toBe(0)
-      expect(cliInfo).toHaveBeenCalledWith(
+      expect(cliInfo.mock.calls.map(([m]) => m)).toContainEqual(
         expect.stringContaining('4 markdowns')
       )
     })
@@ -775,7 +775,7 @@ describe('Marp CLI', () => {
 
     it('converts markdown came from stdin and outputs to stdout', async () => {
       expect(await marpCli()).toBe(0)
-      expect(cliInfo).toHaveBeenCalledWith(
+      expect(cliInfo.mock.calls.map(([m]) => m)).toContainEqual(
         expect.stringContaining('<stdin> => <stdout>')
       )
       expect(stdout).toHaveBeenCalledWith(expect.any(Buffer))
@@ -786,7 +786,7 @@ describe('Marp CLI', () => {
         jest.spyOn(console, 'error').mockImplementation()
 
         expect(await marpCli(['--stdin=false'])).toBe(0)
-        expect(cliInfo).not.toHaveBeenCalledWith(
+        expect(cliInfo.mock.calls.map(([m]) => m)).not.toContainEqual(
           expect.stringContaining('<stdin> => <stdout>')
         )
         expect(stdout).not.toHaveBeenCalledWith(expect.any(Buffer))

--- a/yarn.lock
+++ b/yarn.lock
@@ -7923,6 +7923,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
Now Marp CLI outputs warning if failed the request of file scheme. (powered by Puppeteer's `requestfailed` event)

![](https://user-images.githubusercontent.com/3993388/58261513-6514f100-7db3-11e9-84d1-b6afcc8273e2.png)

User can see this warning when using local files in Markdown conversion to PDF and images. It would help user to notice requiring uploaded assets, or lacked `--allow-local-files` option to render local files.

It requires the update of `href` attr of `base` tag: Add `file:` scheme, to fallback a relative path in `data:` scheme HTML to `file:` scheme and catch request errors by Puppeteer correctly.

Fixes #84.