### PR TITLE
Control aria-hidden attribute properly in bespoke template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Slides with code block always verbalized by screen-reader ([#236](https://github.com/marp-team/marp-cli/issues/236), [#238](https://github.com/marp-team/marp-cli/pull/238))
+
 ### Changed
 
 - Upgrade Node and dependent packages to the latest version ([#237](https://github.com/marp-team/marp-cli/pull/237))

--- a/src/templates/bespoke/classes.ts
+++ b/src/templates/bespoke/classes.ts
@@ -2,22 +2,26 @@
 
 export default function bespokeClasses(deck) {
   deck.parent.classList.add('bespoke-marp-parent')
-  deck.slides.map((element) => element.classList.add('bespoke-marp-slide'))
+  deck.slides.forEach((el: HTMLElement) =>
+    el.classList.add('bespoke-marp-slide')
+  )
 
   deck.on('activate', (e) => {
-    const shouldResetAnimation = !e.slide.classList.contains(
-      'bespoke-marp-active'
-    )
+    const slide: HTMLElement = e.slide
+    const shouldResetAnim = !slide.classList.contains('bespoke-marp-active')
 
-    deck.slides.map((element) => {
-      element.classList.remove('bespoke-marp-active')
+    deck.slides.forEach((el: HTMLElement) => {
+      el.classList.remove('bespoke-marp-active')
+      el.setAttribute('aria-hidden', 'true')
     })
-    e.slide.classList.add('bespoke-marp-active')
 
-    if (shouldResetAnimation) {
-      e.slide.classList.add('bespoke-marp-active-ready')
+    slide.classList.add('bespoke-marp-active')
+    slide.removeAttribute('aria-hidden')
+
+    if (shouldResetAnim) {
+      slide.classList.add('bespoke-marp-active-ready')
       void document.body.clientHeight
-      e.slide.classList.remove('bespoke-marp-active-ready')
+      slide.classList.remove('bespoke-marp-active-ready')
     }
   })
 }

--- a/src/templates/bespoke/inactive.ts
+++ b/src/templates/bespoke/inactive.ts
@@ -7,9 +7,13 @@ export default function bespokeInactive(timeout = 2000) {
 
       activeTimer = setTimeout(() => {
         deck.parent.classList.add('bespoke-marp-inactive')
+        deck.fire('marp-inactive')
       }, timeout)
 
-      deck.parent.classList.remove('bespoke-marp-inactive')
+      if (deck.parent.classList.contains('bespoke-marp-inactive')) {
+        deck.parent.classList.remove('bespoke-marp-inactive')
+        deck.fire('marp-active')
+      }
     }
 
     document.addEventListener('mousedown', activate)

--- a/src/templates/bespoke/osc.ts
+++ b/src/templates/bespoke/osc.ts
@@ -74,6 +74,9 @@ export default function bespokeOSC(selector: string = '.bespoke-marp-osc') {
       )
     })
 
+    deck.on('marp-active', () => osc.removeAttribute('aria-hidden'))
+    deck.on('marp-inactive', () => osc.setAttribute('aria-hidden', 'true'))
+
     if (screenfull.isEnabled) {
       screenfull.onchange(() =>
         oscElements('fullscreen', (fs) =>


### PR DESCRIPTION
Screen-reader does not follow the hidden state of some slide pages and on-screen controller in the exported HTML with `bespoke` template.

To improve a11y, we've updated some bespoke plugins to control `aria-hidden` attribute in some elements that are actually not hidden. I've confirmed that a11y was improved, by the accessibility inspector in Firefox developer tools.

Fixed #236.