### PR TITLE
Add bespoke interactive plugin to improve event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 - Marp CLI requires Node >= v8.16.0
 - [GFM strikethrough syntax](https://github.com/marp-team/marp-core/issues/102) added to Marp Core v0.15.0 may break existing slides
 
+### Added
+
+- Add bespoke interactive plugin to improve event handling ([#181](https://github.com/marp-team/marp-cli/pull/181))
+
+### Fixed
+
+- Navigate twice when hitting space bar after clicked next button on OSC ([#156](https://github.com/marp-team/marp-cli/issues/156), [#181](https://github.com/marp-team/marp-cli/pull/181))
+
 ### Changed
 
 - Upgrade Node to v12 LTS ([#179](https://github.com/marp-team/marp-cli/pull/179))

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@types/yargs": "^13.0.3",
     "autoprefixer": "^9.7.1",
     "bespoke": "bespokejs/bespoke",
-    "bespoke-forms": "^1.0.0",
     "builtin-modules": "^3.1.0",
     "cheerio": "^1.0.0-rc.3",
     "codecov": "^3.6.1",

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -45,6 +45,9 @@ $progressHeight: 5px;
       white-space: nowrap;
       z-index: 1;
 
+      /* Hack for Chrome to show OSC overlay onto video correctly */
+      will-change: transform;
+
       > * {
         margin-left: 6px;
 

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -1,7 +1,7 @@
 import bespoke from 'bespoke'
-import bespokeForms from 'bespoke-forms'
 import bespokeClasses from './classes'
 import bespokeInactive from './inactive'
+import bespokeInteractive from './interactive'
 import bespokeLoad from './load'
 import bespokeFragments from './fragments'
 import bespokeFullscreen from './fullscreen'
@@ -15,7 +15,7 @@ import { readQuery } from './utils'
 
 export default function(target = document.getElementById('p')!) {
   const deck = bespoke.from(target, [
-    bespokeForms(),
+    bespokeInteractive,
     bespokeClasses,
     bespokeInactive(),
     bespokeLoad,

--- a/src/templates/bespoke/interactive.ts
+++ b/src/templates/bespoke/interactive.ts
@@ -1,0 +1,24 @@
+// Based on https://github.com/bespokejs/bespoke-forms
+
+const interactiveNodes = [
+  'AUDIO',
+  'BUTTON',
+  'INPUT',
+  'SELECT',
+  'TEXTAREA',
+  'VIDEO',
+]
+
+export default function bespokeInteractive(deck) {
+  ;(deck.parent as HTMLElement).addEventListener('keydown', e => {
+    if (!e.target) return
+
+    const element = e.target as HTMLElement
+
+    if (
+      interactiveNodes.includes(element.nodeName) ||
+      element.contentEditable === 'true'
+    )
+      e.stopPropagation()
+  })
+}

--- a/src/templates/bespoke/osc.ts
+++ b/src/templates/bespoke/osc.ts
@@ -20,7 +20,11 @@ export default function bespokeOSC(selector: string = '.bespoke-marp-osc') {
   return deck => {
     osc.addEventListener('click', e => {
       if (e.target instanceof HTMLElement) {
-        switch (e.target.dataset.bespokeMarpOsc) {
+        const { bespokeMarpOsc } = e.target.dataset
+
+        if (bespokeMarpOsc) e.target.blur()
+
+        switch (bespokeMarpOsc) {
           case 'next':
             deck.next()
             break

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -17,6 +17,7 @@ afterEach(() => {
 describe("Bespoke template's browser context", () => {
   const marp = new Marp({
     container: new MarpitElement('div', { id: 'p' }),
+    html: true,
   })
 
   const defaultMarkdown = '# 1\n\n---\n\n## 2\n\n---\n\n### 3'
@@ -45,7 +46,7 @@ describe("Bespoke template's browser context", () => {
     }
   }
 
-  const keydown = (opts, target = document) =>
+  const keydown = (opts, target: EventTarget = document) =>
     target.dispatchEvent(new KeyboardEvent('keydown', opts))
 
   describe('Classes', () => {
@@ -263,6 +264,37 @@ describe("Bespoke template's browser context", () => {
       jest.advanceTimersByTime(1)
       expect(parent.className).toContain('bespoke-marp-inactive')
     })
+  })
+
+  describe('Interactive', () => {
+    const elements = {
+      input: '<input type="text" id="element" />',
+      textarea: '<textarea id="element"></textarea>',
+      select: '<select id="element"><option value="a">a</option></select>',
+      button: '<button type="button" id="element">button</button>',
+      audio:
+        '<audio controls src="https://example.com/audio.mp3" id="element"></audio>',
+      video:
+        '<video controls src="https://example.com/video.mp3" id="element"></video>',
+    }
+
+    for (const kind of Object.keys(elements)) {
+      const element = elements[kind]
+
+      it(`prevents navigation on ${kind} element`, () => {
+        render(`${element}\n\n---\n\n2`)
+        const deck = bespoke()
+
+        keydown(
+          { bubbles: true, which: Key.RightArrow },
+          document.getElementById('element')!
+        )
+        expect(deck.slide()).toBe(0)
+
+        keydown({ bubbles: true, which: Key.RightArrow }, deck.slides[0])
+        expect(deck.slide()).toBe(1)
+      })
+    }
   })
 
   describe('Load', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,11 +1095,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bespoke-forms@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/bespoke-forms/-/bespoke-forms-1.0.0.tgz#fccdc60a1f7b598ed7df7c8efe554a4c4d8ce158"
-  integrity sha1-/M3GCh97WY7X33yO/lVKTE2M4Vg=
-
 bespoke@bespokejs/bespoke:
   version "1.2.0-dev"
   resolved "https://codeload.github.com/bespokejs/bespoke/tar.gz/81c1da25210feca2a166ec782abcbf88ae969593"


### PR DESCRIPTION
We've added interactive plugin for bespoke, to improve event handling about keys for navigation. We had used [`bespoke-forms`](https://github.com/bespokejs/bespoke-forms) but it does not support recent elements such as `<button>`, `<video>` and `<audio>`.

And we've improved focus handling on OSC. The overlay control is not assumed to control with keyboard, so we are going to remove focus ring through `blur()`.

Resolves #156.