### PR TITLE
Test against Node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,14 @@ jobs:
     steps:
       - test
 
+  test-node14:
+    executor:
+      name: node
+      browser: true
+      version: '14'
+    steps:
+      - test
+
   docker-image-latest:
     executor: docker
     steps:
@@ -166,10 +174,14 @@ workflows:
       - test-node12:
           requires:
             - audit
+      - test-node14:
+          requires:
+            - audit
       - docker-image-latest:
           requires:
             - test-node10
             - test-node12
+            - test-node14
           filters:
             branches:
               only: master

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -24,6 +24,7 @@ jobs:
         node-version:
           - '^10.17.0'
           - '12.18.2'
+          - '^14.5.0'
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - Keep awake the display in `bespoke` template if [Screen Wake Lock API](https://web.dev/wakelock/) is available (Chrome >= 84) ([#239](https://github.com/marp-team/marp-cli/issues/239), [#246](https://github.com/marp-team/marp-cli/pull/246))
+- Test against Node 14 (Fermium) ([#251](https://github.com/marp-team/marp-cli/pull/251))
+
+### Changed
+
 - Migrate from TSLint to ESLint ([#250](https://github.com/marp-team/marp-cli/pull/250))
 
 ## v0.18.3 - 2020-07-09


### PR DESCRIPTION
We've started running test against Node 14 on CI, to support LTS candidate Node.js. Probably no changes for existing codes would require.