### PR TITLE
Please note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Do you never want to install any dependent tools? we also provide executable bin
 
 **[:fast_forward: Download the latest standalone binary for your OS from release page.](https://github.com/marp-team/marp-cli/releases)**
 
-## Basic usage
+## Basic usage(Standalone)
 
 ### Convert to HTML
 


### PR DESCRIPTION
# Summary
`npx` command is omitted in Basic Usage.
If someone installed via `npm`, he hits  `marp` command, it doesn't work.

## bad
```
$ marp slide-deck.md
zsh: command not found: marp
```

## good
```
$ npx marp slide-deck.md
```