### PR TITLE
Improve Puppetter utility based on several reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Recognize `CHROME_ENABLE_EXTENSIONS` environment value for enabling Chrome extensions while converting ([#231](https://github.com/marp-team/marp-cli/issues/231), [#234](https://github.com/marp-team/marp-cli/pull/234))
+
 ### Fixed
 
 - Recover experimental preview window option (`--preview`, `-p`) and back out deprecation ([#211](https://github.com/marp-team/marp-cli/issues/211), [#232](https://github.com/marp-team/marp-cli/pull/232))
+- Show helpful message if the executable Chrome path could not find out ([#220](https://github.com/marp-team/marp-cli/issues/220), [#234](https://github.com/marp-team/marp-cli/pull/234))
+
+### Changed
+
 - Reduce direct dependencies ([#233](https://github.com/marp-team/marp-cli/pull/233))
 
 ## v0.18.0 - 2020-06-08

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -24,11 +24,6 @@ import templates, {
 import { ThemeSet } from './theme'
 import { notifier } from './watcher'
 
-type ResolvedType<T> = T extends Promise<infer U> ? U : never
-type GeneratedPuppeteerLaunchArgs = ResolvedType<
-  ReturnType<typeof generatePuppeteerLaunchArgs>
->
-
 export enum ConvertType {
   html = 'html',
   pdf = 'pdf',
@@ -352,7 +347,7 @@ export class Converter {
     baseFile: File,
     processer: (page: puppeteer.Page, uri: string) => Promise<T>
   ) {
-    const { executablePath } = await Converter.puppeteerLaunchArgs()
+    const { executablePath } = generatePuppeteerLaunchArgs()
 
     const tmpFile: File.TmpFileInterface | undefined = await (() => {
       if (!this.options.allowLocalFiles) return undefined
@@ -443,12 +438,11 @@ export class Converter {
   }
 
   private static browser?: puppeteer.Browser
-  private static cachedPuppeteerLaunchArgs?: GeneratedPuppeteerLaunchArgs
 
   private static async runBrowser() {
     if (!Converter.browser) {
       Converter.browser = await puppeteer.launch({
-        ...(await Converter.puppeteerLaunchArgs()),
+        ...generatePuppeteerLaunchArgs(),
         userDataDir: await generatePuppeteerDataDirPath('marp-cli-conversion'),
       })
       Converter.browser.once('disconnected', () => {
@@ -456,14 +450,5 @@ export class Converter {
       })
     }
     return Converter.browser
-  }
-
-  private static async puppeteerLaunchArgs(): Promise<
-    GeneratedPuppeteerLaunchArgs
-  > {
-    if (!Converter.cachedPuppeteerLaunchArgs) {
-      Converter.cachedPuppeteerLaunchArgs = await generatePuppeteerLaunchArgs()
-    }
-    return Converter.cachedPuppeteerLaunchArgs
   }
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -131,7 +131,7 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
       ...baseArgs,
       args: [
         ...baseArgs.args,
-        '--app=data:text/html,<title>Marp CLI</title>',
+        `--app=data:text/html,<title>${encodeURIComponent('Marp CLI')}</title>`,
         `--window-size=${this.options.width},${this.options.height}`,
       ],
       defaultViewport: null,

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -125,7 +125,7 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
   }
 
   private async launch() {
-    const baseArgs = await generatePuppeteerLaunchArgs()
+    const baseArgs = generatePuppeteerLaunchArgs()
 
     this.puppeteerInternal = await puppeteer.launch({
       args: [

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -128,13 +128,13 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
     const baseArgs = generatePuppeteerLaunchArgs()
 
     this.puppeteerInternal = await puppeteer.launch({
+      ...baseArgs,
       args: [
         ...baseArgs.args,
         '--app=data:text/html,<title>Marp CLI</title>',
         `--window-size=${this.options.width},${this.options.height}`,
       ],
       defaultViewport: null,
-      executablePath: baseArgs.executablePath,
       headless: process.env.NODE_ENV === 'test',
       userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview'),
     })

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -63,5 +63,16 @@ export const generatePuppeteerLaunchArgs = () => {
     }
   }
 
-  return { executablePath, args: [...args] }
+  return {
+    executablePath,
+    args: [...args],
+
+    // Workaround to avoid force-extensions policy for Chrome enterprise (SET CHROME_ENABLE_EXTENSIONS=1)
+    // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-windows
+    //
+    // @see https://github.com/marp-team/marp-cli/issues/231
+    ignoreDefaultArgs: process.env.CHROME_ENABLE_EXTENSIONS
+      ? ['--disable-extensions']
+      : undefined,
+  }
 }

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util'
 import os from 'os'
 import path from 'path'
 import { Launcher } from 'chrome-launcher'
+import { CLIError } from '../error'
 
 const execPromise = promisify(exec)
 
@@ -35,7 +36,7 @@ export const generatePuppeteerDataDirPath = async (
   return path.resolve(os.tmpdir(), name)
 }
 
-export async function generatePuppeteerLaunchArgs() {
+export const generatePuppeteerLaunchArgs = () => {
   const args = new Set<string>()
 
   // Docker environment and WSL environment need to disable sandbox. :(
@@ -53,6 +54,12 @@ export async function generatePuppeteerLaunchArgs() {
       executablePath = '/usr/bin/chromium-browser'
     } else {
       ;[executablePath] = Launcher.getInstallations()
+    }
+
+    if (!executablePath) {
+      throw new CLIError(
+        'You have to install Google Chrome or Chromium to convert slide deck with current options.'
+      )
     }
   }
 


### PR DESCRIPTION
Improved Puppetter utility based on several reports.

- Remove unnecessarry `async`/`await` keyword from `generatePuppeteerLaunchArgs()`.
- Throw `CLIError` with helpful message if the executable Chrome path cannot find out. (#220)
- Add escape-hatch for policy-applied Chrome Windows. (#231)
  - Running `SET CHROME_ENABLE_EXTENSIONS=1` before executing Marp CLI can enable extensions while converting Markdown.
  - Because of leading insecure conversion, we don't want to enable extensions by default if possible. It may break and leak the content of slide deck.

Closes #220. #231 needs more reports about this change. 