### PR TITLE
Make bespoke plugin robust against storage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Fixed
 
 - PPTX creation does no longer make multiple master slides ([#166](https://github.com/marp-team/marp-cli/issues/166), [#205](https://github.com/marp-team/marp-cli/pull/205))
+- Make bespoke plugins robust against storage error ([#207](https://github.com/marp-team/marp-cli/issues/207), [#208](https://github.com/marp-team/marp-cli/pull/208))
 
 ### Changed
 
 - Use PptxGenJS v3 instead of `@marp-team/pptx` ([#205](https://github.com/marp-team/marp-cli/pull/205))
+- Disable opening presenter view in `bespoke` template if using `localStorage` has restricted in browser ([#208](https://github.com/marp-team/marp-cli/pull/208))
 
 ## v0.17.1 - 2020-02-22
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ The `bespoke` template is using [Bespoke.js](https://github.com/bespokejs/bespok
 - **Presenter view**: Open presenter view in external window by hitting <kbd>p</kbd> key.
 - **Progress bar** (optional): By setting `--bespoke.progress` option, you can add a progress bar on the top of the deck.
 
+> ℹ️ Presenter view may be disabled if [the browser restricted using localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage) (e.g. Open HTML in the old Safari with private browsing, or open the _local_ HTML file with Chrome that has blocked 3rd party cookies in `chrome://settings/content/cookies`).
+
 ### `bare` template
 
 The `bare` template is a primitive template, and there is no extra features. It only has minimum assets to give your presentation with browser.

--- a/src/templates/bespoke/osc.ts
+++ b/src/templates/bespoke/osc.ts
@@ -1,4 +1,5 @@
 import { default as screenfull } from 'screenfull'
+import { storage } from './utils'
 
 export default function bespokeOSC(selector: string = '.bespoke-marp-osc') {
   const osc = document.querySelector(selector)
@@ -16,6 +17,13 @@ export default function bespokeOSC(selector: string = '.bespoke-marp-osc') {
   // Hide fullscreen button in not-supported browser (e.g. phone device)
   if (!screenfull.isEnabled)
     oscElements('fullscreen', btn => (btn.style.display = 'none'))
+
+  // Disable presenter button if using localStorage is restricted
+  if (!storage.available)
+    oscElements('presenter', (btn: HTMLButtonElement) => {
+      btn.disabled = true
+      btn.title = 'Presenter view is disabled due to restricted localStorage.'
+    })
 
   return deck => {
     osc.addEventListener('click', e => {

--- a/src/templates/bespoke/presenter/normal-view.ts
+++ b/src/templates/bespoke/presenter/normal-view.ts
@@ -1,4 +1,4 @@
-import { generateURLfromParams } from '../utils'
+import { generateURLfromParams, storage } from '../utils'
 
 type BespokeForPresenter = { syncKey: string; [key: string]: any }
 
@@ -16,14 +16,15 @@ export default function normalView(deck) {
     presenterUrl: { enumerable: true, get: presenterUrl },
   })
 
-  // Register keyboard shortcut
-  document.addEventListener('keydown', e => {
-    // `p` without modifier key (Alt, Control, and Command)
-    if (e.which === 80 && !e.altKey && !e.ctrlKey && !e.metaKey) {
-      e.preventDefault()
-      deck.openPresenterView()
-    }
-  })
+  // Register keyboard shortcut if using localStorage is not restricted
+  if (storage.available)
+    document.addEventListener('keydown', e => {
+      // `p` without modifier key (Alt, Control, and Command)
+      if (e.which === 80 && !e.altKey && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault()
+        deck.openPresenterView()
+      }
+    })
 }
 
 /** Open new window for presenter view. */

--- a/src/templates/bespoke/sync.ts
+++ b/src/templates/bespoke/sync.ts
@@ -1,5 +1,6 @@
 import nanoid from 'nanoid'
 import { FragmentEvent } from './fragments'
+import { storage } from './utils'
 
 export interface BespokeSyncOption {
   key?: string
@@ -16,7 +17,7 @@ export default function bespokeSync(opts: BespokeSyncOption = {}) {
   const storageKey = `bespoke-marp-sync-${key}`
 
   const getState = (): Partial<BespokeSyncState> => {
-    const stateJSON = localStorage.getItem(storageKey)
+    const stateJSON = storage.get(storageKey)
     if (!stateJSON) return Object.create(null)
 
     return JSON.parse(stateJSON)
@@ -28,7 +29,7 @@ export default function bespokeSync(opts: BespokeSyncOption = {}) {
     const currentState = getState()
     const newState = { ...currentState, ...updater(currentState) }
 
-    localStorage.setItem(storageKey, JSON.stringify(newState))
+    storage.set(storageKey, JSON.stringify(newState))
     return newState
   }
 
@@ -76,7 +77,7 @@ export default function bespokeSync(opts: BespokeSyncOption = {}) {
       const { reference } = getState()
 
       if (reference === undefined || reference <= 1) {
-        localStorage.removeItem(storageKey)
+        storage.remove(storageKey)
       } else {
         setState(() => ({ reference: reference - 1 }))
       }

--- a/src/templates/bespoke/utils.ts
+++ b/src/templates/bespoke/utils.ts
@@ -91,7 +91,9 @@ export const setViewMode = () =>
 export const storage = (() => {
   const available = (() => {
     try {
-      localStorage.getItem('bespoke-marp')
+      localStorage.setItem('bespoke-marp', 'bespoke-marp')
+      localStorage.removeItem('bespoke-marp')
+
       return true
     } catch (e) {
       console.warn(

--- a/src/templates/bespoke/utils.ts
+++ b/src/templates/bespoke/utils.ts
@@ -87,3 +87,44 @@ export const setViewMode = () =>
       }
     })()
   )
+
+export const storage = (() => {
+  const available = (() => {
+    try {
+      localStorage.getItem('bespoke-marp')
+      return true
+    } catch (e) {
+      console.warn(
+        'Warning: Using localStorage is restricted in the current host so some features may not work.'
+      )
+      return false
+    }
+  })()
+
+  return {
+    available,
+    get: (key: string): string | null => {
+      try {
+        return localStorage.getItem(key)
+      } catch (e) {
+        return null
+      }
+    },
+    set: (key: string, value: string): boolean => {
+      try {
+        localStorage.setItem(key, value)
+        return true
+      } catch (e) {
+        return false
+      }
+    },
+    remove: (key: string): boolean => {
+      try {
+        localStorage.removeItem(key)
+        return true
+      } catch (e) {
+        return false
+      }
+    },
+  }
+})()


### PR DESCRIPTION
We received the report about not working the whole of bespoke template in the browser that has restricted using `localStorage`. This PR will make some bespoke plugins robust against errors thrown by `localStorage`.

- Sync plugin manipulates `localStorage` through the robust storage utility object. The presentation does not stop working by thrown error but sync logic may not be able to use in some rarely cases.
- The plugin depended on sync plugin will disable when using `localStorage` is restricted. It's relevant to presenter plugin and OSC plugin (presenter button).

Resolves #207.

### ToDo

- [x] Add test cases
- [x] Add troubleshoot about disabled presenter view to README.md
