### PR TITLE
Fix up not working watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Downgrade pkg to v4.3.x to fix segfault in the standalone build for Windows ([#111](https://github.com/marp-team/marp-cli/issues/111), [#112](https://github.com/marp-team/marp-cli/pull/112))
 - Improve error handling while running server ([#115](https://github.com/marp-team/marp-cli/pull/115))
+- Fix up not working watch mode ([#116](https://github.com/marp-team/marp-cli/pull/116))
 
 ## v0.11.0 - 2019-06-24
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -313,11 +313,14 @@ export default async function(argv: string[] = []): Promise<number> {
     if (!(e instanceof CLIError)) throw e
 
     cli.error(e.message)
+
+    // Stop running notifier and watcher to exit process correctly
+    // (NOTE: Don't close in the finally block to keep watching)
+    notifier.stop()
+    if (watcherInstance) watcherInstance.chokidar.close()
+
     return e.errorCode
   } finally {
     await Converter.closeBrowser()
-    notifier.stop()
-
-    if (watcherInstance) watcherInstance.chokidar.close()
   }
 }


### PR DESCRIPTION
By closing watcher and notifier in the `finally` block, a hot reload feature via `--watch` (`-w`) was not working since v0.10.1. 😭