### PR TITLE
Update demo slide to Markdown used in screencast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- A demo slide and the button to run in [Gitpod](https://gitpod.io/#https://github.com/marp-team/marp-cli) ([#113](https://github.com/marp-team/marp-cli/pull/113) by [@mouse484](https://github.com/mouse484))
+- A demo slide and the button to run in [Gitpod](https://gitpod.io/#https://github.com/marp-team/marp-cli) ([#113](https://github.com/marp-team/marp-cli/pull/113) by [@mouse484](https://github.com/mouse484), [#114](https://github.com/marp-team/marp-cli/pull/114))
 
 ### Fixed
 

--- a/demo/demo.md
+++ b/demo/demo.md
@@ -1,5 +1,0 @@
-# Marp demo
-
----
-
-## It can convert Marp / Marpit Markdown files into static HTML / CSS and PDF.

--- a/demo/index.md
+++ b/demo/index.md
@@ -1,0 +1,20 @@
+---
+marp: true
+theme: uncover
+---
+
+# Hello, I'm Marp CLI!
+
+Write and convert your presentation deck with just a plain Markdown!
+
+---
+
+<!-- backgroundColor: beige -->
+
+## Watch and preview
+
+Marp CLI is supported watch mode and preview window.
+
+---
+
+# <!--fit--> :+1:


### PR DESCRIPTION
- Update demo slide Markdown from the original content to the content used in screencast.
- Rename filename from `demo.md` to `index.md` to serve slide by default.