### PR TITLE
Setup cache, badge, and skip tag support for GitHub Actions

### DIFF
--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -29,6 +29,19 @@ jobs:
       - name: Install yarn
         run: yarn policies set-version 1.19.1
 
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn_cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn_cache-${{ runner.os }}-${{ matrix.node-version }}-
+            yarn_cache-${{ runner.os }}-
+
       - name: Cache node_modules
         uses: actions/cache@v1
         with:

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -20,22 +20,37 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install with yarn
-        run: |
-          yarn policies set-version 1.19.1
-          yarn install
+
+      - name: Install yarn
+        run: yarn policies set-version 1.19.1
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            node_modules-${{ runner.os }}-${{ matrix.node-version }}-
+            node_modules-${{ runner.os }}-
+
+      - name: Install dependencies with yarn
+        run: yarn install
+
       - name: Jest
         run: yarn test:coverage --ci -i --reporters=default --reporters=jest-junit
         env:
           CI: true
+
       - uses: actions/upload-artifact@v1
         with:
           name: coverage
           path: coverage
+
       - name: Codecov
         run: yarn codecov -F windows
         env:

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -5,8 +5,15 @@ on:
   - push
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    if: "! ( contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]') )"
+    steps:
+      - run: echo "${{ github.event.head_commit.message }}"
+
   win-test:
     runs-on: windows-latest
+    needs: validate
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install yarn
         run: yarn policies set-version 1.19.1
 
-      - name: Restore node_modules cache
+      - name: Cache node_modules
         uses: actions/cache@v1
         with:
           path: node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Setup cache, badge, and skip tag support for GitHub Actions ([#186](https://github.com/marp-team/marp-cli/pull/186))
+
 ### Changed
 
 - Update community health files ([#185](https://github.com/marp-team/marp-cli/pull/185))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # @marp-team/marp-cli
 
 [![CircleCI](https://img.shields.io/circleci/project/github/marp-team/marp-cli/master.svg?style=flat-square&logo=circleci)](https://circleci.com/gh/marp-team/marp-cli/)
+[![GitHub Actions](https://github.com/marp-team/marp-cli/workflows/Test%20for%20Windows/badge.svg?branch=master)](https://github.com/marp-team/marp-cli/actions?query=workflow%3A%22Test+for+Windows%22+branch%3Amaster)
 [![Codecov](https://img.shields.io/codecov/c/github/marp-team/marp-cli/master.svg?style=flat-square&logo=codecov)](https://codecov.io/gh/marp-team/marp-cli)
 [![npm](https://img.shields.io/npm/v/@marp-team/marp-cli.svg?style=flat-square&logo=npm)](https://www.npmjs.com/package/@marp-team/marp-cli)
 [![Docker](https://img.shields.io/docker/pulls/marpteam/marp-cli.svg?logo=docker&style=flat-square)](https://hub.docker.com/r/marpteam/marp-cli/)


### PR DESCRIPTION
GitHub Actions is now generally available and with caching support by [actions/cache](https://github.com/actions/cache). We've set up cache for `node_modules` in test on Windows.