### PR TITLE
Update community health files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,12 +14,6 @@ yarn build
 yarn watch
 ```
 
-### Run in Gitpod
-
-You can also build and run `marp-cli` in Gitpod, an online IDE for GitHub:
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/marp-team/marp-cli)
-
 ### Use built version
 
 Use `./marp-cli.js` instead of `marp` command.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,12 +2,7 @@
 
 Thank you for taking the time to read how to contribute to Marp CLI! This is the guideline for contributing to Marp CLI.
 
-But this document hardly has contents! We are following [the contributing guideline of marp-team projects](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md). Please read these guidelines this before starting work in Marp CLI.
-
-- [**Code of Conduct**](https://github.com/marp-team/marp/blob/master/.github/CODE_OF_CONDUCT.md)
-- [**Report issue**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#report-issue)
-- [**Pull request**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#pull-request)
-- [**Release**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#release)
+But this document hardly has contents! We are following [**the contributing guideline of Marp team projects**](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md). _You have to read this before starting work._
 
 ## Development
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [yhatt]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update community health files ([#185](https://github.com/marp-team/marp-cli/pull/185))
+
 ## v0.16.2 - 2019-11-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ For example, the below configuration will set constructor option for Marp Core a
 
 ## Contributing
 
-Are you interested in contributing? Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+Are you interested in contributing? Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) and [the common contributing guideline for Marp team](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md).
 
 ## Author
 


### PR DESCRIPTION
Marp team's common health files such as CONTRIBUTING.md were moved to [`.github` repository](https://github.com/marp-team/.github).

And Marp CLI's `CONTRIBUTING.md` has redundant GitPod button. GitPod would not be used by contributors recently. We've removed it because it isn't a recommended way for develop.