### PR TITLE
Update Dockerfile to work Chromium correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Safari prevents moving slide after too many navigations ([#158](https://github.com/marp-team/marp-cli/issues/158), [#160](https://github.com/marp-team/marp-cli/pull/160))
 - Support preview mode in macOS Catalina ([#173](https://github.com/marp-team/marp-cli/pull/173))
+- Update Dockerfile to work Chromium correctly ([#174](https://github.com/marp-team/marp-cli/pull/174))
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk update && apk upgrade && \
       grep \
       chromium@edge \
       freetype@edge \
+      libstdc++@edge \
       harfbuzz@edge \
       wqy-zenhei@edge \
       ttf-liberation@edge \


### PR DESCRIPTION
https://app.circleci.com/jobs/github/marp-team/marp-cli/2528/parallel-runs/0/steps/0-103

```
$ chromium-browser --version
Error relocating /usr/lib/chromium/chrome: _ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev: symbol not found
Error relocating /usr/lib/chromium/chrome: _ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev: symbol not found
Error relocating /usr/lib/chromium/chrome: _ZNSt19_Sp_make_shared_tag5_S_eqERKSt9type_info: symbol not found
```

Chromium on Alpine Linux now requires `libstdc++`.