### PR TITLE
s/overridenName/overrideName/

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,17 +12,17 @@ const themeExtensions = ['*.css']
 
 export class Theme {
   readonly filename: string
-  readonly overridenName?: string
+  readonly overrideName?: string
   name?: string
 
   private readBuffer?: Buffer
 
   private constructor(filename: string, opts: Theme.Options) {
     this.filename = filename
-    this.overridenName =
+    this.overrideName =
       opts.overrideName === true ? this.genUniqName() : opts.overrideName
 
-    this.name = this.overridenName
+    this.name = this.overrideName
   }
 
   get buffer() {
@@ -32,8 +32,8 @@ export class Theme {
   get css() {
     const buf = this.buffer.toString()
 
-    return this.overridenName
-      ? `${buf}\n/* @theme ${this.overridenName} */`
+    return this.overrideName
+      ? `${buf}\n/* @theme ${this.overrideName} */`
       : buf
   }
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -340,9 +340,9 @@ describe('Marp CLI', () => {
         const { themeSet } = converter.options
         const theme = themeSet.themes.get(cssFile)!
 
-        expect(theme.overridenName).not.toBeUndefined()
+        expect(theme.overrideName).not.toBeUndefined()
         expect(converter.options.globalDirectives.theme).toBe(
-          theme.overridenName
+          theme.overrideName
         )
         expect(themeSet.fnForWatch).toContain(cssFile)
       })


### PR DESCRIPTION
Isn't it actually a variable named overrideName?
Test is successful in my environment.

```
$ yarn test
yarn run v1.7.0
$ jest
 PASS  test/converter.ts (11.936s)
 PASS  test/marp-cli.ts (12.449s)
 PASS  test/server.ts
 PASS  test/preview.ts (15.733s)
 PASS  test/engine.ts
 PASS  test/watcher.ts
 PASS  test/theme.ts
 PASS  test/cli.ts
 PASS  test/error.ts
 PASS  test/templates/bespoke.ts
 PASS  test/templates/watch.ts
 PASS  test/server/server-index.ts

Test Suites: 12 passed, 12 total
Tests:       184 passed, 184 total
Snapshots:   0 total
Time:        20.217s
Ran all test suites.
✨  Done in 21.72s.
```