### PR TITLE
Wrap bespoke state plugin's state updation in try-catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Safari prevents moving slide after too many navigations ([#158](https://github.com/marp-team/marp-cli/issues/158), [#160](https://github.com/marp-team/marp-cli/pull/160))
+
 ## v0.14.1 - 2019-09-15
 
 ### Fixed

--- a/src/templates/bespoke/state.ts
+++ b/src/templates/bespoke/state.ts
@@ -12,8 +12,16 @@ const coerceInt = (ns: string) => {
 export default function bespokeState(opts: BespokeStateOption = {}) {
   const options: BespokeStateOption = { history: true, ...opts }
 
-  const updateState = (...args: Parameters<typeof history['pushState']>) =>
-    options.history ? history.pushState(...args) : history.replaceState(...args)
+  const updateState = (...args: Parameters<typeof history['pushState']>) => {
+    try {
+      options.history
+        ? history.pushState(...args)
+        : history.replaceState(...args)
+    } catch (e) {
+      // Safari may throw SecurityError by replacing state 100 times per 30 seconds.
+      console.error(e)
+    }
+  }
 
   return deck => {
     let internalNavigation = true
@@ -77,11 +85,15 @@ export default function bespokeState(opts: BespokeStateOption = {}) {
           const params = new URLSearchParams(location.search)
           params.delete('f')
 
-          history.replaceState(
-            null,
-            document.title,
-            generateURLfromParams(params)
-          )
+          try {
+            history.replaceState(
+              null,
+              document.title,
+              generateURLfromParams(params)
+            )
+          } catch (e) {
+            console.error(e)
+          }
         })
       )
 


### PR DESCRIPTION
Safari may throw SecurityError by replacing state 100 times per 30 seconds. Wrapping in try-catch is important for doing remained processes correctly.

Resolves #158.