### PR TITLE
Reconnect to file watcher when disconnected from WebSocket server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reconnect to file watcher when disconnected from WebSocket server ([#130](https://github.com/marp-team/marp-cli/pull/130))
+
 ## v0.12.1 - 2019-07-13
 
 ### Changed

--- a/src/templates/watch/watch.ts
+++ b/src/templates/watch/watch.ts
@@ -27,5 +27,5 @@ const connect = (path: string, reconnect: boolean = false) => {
 
 export default function() {
   const wsPath = (window as any).__marpCliWatchWS
-  if (wsPath) connect(wsPath)
+  if (wsPath) return connect(wsPath)
 }

--- a/src/templates/watch/watch.ts
+++ b/src/templates/watch/watch.ts
@@ -1,10 +1,31 @@
-export default function() {
-  const wsPath = (<any>window).__marpCliWatchWS
+const reconnectMs = 5000
 
-  if (wsPath) {
-    const ws = new WebSocket(wsPath)
-    ws.addEventListener('message', e => {
-      if (e.data === 'reload') location.reload()
-    })
-  }
+const connect = (path: string, reconnect: boolean = false) => {
+  const ws = new WebSocket(path)
+
+  ws.addEventListener('open', () => {
+    console.info('[Marp CLI] Observing the change of file...')
+    if (reconnect) location.reload()
+  })
+  ws.addEventListener('close', () => {
+    console.warn(
+      `[Marp CLI] WebSocket for file watcher was disconnected. Try re-connecting in ${reconnectMs}ms...`
+    )
+    setTimeout(() => {
+      connect(
+        path,
+        true
+      )
+    }, reconnectMs)
+  })
+  ws.addEventListener('message', e => {
+    if (e.data === 'reload') location.reload()
+  })
+
+  return ws
+}
+
+export default function() {
+  const wsPath = (window as any).__marpCliWatchWS
+  if (wsPath) connect(wsPath)
 }

--- a/test/templates/watch.ts
+++ b/test/templates/watch.ts
@@ -8,12 +8,23 @@ afterEach(() => jest.restoreAllMocks())
 describe('Watch mode notifier on browser context', () => {
   let server: Server
 
-  beforeEach(async done => {
+  const createWSServer = async () => {
+    const port = await portfinder.getPortPromise({ port: 52000 })
+
+    return new Promise<Server>((res, rej) => {
+      try {
+        const createdServer = new Server({ port }, () => res(createdServer))
+      } catch (e) {
+        rej(e)
+      }
+    })
+  }
+
+  beforeEach(async () => {
     jest.spyOn(console, 'info').mockImplementation()
     jest.spyOn(console, 'warn').mockImplementation()
 
-    const port = await portfinder.getPortPromise({ port: 52000 })
-    server = new Server({ port }, done)
+    server = await createWSServer()
   })
 
   afterEach(() => server.close())
@@ -36,7 +47,6 @@ describe('Watch mode notifier on browser context', () => {
 
     it('listens reload event', async () => {
       const reload = jest.spyOn(location, 'reload').mockImplementation()
-
       const send = await new Promise<(data: any) => Promise<void>>(
         (res, rej) => {
           server.on('error', e => rej(e))
@@ -57,10 +67,45 @@ describe('Watch mode notifier on browser context', () => {
       )
 
       await send('ready')
-      expect(reload).not.toHaveBeenCalled()
+      expect(reload).not.toBeCalled()
 
       await send('reload')
-      expect(reload).toHaveBeenCalled()
+      expect(reload).toBeCalled()
+    })
+
+    context('when closed WebSocket server', () => {
+      beforeEach(() => jest.useFakeTimers())
+      afterEach(() => jest.useRealTimers())
+
+      it('reconnects watcher in 5 sec', async done => {
+        const reload = jest.spyOn(location, 'reload').mockImplementation()
+        const clientSocket = await new Promise<WebSocket>((res, rej) => {
+          let socket: WebSocket
+
+          server.once('error', e => rej(e))
+          server.once('connection', () => res(socket))
+
+          socket = watch()!
+        })
+
+        await new Promise(res => {
+          clientSocket.addEventListener('close', res)
+          server.close()
+        })
+
+        server = await createWSServer()
+        server.once('connection', (ws, socket) => {
+          expect(socket.url).toBe('/test')
+
+          ws.on('pong', () => {
+            expect(reload).toBeCalled()
+            done()
+          })
+          ws.ping()
+        })
+
+        jest.advanceTimersByTime(5000)
+      })
     })
   })
 })


### PR DESCRIPTION
In watching the change of files by `--watch` and `--server`, generated HTMLs cannot recover WebSocket connection when disconnected from server.

This PR adds the logic trying to recover connection if disconnected from WebSocket server. It's useful for tracking change of engine JS through using additional tools such as `nodemon`.