### PR TITLE
Fix failing --allow-local-files option on WSL environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix failing `--allow-local-files` option on WSL environment ([#182](https://github.com/marp-team/marp-cli/pull/182))
+
 ## v0.16.0 - 2019-11-06
 
 ### Breaking

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -99,10 +99,10 @@ export class Converter {
     const isFile = (f: File | undefined): f is File =>
       !!f && f.type === FileType.File
 
-    const resolveBase = async ({ absoluteFileScheme }: File) =>
+    const resolveBase = async (f: File) =>
       isWSL()
-        ? `file:${await resolveWSLPath(absoluteFileScheme)}`
-        : absoluteFileScheme
+        ? `file:${await resolveWSLPath(f.absolutePath)}`
+        : f.absoluteFileScheme
 
     let additionals = ''
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -96,7 +96,13 @@ export class Converter {
 
   async convert(markdown: string, file?: File): Promise<TemplateResult> {
     const { lang, globalDirectives, type } = this.options
-    const isFile = file && file.type === FileType.File
+    const isFile = (f: File | undefined): f is File =>
+      !!f && f.type === FileType.File
+
+    const resolveBase = async ({ absoluteFileScheme }: File) =>
+      isWSL()
+        ? `file:${await resolveWSLPath(absoluteFileScheme)}`
+        : absoluteFileScheme
 
     let additionals = ''
 
@@ -112,20 +118,20 @@ export class Converter {
       ...(this.options.templateOption || {}),
       lang,
       base:
-        isFile && type !== ConvertType.html
-          ? file!.absoluteFileScheme
+        isFile(file) && type !== ConvertType.html
+          ? await resolveBase(file)
           : undefined,
       notifyWS:
-        isFile && this.options.watch && type === ConvertType.html
-          ? await notifier.register(file!.absolutePath)
+        isFile(file) && this.options.watch && type === ConvertType.html
+          ? await notifier.register(file.absolutePath)
           : undefined,
       renderer: tplOpts => {
         const engine = this.generateEngine(tplOpts)
         const ret = engine.render(`${markdown}${additionals}`)
         const info = engine[engineInfo]
 
-        if (isFile)
-          this.options.themeSet.observe(file!.absolutePath, info && info.theme)
+        if (isFile(file))
+          this.options.themeSet.observe(file.absolutePath, info && info.theme)
 
         return { ...ret, ...info! }
       },


### PR DESCRIPTION
Marp CLI does not render local file assets in WSL environment even if `--allow-local-files` option is enabled.

We are using Puppeteer to convert Markdown into PDF, PPTX, and images through *Windows Chrome*, so tmp file has to resolve base path into WSL.