### PR TITLE
Fix fallback of File#absoluteFileScheme for old Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix an issue `--allow-local-files` may not work in the old Node + Windows ([#133](https://github.com/marp-team/marp-cli/issues/133), [#136](https://github.com/marp-team/marp-cli/pull/136))
+
 ### Changed
 
 - Reconnect to file watcher when disconnected from WebSocket server ([#130](https://github.com/marp-team/marp-cli/pull/130))

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "chrome-launcher": "^0.11.1",
     "cosmiconfig": "^5.2.1",
     "express": "^4.17.1",
+    "file-url": "^3.0.0",
     "get-stdin": "^7.0.0",
     "globby": "^10.0.1",
     "import-from": "^3.0.0",

--- a/src/file.ts
+++ b/src/file.ts
@@ -46,7 +46,7 @@ export class File {
       return url.pathToFileURL(this.absolutePath).toString()
 
     // Fallback for Node < v10.12.0
-    return `file://${path.posix.resolve(this.path)}`
+    return new url.URL(`file://${this.absolutePath}`).toString()
   }
 
   convert(output: string | false | undefined, opts: FileConvertOption): File {

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,11 +1,12 @@
 import fs from 'fs'
+import path from 'path'
+import * as url from 'url'
+import { promisify } from 'util'
+import fileUrl from 'file-url'
 import getStdin from 'get-stdin'
 import globby, { GlobbyOptions } from 'globby'
 import mkdirp from 'mkdirp'
-import path from 'path'
-import * as url from 'url'
 import { tmpName } from 'tmp'
-import { promisify } from 'util'
 
 const stat = promisify(fs.stat)
 const mkdirpPromise = promisify<string, any>(mkdirp)
@@ -46,7 +47,7 @@ export class File {
       return url.pathToFileURL(this.absolutePath).toString()
 
     // Fallback for Node < v10.12.0
-    return new url.URL(`file://${this.absolutePath}`).toString()
+    return fileUrl(this.absolutePath)
   }
 
   convert(output: string | false | undefined, opts: FileConvertOption): File {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,6 +2610,11 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-url@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-3.0.0.tgz#247a586a746ce9f7a8ed05560290968afc262a77"
+  integrity sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"


### PR DESCRIPTION
I'm trying to resolve #133.

`url.pathToFileURL` cannot use in Node < v10.12.0 so file scheme URI would be resolved manually. A problem is that its logic is using `path.posix.resolve()`. It would be returned incorrect path in Windows.

We've fixed it by using `file-url` module. Marp for VS Code's built-in Node is v10.11.0 so it may resolve an edge case like reported in https://github.com/marp-team/marp-vscode/issues/64.