### PR TITLE
Normalize font-family for interfaces

### DIFF
--- a/src/server/index.scss
+++ b/src/server/index.scss
@@ -7,6 +7,7 @@ body {
   background: #fff;
   color: #444;
   font-size: 15px;
+  font-family: sans-serif;
 }
 
 h1 {

--- a/src/server/index.scss
+++ b/src/server/index.scss
@@ -6,8 +6,8 @@ $list-icon-vertical-gap: 5px;
 body {
   background: #fff;
   color: #444;
+  font-family: Helvetica, Arial, sans-serif;
   font-size: 15px;
-  font-family: sans-serif;
 }
 
 h1 {

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -176,7 +176,7 @@ $progressHeight: 5px;
     background: #161616;
 
     .bespoke-marp-presenter-container {
-      font-family: sans-serif;
+      font-family: Helvetica, Arial, sans-serif;
       height: 100%;
       left: 0;
       position: absolute;

--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -171,11 +171,12 @@ $progressHeight: 5px;
 
   // Presenter view
   body[data-bespoke-view='presenter'] {
-    $text-color: #ddd;
+    $text-color: #eee;
 
     background: #161616;
 
     .bespoke-marp-presenter-container {
+      font-family: sans-serif;
       height: 100%;
       left: 0;
       position: absolute;
@@ -250,6 +251,7 @@ $progressHeight: 5px;
           width: calc(100% - 40px);
           height: calc(100% - 40px);
           box-sizing: border-box;
+          font-size: 1.1em;
           overflow: auto;
           padding-right: 3px;
           white-space: pre-wrap;


### PR DESCRIPTION
We've received a feedback about unexpected font of interface at https://github.com/marp-team/marpit/issues/82#issuecomment-653549881: Presenter notes are rendering in serif font.

The root cause is the difference of the default font between browsers. Chrome and Firefox renders in Sans-serif font by default, and Safari renders in Serif font. So I've fixed CSS definitions to normalize font family for Marp interfaces: `bespoke` template's presenter view, and server index in server mode.

> Must not define `font-family` in `body` because theme CSS may follow browser default CSS.