### PR TITLE
Change port number for file watcher from 52000 to 37717

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 ports:
   - port: 8080
     onOpen: open-preview
-  - port: 52000
+  - port: 37717
     onOpen: ignore
 tasks:
   - init: yarn install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Reconnect to file watcher when disconnected from WebSocket server ([#130](https://github.com/marp-team/marp-cli/pull/130))
+- Change port number for file watcher from 52000 to 37717 ([#135](https://github.com/marp-team/marp-cli/issues/135), [#137](https://github.com/marp-team/marp-cli/pull/137))
 
 ## v0.12.1 - 2019-07-13
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -86,7 +86,7 @@ export class WatchNotifier {
 
   async port() {
     if (this.portNumber === undefined)
-      this.portNumber = await portfinder.getPortPromise({ port: 52000 })
+      this.portNumber = await portfinder.getPortPromise({ port: 37717 })
 
     return this.portNumber
   }

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -210,7 +210,7 @@ describe('Converter', () => {
 
         const { result } = await converter.convert(md, dummyFile)
         expect(result).toContain(
-          `<script>window\.__marpCliWatchWS="ws://localhost:52000/${hash}";`
+          `<script>window\.__marpCliWatchWS="ws://localhost:37717/${hash}";`
         )
       })
     })

--- a/test/templates/watch.ts
+++ b/test/templates/watch.ts
@@ -9,7 +9,7 @@ describe('Watch mode notifier on browser context', () => {
   let server: Server
 
   const createWSServer = async () => {
-    const port = await portfinder.getPortPromise({ port: 52000 })
+    const port = await portfinder.getPortPromise({ port: 37717 })
 
     return new Promise<Server>((res, rej) => {
       try {

--- a/test/watcher.ts
+++ b/test/watcher.ts
@@ -165,11 +165,11 @@ describe('WatchNotifier', () => {
     expect(notifier).toBeInstanceOf(WatchNotifier))
 
   describe('#port', () => {
-    it('finds available port from 52000', async () => {
+    it('finds available port from 37717', async () => {
       const finderSpy = jest.spyOn(portfinder, 'getPortPromise')
       const instance = new WatchNotifier()
 
-      expect(await instance.port()).toBe(52000)
+      expect(await instance.port()).toBe(37717)
       expect(finderSpy).toHaveBeenCalledTimes(1)
 
       // Return stored port number of instance when called twice
@@ -177,16 +177,16 @@ describe('WatchNotifier', () => {
       expect(finderSpy).toHaveBeenCalledTimes(1)
     })
 
-    context('when 52000 port is using for the other purpose', () => {
+    context('when 37717 port is using for the other purpose', () => {
       let server: http.Server
 
       beforeEach(
-        () => (server = http.createServer((_, res) => res.end()).listen(52000))
+        () => (server = http.createServer((_, res) => res.end()).listen(37717))
       )
       afterEach(() => server.close())
 
-      it('returns port number 52001', async () =>
-        expect(await new WatchNotifier().port()).toBe(52001))
+      it('returns port number 37718', async () =>
+        expect(await new WatchNotifier().port()).toBe(37718))
     })
   })
 
@@ -194,7 +194,7 @@ describe('WatchNotifier', () => {
     it('generates WebSocket URL from path string and add to listeners', async () => {
       const instance = new WatchNotifier()
       expect(await instance.register('test')).toBe(
-        `ws://localhost:52000/${testIdentifier}`
+        `ws://localhost:37717/${testIdentifier}`
       )
 
       const listenerSet = instance.listeners.get(testIdentifier)


### PR DESCRIPTION
Resolves #135.

Now `portfinder` is no longer prevented using port > 40000, but a reason why should prevent using these port is explained clearly in https://github.com/http-party/node-portfinder/pull/82#issuecomment-520199847.

A new port number 37717 is just a meaingless prime number. ;)