### PR TITLE
Fix serving index files

### DIFF
--- a/src/server/index.pug
+++ b/src/server/index.pug
@@ -18,7 +18,7 @@ html
     ul#index
       each file in files
         li(class={ convertible: file.convertible, directory: file.directory, nodeModules: file.nodeModules })
-          a.link.file(href=encodeURIComponent(file.name))= file.name
+          a.link.file(href=encodeURIComponent(file.name) + (file.directory ? "/" : ""))= file.name
 
           if file.convertible
             a.link.pdf(href=`${encodeURIComponent(file.name)}?pdf`) PDF


### PR DESCRIPTION
Fixed URLs serving index files (`index.md`, `PITCHME.md`) in server mode.

## Problem

Write presentation files in directories like below:

- `serverRoot/files/index.md` : markdown file for Marp
- `serverRoot/files/image.png` : image file, used in index.md as `![](image.png)`

And run marp-cli as server mode like `marp --server serverRoot/`.

Then `http://localhost:8080/` shows files and directories in `serverRoot` by `serve-index`.
In the above settings, a link on that page is `http://localhost:8080/files`.

When access to that, `serverRoot/files/index.md` is converted and shown in a browser, but `serverRoot/files/image.png` is not shown in the presentation because the presentation address is `/files` and `![](image.png)` is linked to `/image.png`, not `/files/image.png`.

When access to `http://localhost:8080/files/` (with a trailing slash), `serverRoot/files/image.png` is shown.

For compatibility with other modes, `![](image.png)` should be linked to `/files/image.png`, not `/image.png` I think.

## Solution

To fix this, there are 2 solutions:

1. Add a trailing slash to the links on the `serve-index` page.
2. Redirect to URL with a trailing slash.

In this PR, fixed the template file `src/server/index.pug` to add a trailing slash to the directory links.