### PR TITLE
Revert @rollup/plugin-typescript to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Add a trailing slash to the directory links on server index page to avoid broken path resolution ([#221](https://github.com/marp-team/marp-cli/pull/221) by [@n-ari](https://github.com/n-ari))
+- Revert `@rollup/plugin-typescript` to v3 ([#223](https://github.com/marp-team/marp-cli/pull/223))
 
 ## v0.17.4 - 2020-04-18
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.1",
-    "@rollup/plugin-typescript": "^4.1.1",
+    "@rollup/plugin-typescript": "^3.1.0",
     "@rollup/plugin-url": "^4.0.2",
     "@types/cheerio": "^0.22.17",
     "@types/express": "^4.17.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,10 +566,10 @@
     "@rollup/pluginutils" "^3.0.4"
     magic-string "^0.25.5"
 
-"@rollup/plugin-typescript@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-4.1.1.tgz#bcb38ca4d89a35da2238a6f1136af460a1b2cb09"
-  integrity sha512-KYZCn1Iw9hZWkeEPqPs5YjlmvSjR7UdezVca8z0e8rm/29wU24UD9Y4IZHhnc9tm749hzsgBTiOUxA85gfShEQ==
+"@rollup/plugin-typescript@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-3.1.1.tgz#a39175a552ed82a3e424862e6bb403bf9da451ee"
+  integrity sha512-VPY1MbzIJT+obpav9Kns4MlipVJ1FuefwzO4s1uCVXAzVWya+bhhNauOmmqR/hy1zj7tePfh3t9iBN+HbIzyRA==
   dependencies:
     "@rollup/pluginutils" "^3.0.1"
     resolve "^1.14.1"


### PR DESCRIPTION
I met a lot of bugs preventing development in `@rollup/plugin-typescript` v4:

- Watch mode will degrade performance and finally crash by out of memory (https://github.com/rollup/plugins/issues/322)
- Invalid type in watch mode will make failing the whole of process (https://github.com/rollup/plugins/issues/258)
  - We should set `noEmitError: false` manually.
- TS incremental build throws an error in second build (https://github.com/rollup/plugins/issues/249)

We will temporarily downgrade into v3 to make development going smoothly.