### PR TITLE
Process glob-like path that refers to a real file correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix that cannot find Markdown from directory that includes non-ASCII code ([#108](https://github.com/marp-team/marp-cli/issues/108), [#109](https://github.com/marp-team/marp-cli/pull/109))
+- Process glob-like path that refers to a real file correctly ([#95](https://github.com/marp-team/marp-cli/issues/95), [#117](https://github.com/marp-team/marp-cli/pull/117))
 
 ## v0.11.1 - 2019-06-28
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -121,7 +121,7 @@ export class MarpCLIConfig {
     const theme = await this.loadTheme()
     const initialThemes = theme instanceof Theme ? [theme] : []
 
-    const themeSetPathes =
+    const themeSetPaths =
       this.args.themeSet ||
       (this.conf.themeSet
         ? (Array.isArray(this.conf.themeSet)
@@ -131,13 +131,13 @@ export class MarpCLIConfig {
         : [])
 
     const themeSet = await ThemeSet.initialize(
-      (inputDir ? [inputDir] : []).concat(themeSetPathes),
+      (inputDir ? [inputDir] : []).concat(themeSetPaths),
       initialThemes
     )
 
     if (
       themeSet.themes.size <= initialThemes.length &&
-      themeSetPathes.length > 0
+      themeSetPaths.length > 0
     )
       warn('Not found additional theme CSS files.')
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -119,17 +119,17 @@ export class File {
 
   private static stdinBuffer?: Buffer
 
-  static async find(...pathes: string[]): Promise<File[]> {
-    const filepathes = new Set<string>()
+  static async find(...paths: string[]): Promise<File[]> {
+    const filepaths = new Set<string>()
     const globs: string[] = []
 
     // Collect passed files that refers to a real path at first
-    for (const p of pathes) {
+    for (const p of paths) {
       try {
         const s: fs.Stats = await stat(p)
 
         if (s.isFile()) {
-          filepathes.add(path.resolve(p))
+          filepaths.add(path.resolve(p))
           continue
         }
       } catch (e) {}
@@ -145,9 +145,9 @@ export class File {
         files: markdownExtensions.map(ext => `*.${ext}`),
       },
       ignore: ['**/node_modules'],
-    })).forEach(p => filepathes.add(p))
+    })).forEach(p => filepaths.add(p))
 
-    return [...filepathes.values()].map(p => new File(p))
+    return [...filepaths.values()].map(p => new File(p))
   }
 
   static async findDir(directory: string): Promise<File[]> {

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -730,6 +730,17 @@ describe('Marp CLI', () => {
       )
     })
 
+    context('when glob special chars are included in real file path', () => {
+      it('finds out a file correctly', async () => {
+        jest.spyOn(cli, 'info').mockImplementation()
+        jest
+          .spyOn<any, any>(Converter.prototype, 'convertFiles')
+          .mockImplementation(() => [])
+
+        expect(await marpCli([assetFn('_files/字/(non-ascii).md')])).toBe(0)
+      })
+    })
+
     context('when non-ASCII code is included in directory name', () => {
       it('finds out markdown files correctly', async () => {
         jest.spyOn(cli, 'info').mockImplementation()

--- a/test/theme.ts
+++ b/test/theme.ts
@@ -24,7 +24,7 @@ describe('ThemeSet', () => {
   })
 
   describe('#findPath', () => {
-    it('returns the result of findings from original pathes', async () => {
+    it('returns the result of findings from original paths', async () => {
       const themeSet = await ThemeSet.initialize([themeDir])
       const found = await themeSet.findPath()
 


### PR DESCRIPTION
Resolves #95.

I've updated `File.find()` to collect passed files that refers to a real file path at first. After than, remaining glob pathes will pass to globby.