### PR TITLE
Create tmpfile to home directory when detected Snapd Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Output warning if enabled `--allow-local-files` and missing local file(s) ([#200](https://github.com/marp-team/marp-cli/pull/200) by [@cosnomi](https://github.com/cosnomi))
 
+### Fixed
+
+- Fix failing `--allow-local-files` option with [Snapd Chromium](https://snapcraft.io/install/chromium/ubuntu) ([#201](https://github.com/marp-team/marp-cli/issues/201), [#203](https://github.com/marp-team/marp-cli/pull/203))
+
 ## v0.17.0 - 2020-01-18
 
 ### Breaking

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import * as url from 'url'
 import { promisify } from 'util'
@@ -102,8 +103,14 @@ export class File {
     }
   }
 
-  async saveTmpFile(ext?: string): Promise<File.TmpFileInterface> {
-    const tmp: string = await tmpNamePromise({ postfix: ext })
+  async saveTmpFile(
+    opts: { extension?: string; home?: boolean } = {}
+  ): Promise<File.TmpFileInterface> {
+    const tmp: string = await tmpNamePromise({
+      dir: opts.home ? os.homedir() : undefined,
+      postfix: opts.extension,
+    })
+
     await this.saveToFile(tmp)
 
     return {

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -36,9 +36,7 @@ export const generatePuppeteerDataDirPath = async (
   return path.resolve(os.tmpdir(), name)
 }
 
-export async function generatePuppeteerLaunchArgs(): Promise<
-  Partial<LaunchOptions>
-> {
+export async function generatePuppeteerLaunchArgs() {
   // Puppeteer >= v1.13.0 doesn't use BGPT due to crbug.com/937609.
   // https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js
   //

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -301,7 +301,9 @@ describe('Converter', () => {
                 'Insecure local file accessing is enabled'
               )
             )
-            expect(fileTmp).toBeCalledWith('.html')
+            expect(fileTmp).toBeCalledWith(
+              expect.objectContaining({ extension: '.html' })
+            )
             expect(fileCleanup).toBeCalledWith(
               expect.stringContaining(os.tmpdir())
             )


### PR DESCRIPTION
Resolve #201 and marp-team/marp-vscode#94. See details in https://github.com/marp-team/marp-cli/issues/201#issuecomment-586725940.

> we recognized the Snapd Chromium cannot access from the sandbox container to user-land `/tmp/`, due to [strict snap confinement](https://snapcraft.io/docs/snap-confinement). Snapd Chromium only allows [reading visible files from `$HOME`](https://snapcraft.io/docs/home-interface).
> 
> Marp CLI should create visible tmp file into `$HOME` when the resolved Chromium path starts with `/snap`.
