### PR TITLE
Refactor Server class to handle error while converting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Downgrade pkg to v4.3.x to fix segfault in the standalone build for Windows ([#111](https://github.com/marp-team/marp-cli/issues/111), [#112](https://github.com/marp-team/marp-cli/pull/112))
+- Improve error handling while running server ([#115](https://github.com/marp-team/marp-cli/pull/115))
 
 ## v0.11.0 - 2019-06-24
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -287,9 +287,11 @@ export default async function(argv: string[] = []): Promise<number> {
 
       if (cvtOpts.server) {
         const server = new Server(converter, {
-          onConverted,
           directoryIndex: ['index.md', 'PITCHME.md'], // GitPitch compatible
         })
+        server.on('converted', onConverted)
+        server.on('error', e => cli.error(e.toString()))
+
         await server.start()
 
         const url = `http://localhost:${server.port}`

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -104,17 +104,17 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
 }
 
 export namespace Preview {
-  export interface Options {
-    height: number
-    width: number
-  }
-
   export interface Events {
     close(window: any): void
     exit(): void
     launch(): void
     open(window: any, location: string): void
     opening(location: string): void
+  }
+
+  export interface Options {
+    height: number
+    width: number
   }
 }
 


### PR DESCRIPTION
I've refactored `Server` class by extending `(Typed)EventEmitter` to improve error handling while converting Markdown.

- A constructor option `onConverted` is replaced to `convert` event provided by `EventEmitter`.
- When raising an error while converting Markdown...
  - Returns 503 error with raised error message.
  - Emits `error` event with error instance. Marp CLI uses this to output error message to console.