### PR TITLE
Replace different style badge for GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Setup cache, badge, and skip tag support for GitHub Actions ([#186](https://github.com/marp-team/marp-cli/pull/186))
+- Setup cache, badge, and skip tag support for GitHub Actions ([#186](https://github.com/marp-team/marp-cli/pull/186), [#192](https://github.com/marp-team/marp-cli/pull/192))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @marp-team/marp-cli
 
 [![CircleCI](https://img.shields.io/circleci/project/github/marp-team/marp-cli/master.svg?style=flat-square&logo=circleci)](https://circleci.com/gh/marp-team/marp-cli/)
-[![GitHub Actions](https://github.com/marp-team/marp-cli/workflows/Test%20for%20Windows/badge.svg?branch=master)](https://github.com/marp-team/marp-cli/actions?query=workflow%3A%22Test+for+Windows%22+branch%3Amaster)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/marp-team/marp-cli/Test%20for%20Windows/master?style=flat-square&logo=github)](https://github.com/marp-team/marp-cli/actions?query=workflow%3A%22Test+for+Windows%22+branch%3Amaster)
 [![Codecov](https://img.shields.io/codecov/c/github/marp-team/marp-cli/master.svg?style=flat-square&logo=codecov)](https://codecov.io/gh/marp-team/marp-cli)
 [![npm](https://img.shields.io/npm/v/@marp-team/marp-cli.svg?style=flat-square&logo=npm)](https://www.npmjs.com/package/@marp-team/marp-cli)
 [![Docker](https://img.shields.io/docker/pulls/marpteam/marp-cli.svg?logo=docker&style=flat-square)](https://hub.docker.com/r/marpteam/marp-cli/)


### PR DESCRIPTION
Shields.io now supports a badge for GitHub Actions workflow.