### PR TITLE
Fix httpServer error handling.

### DIFF
--- a/test/__mocks__/express.ts
+++ b/test/__mocks__/express.ts
@@ -1,5 +1,10 @@
 const express = require.requireActual('express')
 
-express.application.listen = jest.fn((port, callback) => callback())
+express.application.listen = jest.fn(port => {})
+express.application.listen.mockReturnValue({
+  on: (event, callback) => {
+    callback()
+  },
+})
 
 module.exports = express

--- a/test/server.ts
+++ b/test/server.ts
@@ -72,7 +72,7 @@ describe('Server', () => {
       const server = new Server(converter())
       await server.start()
 
-      expect(server.server!.listen).toBeCalledWith(8080, expect.any(Function))
+      expect(server.server!.listen).toBeCalledWith(8080)
     })
   })
 


### PR DESCRIPTION
Fixed to handler httpServer start up error.

For example, current marp-cli ignores EADDRINUSE error as below:

```
# Start some web server in port 8080
% marp --html --server .
[  INFO ] [Server mode] Start server listened at http://localhost:8080/ ...

# No error message.
```

**Changes**: 

- Properly handle `'error'` event of node.js httpServer
- Fixed "Unhandled promise rejection" problem on server startup error
- Handle `EADDRINUSE` to show user friendly message