### PR TITLE
Use passive event listener as much as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Use PptxGenJS v3 instead of `@marp-team/pptx` ([#205](https://github.com/marp-team/marp-cli/pull/205))
 - Disable opening presenter view in `bespoke` template if using `localStorage` has restricted in browser ([#208](https://github.com/marp-team/marp-cli/pull/208))
+- Use passive event listener as much as possible ([#209](https://github.com/marp-team/marp-cli/pull/209))
 
 ## v0.17.1 - 2020-02-22
 

--- a/src/templates/bespoke/touch.ts
+++ b/src/templates/bespoke/touch.ts
@@ -30,9 +30,14 @@ export default function bespokeTouch(opts: BespokeTouchOption = {}) {
       }
     }
 
-    parent.addEventListener('touchstart', e => {
-      touchStart = e.touches.length === 1 ? touchPoint(e.touches[0]) : undefined
-    })
+    parent.addEventListener(
+      'touchstart',
+      e => {
+        touchStart =
+          e.touches.length === 1 ? touchPoint(e.touches[0]) : undefined
+      },
+      { passive: true }
+    )
 
     parent.addEventListener('touchmove', e => {
       if (touchStart) {
@@ -51,17 +56,21 @@ export default function bespokeTouch(opts: BespokeTouchOption = {}) {
       }
     })
 
-    parent.addEventListener('touchend', e => {
-      if (touchStart) {
-        if (touchStart.delta && touchStart.delta >= options.swipeThreshold!) {
-          let radian = touchStart.radian! - options.slope!
-          radian = ((radian + Math.PI) % (Math.PI * 2)) - Math.PI
+    parent.addEventListener(
+      'touchend',
+      e => {
+        if (touchStart) {
+          if (touchStart.delta && touchStart.delta >= options.swipeThreshold!) {
+            let radian = touchStart.radian! - options.slope!
+            radian = ((radian + Math.PI) % (Math.PI * 2)) - Math.PI
 
-          deck[radian < 0 ? 'next' : 'prev']()
-          e.stopPropagation()
+            deck[radian < 0 ? 'next' : 'prev']()
+            e.stopPropagation()
+          }
+          touchStart = undefined
         }
-        touchStart = undefined
-      }
-    })
+      },
+      { passive: true }
+    )
   }
 }


### PR DESCRIPTION
Lighthouse is pointing out to [use passive event listener for improving scroll performance with touch](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners). This PR adds `{ passive: true }` to touch event listeners that does never call `e.preventDefault()`.