### PR TITLE
Add v8-compile-cache to make faster startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `v8-compile-cache` to make faster startup ([#139](https://github.com/marp-team/marp-cli/pull/139))
+
 ## v0.13.0 - 2019-08-23
 
 ### Fixed

--- a/marp-cli.js
+++ b/marp-cli.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+require('v8-compile-cache')
 require('./lib/marp-cli.js')
   .default(process.argv.slice(2))
   .then(exitCode => process.on('exit', () => process.exit(exitCode)))

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "serve-index": "^1.9.1",
     "strip-ansi": "^5.2.0",
     "tmp": "^0.1.0",
+    "v8-compile-cache": "^2.1.0",
     "wrap-ansi": "^6.0.0",
     "ws": "^7.1.2",
     "yargs": "^14.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7852,6 +7852,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
+v8-compile-cache@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
Make CLI be faster by adding `v8-compile-cache` that attaches the require hook for using V8 code cache.

Benchmark of `time ./marp-cli.js` in my environments shows not dramatic but steady x1.15 speed up. (Use average time of 10 executions)

|`real`|Mac|Win|
|:---:|:---|:---|
|`master`|0.671s|0.960s|
|`v8-compile-cache`|0.585s (x1.15)|0.843s (x1.14)|