### PR TITLE
Hold the progress state of fragments on to URL query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Hold the progress state of fragments on to URL query parameter ([#149](https://github.com/marp-team/marp-cli/pull/149))
+
 ## v0.13.1 - 2019-09-10
 
 ### Added

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -4,10 +4,10 @@ import bespokeClasses from './classes'
 import bespokeInactive from './inactive'
 import bespokeFragments from './fragments'
 import bespokeFullscreen from './fullscreen'
-import bespokeHash from './hash'
 import bespokeNavigation from './navigation'
 import bespokeOSC from './osc'
 import bespokeProgress from './progress'
+import bespokeState from './state'
 import bespokeSync from './sync'
 import bespokeTouch from './touch'
 import { readQuery } from './utils'
@@ -19,7 +19,7 @@ export default function(target = document.getElementById('presentation')!) {
     bespokeForms(),
     bespokeClasses,
     bespokeInactive(),
-    bespokeHash({ history: false }),
+    bespokeState({ history: false }),
     bespokeNavigation(),
     bespokeFullscreen,
     bespokeProgress,

--- a/src/templates/bespoke/state.ts
+++ b/src/templates/bespoke/state.ts
@@ -1,38 +1,92 @@
-// Based on https://github.com/bespokejs/bespoke-hash
+import { generateURLfromParams, readQuery } from './utils'
 
 export interface BespokeStateOption {
   history?: boolean
 }
 
+const coerceInt = (ns: string) => {
+  const coerced = Number.parseInt(ns, 10)
+  return Number.isNaN(coerced) ? null : coerced
+}
+
 export default function bespokeState(opts: BespokeStateOption = {}) {
-  const options: BespokeStateOption = {
-    history: true,
-    ...opts,
-  }
+  const options: BespokeStateOption = { history: true, ...opts }
+
+  const updateState = (...args: Parameters<typeof history['pushState']>) =>
+    options.history ? history.pushState(...args) : history.replaceState(...args)
 
   return deck => {
-    function activateSlide(index) {
-      const idx = Math.max(0, Math.min(index, deck.slides.length - 1))
-      if (idx !== deck.slide()) deck.slide(idx)
+    let internalNavigation = true
+
+    const navInternally = (action: () => any) => {
+      const previous = internalNavigation
+
+      try {
+        internalNavigation = true
+        return action()
+      } finally {
+        internalNavigation = previous
+      }
     }
 
-    function parseHash() {
-      const pageNumber = parseInt(window.location.hash.slice(1), 10)
-      if (!Number.isNaN(pageNumber)) activateSlide(pageNumber - 1)
+    const activateSlide = (index: number, fragment: number | null) => {
+      const { fragments, slides } = deck
+      const idx = Math.max(0, Math.min(index, slides.length - 1))
+      const frag = Math.max(0, Math.min(fragment || 0, fragments.length - 1))
+
+      if (idx !== deck.slide() || frag !== deck.fragmentIndex)
+        deck.slide(idx, { fragment: frag })
     }
+
+    const parseState = (opts: any = { fragment: true }) => {
+      const page = (coerceInt(location.hash.slice(1)) || 1) - 1
+      const fragment = opts.fragment ? coerceInt(readQuery('f') || '') : null
+
+      activateSlide(page, fragment)
+    }
+
+    deck.on('fragment', ({ index, fragmentIndex }) => {
+      if (internalNavigation) return
+
+      const params = new URLSearchParams(location.search)
+
+      if (fragmentIndex === 0) {
+        params.delete('f')
+      } else {
+        params.set('f', fragmentIndex.toString())
+      }
+
+      updateState(
+        null,
+        document.title,
+        generateURLfromParams(params, { ...location, hash: `#${index + 1}` })
+      )
+    })
 
     setTimeout(() => {
-      parseHash()
+      parseState()
 
-      deck.on('activate', e => {
-        if (options.history) {
-          window.location.hash = e.index + 1
-        } else {
-          window.location.replace(`#${e.index + 1}`)
-        }
+      window.addEventListener('hashchange', () =>
+        navInternally(() => {
+          parseState({ fragment: false })
+
+          // f parameter has to remove
+          const params = new URLSearchParams(location.search)
+          params.delete('f')
+
+          history.replaceState(
+            null,
+            document.title,
+            generateURLfromParams(params)
+          )
+        })
+      )
+
+      window.addEventListener('popstate', () => {
+        if (!internalNavigation) navInternally(() => parseState())
       })
 
-      window.addEventListener('hashchange', parseHash)
+      internalNavigation = false
     }, 0)
   }
 }

--- a/src/templates/bespoke/state.ts
+++ b/src/templates/bespoke/state.ts
@@ -1,11 +1,11 @@
 // Based on https://github.com/bespokejs/bespoke-hash
 
-export interface BespokeHashOption {
+export interface BespokeStateOption {
   history?: boolean
 }
 
-export default function bespokeHash(opts: BespokeHashOption = {}) {
-  const options: BespokeHashOption = {
+export default function bespokeState(opts: BespokeStateOption = {}) {
+  const options: BespokeStateOption = {
     history: true,
     ...opts,
   }

--- a/src/templates/bespoke/state.ts
+++ b/src/templates/bespoke/state.ts
@@ -32,7 +32,10 @@ export default function bespokeState(opts: BespokeStateOption = {}) {
     const activateSlide = (index: number, fragment: number | null) => {
       const { fragments, slides } = deck
       const idx = Math.max(0, Math.min(index, slides.length - 1))
-      const frag = Math.max(0, Math.min(fragment || 0, fragments.length - 1))
+      const frag = Math.max(
+        0,
+        Math.min(fragment || 0, fragments[idx].length - 1)
+      )
 
       if (idx !== deck.slide() || frag !== deck.fragmentIndex)
         deck.slide(idx, { fragment: frag })

--- a/src/templates/bespoke/utils.ts
+++ b/src/templates/bespoke/utils.ts
@@ -1,2 +1,10 @@
+export const generateURLfromParams = (
+  params: URLSearchParams,
+  { protocol, host, pathname, hash }: Location = location
+) => {
+  const q = params.toString()
+  return `${protocol}//${host}${pathname}${q ? '?' : ''}${q}${hash}`
+}
+
 export const readQuery = (name: string) =>
   new URLSearchParams(location.search).get(name)

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -219,7 +219,7 @@ describe("Bespoke template's browser context", () => {
     })
   })
 
-  describe('Hash', () => {
+  describe('State', () => {
     it('activates initial page by hash index', () => {
       location.href = 'http://localhost/#2'
 


### PR DESCRIPTION
We've renewed Bespoke.js hash plugin to "State plugin". It holds the index of shown fragment on to `f` query parameter if the current state of slide is in the progress of fragments.

User can show the middle of fragment animation by accessing URL that has `f` query parameter.

![fragment](https://user-images.githubusercontent.com/3993388/64675683-bc4be800-d4ae-11e9-9d3d-08835e9e6427.gif)

We are planning to make the best use of this feature in next slide preview in presenter view. (#142)