### PR TITLE
Ignore installing step of puppeteer-core in Dockerfile if the compatible tag is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore installing step of `puppeteer-core` in Dockerfile if the compatible tag was not found ([#214](https://github.com/marp-team/marp-cli/pull/214))
+
 ### Changed
 
 - Upgrade dependent packages to the latest version ([#212](https://github.com/marp-team/marp-cli/pull/212))

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ ENV IS_DOCKER true
 
 WORKDIR /home/marp/.cli
 COPY --chown=marp:marp . /home/marp/.cli/
-RUN yarn install && yarn add puppeteer-core@chrome-$(chromium-browser --version | sed -r 's/^Chromium ([0-9]+).+$/\1/') \
-    && yarn build && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean \
+RUN yarn add puppeteer-core@chrome-$(chromium-browser --version | sed -r 's/^Chromium ([0-9]+).+$/\1/') || true
+RUN yarn install && yarn build && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean \
     && node /home/marp/.cli/marp-cli.js --version
 
 WORKDIR /home/marp/app


### PR DESCRIPTION
Puppeteer does not provide `chrome-80` tag so building Docker image was failed. If the compatible tag is not found, we will ignore install step of `puppeteer-core` in Dockerfile.