### PR TITLE
Improve version output when using user-installed Marp Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve version output when using user-installed Marp Core ([#105](https://github.com/marp-team/marp-cli/pull/105))
+
 ## v0.10.1 - 2019-06-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ npm install -g @marp-team/marp-cli
 
 ### Standalone binary _(EXPERIMENTAL)_
 
-Do you never want to install any dependent tools? we also provide executable binaries for Linux, macOS, and Windows. [:fast_forward: Download the latest standalone binary for your OS from release page.](https://github.com/marp-team/marp-cli/releases)
+Do you never want to install any dependent tools? we also provide executable binaries for Linux, macOS, and Windows.
+
+**[:fast_forward: Download the latest standalone binary for your OS from release page.](https://github.com/marp-team/marp-cli/releases)**
 
 ## Basic usage
 
@@ -326,10 +328,10 @@ By using `--version` (`-v`) option, you may confirm the version of engine that i
 
 ```console
 $ marp --version
-@marp-team/marp-cli v0.x.x (/w bundled @marp-team/marp-core v0.x.x)
+@marp-team/marp-cli v0.x.x (w/ bundled @marp-team/marp-core v0.x.x)
 ```
 
-Marp CLI prefers to use _an installed core by user_ than the bundled. If the current project has installed `@marp-team/marp-core` individually, it would show its version and the annotation "/w customized engine".
+Marp CLI prefers to use _an installed core by user_ than the bundled. If the current project has installed `@marp-team/marp-core` individually, it would show its version and the annotation: `w/ user-installed @marp-team/marp-core vX.X.X` or `w/ customized engine`.
 
 ## Configuration file
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,21 +4,21 @@ import { MarpCLIConfig } from './config'
 import { name, version } from '../package.json'
 
 export default async function outputVersion(config: MarpCLIConfig): Promise<0> {
+  let engineVer = ''
   const { engine } = config
-  let coreVer = ''
 
   if (engine.klass === Marp) {
-    coreVer = `bundled @marp-team/marp-core v${bundledCoreVer}`
+    engineVer = `bundled @marp-team/marp-core v${bundledCoreVer}`
 
     if (engine.package && engine.package.version !== bundledCoreVer) {
-      coreVer = `user-installed @marp-team/marp-core v${engine.package.version}`
+      engineVer = `user-installed @marp-team/marp-core v${engine.package.version}`
     }
   } else if (engine.package && engine.package.name && engine.package.version) {
-    coreVer = `customized engine in ${engine.package.name} v${engine.package.version}`
+    engineVer = `customized engine in ${engine.package.name} v${engine.package.version}`
   } else {
-    coreVer = `customized engine`
+    engineVer = `customized engine`
   }
 
-  console.log(`${name} v${version}${coreVer ? ` (w/ ${coreVer})` : ''}`)
+  console.log(`${name} v${version}${engineVer ? ` (w/ ${engineVer})` : ''}`)
   return 0
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,17 +4,21 @@ import { MarpCLIConfig } from './config'
 import { name, version } from '../package.json'
 
 export default async function outputVersion(config: MarpCLIConfig): Promise<0> {
-  let message = `${name} v${version} `
   const { engine } = config
+  let coreVer = ''
 
   if (engine.klass === Marp) {
-    message += `(/w bundled @marp-team/marp-core v${bundledCoreVer})`
+    coreVer = `bundled @marp-team/marp-core v${bundledCoreVer}`
+
+    if (engine.package && engine.package.version !== bundledCoreVer) {
+      coreVer = `user-installed @marp-team/marp-core v${engine.package.version}`
+    }
   } else if (engine.package && engine.package.name && engine.package.version) {
-    message += `(/w customized engine in ${engine.package.name} v${engine.package.version})`
+    coreVer = `customized engine in ${engine.package.name} v${engine.package.version}`
   } else {
-    message += `(/w customized engine)`
+    coreVer = `customized engine`
   }
 
-  console.log(message)
+  console.log(`${name} v${version}${coreVer ? ` (w/ ${coreVer})` : ''}`)
   return 0
 }


### PR DESCRIPTION
Marp CLI prefers user-installed Marp Core instead of bundled version. However, npm (or yarn) sometimes merge two patch versions. In this case, `marp --version` cannot detect user-installed core and may show an incorrect version.

So we've improved `--version` (`-v`) command: Outputs `w/ user-installed @marp-team/marp-core vX.X.X` when a resolved Marp Core has unexpected version against bundled.
