### PR TITLE
Upload artifacts within GitHub Actions

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -45,6 +45,10 @@ jobs:
           yarn standalone:pack
         env:
           MATRIX_OS: ${{ matrix.os }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: assets
+          path: dist
       - name: Upload created asset to GitHub Release
         uses: marp-team/actions@v1
         with:

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -30,6 +30,10 @@ jobs:
         run: yarn test:coverage --ci -i --reporters=default --reporters=jest-junit
         env:
           CI: true
+      - uses: actions/upload-artifact@v1
+        with:
+          name: coverage
+          path: coverage
       - name: Codecov
         run: yarn codecov -F windows
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- Migrate CI for Windows into GitHub Actions ([#132](https://github.com/marp-team/marp-cli/issues/132), [#140](https://github.com/marp-team/marp-cli/pull/140))
+- Migrate CI for Windows into GitHub Actions ([#132](https://github.com/marp-team/marp-cli/issues/132), [#140](https://github.com/marp-team/marp-cli/pull/140), [#146](https://github.com/marp-team/marp-cli/pull/146))
 - Update CircleCI configuration to use v2.1 ([#144](https://github.com/marp-team/marp-cli/pull/144))
 
 ## v0.13.0 - 2019-08-23


### PR DESCRIPTION
Workflows defined by GitHub Actions will upload the coverage result and packaged binaries to artifacts as same as CircleCI.