### PR TITLE
Add bespoke wake-lock plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Keep awake the display in `bespoke` template if [Screen Wake Lock API](https://web.dev/wakelock/) is available (Chrome >= 84) ([#239](https://github.com/marp-team/marp-cli/issues/239), [#246](https://github.com/marp-team/marp-cli/pull/246))
+
 ## v0.18.3 - 2020-07-09
 
 ### Fixed

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -13,6 +13,7 @@ import bespokeState from './state'
 import bespokeSync from './sync'
 import bespokeTouch from './touch'
 import { getViewMode, popQuery, setQuery, setViewMode, ViewMode } from './utils'
+import bespokeWakeLock from './wake-lock'
 
 const pattern = [ViewMode.Normal, ViewMode.Presenter, ViewMode.Next] as const
 
@@ -48,7 +49,8 @@ export default function bespokeTemplate(
       [[x, _, _], bespokeProgress],
       [[x, x, _], bespokeTouch()],
       [[x, _, _], bespokeOSC()],
-      [[x, x, x], bespokeFragments]
+      [[x, x, x], bespokeFragments],
+      [[x, x, _], bespokeWakeLock]
     )
   )
 

--- a/src/templates/bespoke/wake-lock.ts
+++ b/src/templates/bespoke/wake-lock.ts
@@ -1,0 +1,29 @@
+export default function bespokeWakeLock() {
+  if (!('wakeLock' in navigator)) return
+
+  let wakeLock: any
+  const wakeLockApi: any = navigator['wakeLock']
+
+  const requestWakeLock = async () => {
+    try {
+      wakeLock = await wakeLockApi.request('screen')
+      wakeLock.addEventListener('release', () => {
+        console.debug('[Marp CLI] Wake Lock was released')
+      })
+      console.debug('[Marp CLI] Wake Lock is active')
+    } catch (e) {
+      console.warn(e)
+    }
+  }
+
+  const handleVisibilityChange = () => {
+    if (wakeLock && document.visibilityState === 'visible') {
+      requestWakeLock()
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+  document.addEventListener('fullscreenchange', handleVisibilityChange)
+
+  requestWakeLock()
+}


### PR DESCRIPTION
Enable Screen Wake Lock API while opening presentation HTML. Resolves #239.

The current stable Chrome 84 has implemented Screen Wake Lock API. We can prevent turning off the screen while presenting exported HTML. I've confirmed it would work with local files too.


### ToDo

- [x] Add tests