### PR TITLE
Precompile v8 cache while building Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Precompile v8 cache while building Docker image ([#148](https://github.com/marp-team/marp-cli/pull/148))
+
 ## v0.13.1 - 2019-09-10
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ ENV IS_DOCKER true
 WORKDIR /home/marp/.cli
 COPY --chown=marp:marp . /home/marp/.cli/
 RUN yarn install && yarn add puppeteer-core@chrome-$(chromium-browser --version | sed -r 's/^Chromium ([0-9]+).+$/\1/') \
-    && yarn build && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean
+    && yarn build && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean \
+    && node /home/marp/.cli/marp-cli.js --version
 
 WORKDIR /home/marp/app
 ENTRYPOINT ["node", "/home/marp/.cli/marp-cli.js"]


### PR DESCRIPTION
#139 makes CLI be faster but Docker image has not prepared V8 compile cache. This PR will run Marp CLI once while building Docker image and create v8 precompiled cache.

It has about x1.1 faster startup.