### PR TITLE
Rename bespoke option arguments using dot notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Set up CI for Windows with Azure Pipelines ([#120](https://github.com/marp-team/marp-cli/pull/120))
 
+### Changed
+
+- Rename bespoke option arguments using dot notation ([#122](https://github.com/marp-team/marp-cli/pull/122))
+
+### Deprecated
+
+- Deprecate `--bespoke-osc` and `--bespoke-progress` argument options in favor of options using dot notation ([#122](https://github.com/marp-team/marp-cli/pull/122))
+
 ## v0.11.3 - 2019-06-30
 
 ### Fixed

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -125,16 +125,48 @@ export default async function(argv: string[] = []): Promise<number> {
           choices: Object.keys(templates),
           type: 'string',
         },
-        'bespoke-osc': {
+        'bespoke.osc': {
           describe: '[Bespoke] Use on-screen controller',
           defaultDescription: 'true',
           group: OptionGroup.Template,
           type: 'boolean',
         },
-        'bespoke-progress': {
+        'bespoke-osc': {
+          coerce: v => {
+            cli.warn(
+              `${chalk.yellow(
+                '--bespoke-osc'
+              )} option is deprecated. Please use ${chalk.yellow(
+                '--bespoke.osc'
+              )} instead.`
+            )
+            return v
+          },
+          describe: '[DEPRECATED]',
+          group: OptionGroup.Template,
+          hidden: true,
+          type: 'boolean',
+        },
+        'bespoke.progress': {
           describe: '[Bespoke] Use progress bar',
           defaultDescription: 'false',
           group: OptionGroup.Template,
+          type: 'boolean',
+        },
+        'bespoke-progress': {
+          coerce: v => {
+            cli.warn(
+              `${chalk.yellow(
+                '--bespoke-progress'
+              )} option is deprecated. Please use ${chalk.yellow(
+                '--bespoke.progress'
+              )} instead.`
+            )
+            return v
+          },
+          describe: '[DEPRECATED]',
+          group: OptionGroup.Template,
+          hidden: true,
           type: 'boolean',
         },
         title: {


### PR DESCRIPTION
To match the type of configuration object defined in yargs, `--bespoke-osc` and `--bespoke-progress` option arguments were renamed to using dot notation: `--bespoke.osc` and `--bespoke.progress`.

Hyphenated options still can use but they will output warnings.