### PR TITLE
Refactor Puppeteer arguments

### DIFF
--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -2,7 +2,6 @@ import { exec } from 'child_process'
 import { promisify } from 'util'
 import os from 'os'
 import path from 'path'
-import { LaunchOptions } from 'puppeteer-core'
 import * as chromeFinder from 'chrome-launcher/dist/chrome-finder'
 
 const execPromise = promisify(exec)

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -37,12 +37,7 @@ export const generatePuppeteerDataDirPath = async (
 }
 
 export async function generatePuppeteerLaunchArgs() {
-  // Puppeteer >= v1.13.0 doesn't use BGPT due to crbug.com/937609.
-  // https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js
-  //
-  // But it causes invalid rendering in Marp's `inlineSVG` mode. So we override
-  // `--disable-features` option to prevent disabling BGPT.
-  const args = new Set<string>(['--disable-features=TranslateUI'])
+  const args = new Set<string>()
 
   // Docker environment and WSL environment need to disable sandbox. :(
   if (process.env.IS_DOCKER || isWSL()) args.add('--no-sandbox')
@@ -67,9 +62,5 @@ export async function generatePuppeteerLaunchArgs() {
     executablePath = finder ? finder()[0] : undefined
   }
 
-  return {
-    executablePath,
-    ignoreDefaultArgs: ['--disable-features=TranslateUI,BlinkGenPropertyTrees'],
-    args: [...args],
-  }
+  return { executablePath, args: [...args] }
 }


### PR DESCRIPTION
Marp CLI had overridden the argument for disabling BGPT, to enable BGPT forcibly (Enabling BGPT prevents glitched rendering of slide: #78). However, [Puppeteer >= v2.1.0 does no longer disable `BlinkGenPropertyTrees`](https://github.com/puppeteer/puppeteer/pull/5159).

I've refactored `src/utils/puppeteer.ts` to follow the default argument.