### PR TITLE
Remove the detection of helper script from resolved engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Upgrade [Marpit v1.4.1](https://github.com/marp-team/marpit/releases/tag/v1.4.1) and [Marp Core v0.14.0](https://github.com/marp-team/marp-core/releases/tag/v0.14.0) ([#169](https://github.com/marp-team/marp-cli/pull/169))
 - Upgrade dependent packages to the latest version ([#164](https://github.com/marp-team/marp-cli/pull/164), [#169](https://github.com/marp-team/marp-cli/pull/169))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Upgrade dependent packages to the latest version ([#164](https://github.com/marp-team/marp-cli/pull/164), [#169](https://github.com/marp-team/marp-cli/pull/169))
 
+### Removed
+
+- Remove the detection of helper script from resolved engine ([#171](https://github.com/marp-team/marp-cli/pull/171))
+
 ## v0.14.1 - 2019-09-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^5.1.2",
     "rollup-plugin-typescript": "^1.0.1",
-    "rollup-plugin-url": "^3.0.0",
+    "rollup-plugin-url": "^2.2.4",
     "sass": "^1.23.0",
     "screenfull": "^5.0.0",
     "stylelint": "^11.1.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,9 +214,6 @@ export class MarpCLIConfig {
       lang: this.conf.lang || (await osLocale()).replace(/@/g, '-'),
       options: this.conf.options || {},
       pages: !!(this.args.images || this.conf.images),
-      readyScript: this.engine.browserScript
-        ? `<script>${this.engine.browserScript}</script>`
-        : undefined,
       watch:
         pick(this.args.watch, this.conf.watch) || preview || server || false,
     }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -48,7 +48,6 @@ export interface ConverterOption {
   pages?: boolean | number[]
   preview?: boolean
   jpegQuality?: number
-  readyScript?: string
   server?: boolean
   template: string
   templateOption?: TemplateOption
@@ -91,7 +90,7 @@ export class Converter {
   }
 
   async convert(markdown: string, file?: File): Promise<TemplateResult> {
-    const { lang, readyScript, globalDirectives, type } = this.options
+    const { lang, globalDirectives, type } = this.options
     const isFile = file && file.type === FileType.File
 
     let additionals = ''
@@ -107,7 +106,6 @@ export class Converter {
     return await this.template({
       ...(this.options.templateOption || {}),
       lang,
-      readyScript,
       base:
         isFile && type !== ConvertType.html
           ? file!.absoluteFileScheme

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -19,7 +19,6 @@ interface TemplateCoreOption {
   base?: string
   lang: string
   notifyWS?: string
-  readyScript?: string
   renderer: (tplOpts: MarpitOptions) => RendererResult
 }
 
@@ -89,13 +88,6 @@ export const bespoke: Template<TemplateBespokeOption> = async opts => {
         osc: opts.osc === undefined ? true : opts.osc,
         progress: opts.progress,
       },
-      readyScript:
-        opts.readyScript ||
-        `<script>${await libJs(
-          require.resolve(
-            '@marp-team/marpit-svg-polyfill/lib/polyfill.browser.js'
-          )
-        )}</script>`,
       watchJs: await watchJs(opts.notifyWS),
     }),
   }

--- a/src/templates/layout.pug
+++ b/src/templates/layout.pug
@@ -34,7 +34,6 @@ html(lang=lang)
   body
     block deck
       != html
-      != readyScript
 
     block script
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -10,7 +10,7 @@ export default async function outputVersion(config: MarpCLIConfig): Promise<0> {
   const { engine } = config
 
   if (isMarpCore(engine.klass)) {
-    engineVer = `bundled @marp-team/marp-core v${bundledCoreVer}`
+    engineVer = `@marp-team/marp-core v${bundledCoreVer}`
 
     if (engine.package && engine.package.version !== bundledCoreVer) {
       engineVer = `user-installed @marp-team/marp-core v${engine.package.version}`

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -83,16 +83,11 @@ describe('Converter', () => {
 
     it('returns the result of template', async () => {
       const options: any = { html: true }
-      const readyScript = '<b>ready</b>'
-      const { result, rendered } = await instance({
-        options,
-        readyScript,
-      }).convert(md)
+      const { result, rendered } = await instance({ options }).convert(md)
 
       expect(result).toMatch(/^<!DOCTYPE html>[\s\S]+<\/html>$/)
       expect(result).toContain(rendered.html)
       expect(result).toContain(rendered.css)
-      expect(result).toContain(readyScript)
       expect(result).not.toContain('<base')
       expect(rendered.css).toContain('@theme default')
     })

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -1,31 +1,14 @@
 import Marp from '@marp-team/marp-core'
-import resolve, { ResolvedEngine } from '../src/engine'
+import resolve from '../src/engine'
 
 describe('Engine', () => {
-  const coreModule = '@marp-team/marp-core'
-  const marpitModule = '@marp-team/marpit'
-
   describe('.resolve', () => {
     it('returns ResolvedEngine class with resolved class', async () => {
       expect((await resolve(Marp)).klass).toBe(Marp)
-      expect((await resolve(coreModule)).klass.name).toBe('Marp')
+      expect((await resolve('@marp-team/marp-core')).klass.name).toBe('Marp')
 
       // Return with the first resolved class
       expect((await resolve(['__invalid_module__', Marp])).klass).toBe(Marp)
-    })
-
-    it("loads browser script from defined in module's marpBrowser section", async () => {
-      const finder = jest.spyOn(<any>ResolvedEngine.prototype, 'findClassPath')
-
-      // Core (defined marpBrowser)
-      finder.mockImplementation(() => require.resolve(coreModule))
-
-      expect((await resolve(Marp)).browserScript).toBeTruthy()
-      expect((await resolve(coreModule)).browserScript).toBeTruthy()
-
-      // Marpit (not defined marpBrowser)
-      finder.mockImplementation(() => require.resolve(marpitModule))
-      expect((await resolve(marpitModule)).browserScript).toBeUndefined()
     })
   })
 })

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -65,9 +65,7 @@ describe('Marp CLI', () => {
           expect.stringContaining(`@marp-team/marp-cli v${cliVersion}`)
         )
         expect(log).toBeCalledWith(
-          expect.stringContaining(
-            `bundled @marp-team/marp-core v${coreVersion}`
-          )
+          expect.stringContaining(`@marp-team/marp-core v${coreVersion}`)
         )
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,12 +6515,13 @@ rollup-plugin-typescript@^1.0.1:
     resolve "^1.10.0"
     rollup-pluginutils "^2.5.0"
 
-rollup-plugin-url@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-url/-/rollup-plugin-url-3.0.0.tgz#38c1540eb02cf29aec2b7fb57ad3877505ed6a75"
-  integrity sha512-zeSVpWwsePvc6oTw5eyAlkfHhS6ZT9/pNVVgyzbeMTgd6rovxgg0FPE4o86b9Snembc0rCAaTvEsSfZinJMITw==
+rollup-plugin-url@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-url/-/rollup-plugin-url-2.2.4.tgz#36a6dedb709f73647bed7b253b9dcd4f3e781af4"
+  integrity sha512-vQjMgJj3tYrg6nKYO/Tvc8s1WTqbaLzHXia17358E6vO0Iq4Ih5WcWYRPopLMUx0x63/31+9ezApAL0HFd998w==
   dependencies:
     mime "^2.4.4"
+    mkdirp "^0.5.1"
     rollup-pluginutils "^2.8.2"
 
 rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.3, rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:


### PR DESCRIPTION
An updated Marp Core v0.14.0 has injected helper script for browser automatically. Now Marp Core's rendering works well in the customized engine (#168).

By this change, the detection of `marpBrowser` from `package.json` is no longer required. I've removed the logic to inject helper script by Marp CLI.