### PR TITLE
Set up GitHub Dependabot for marp-team packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    reviewers:
+      - 'marp-team/maintainers'
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: '@marp-team/*'
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    reviewers:
+      - 'marp-team/maintainers'
+    schedule:
+      interval: weekly
+    # versioning-strategy: increase-if-necessary
+    open-pull-requests-limit: 0 # Dependabot does not allow relaxed versioning :(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Keep awake the display in `bespoke` template if [Screen Wake Lock API](https://web.dev/wakelock/) is available (Chrome >= 84) ([#239](https://github.com/marp-team/marp-cli/issues/239), [#246](https://github.com/marp-team/marp-cli/pull/246))
 - Test against Node 14 (Fermium) ([#251](https://github.com/marp-team/marp-cli/pull/251))
+- Set up GitHub Dependabot for marp-team packages ([#252](https://github.com/marp-team/marp-cli/pull/252))
 
 ### Changed
 


### PR DESCRIPTION
This PR sets up GitHub Dependabot for marp-team packages as same as marp-team/marp-core#172.

Marp team is working to update dependencies regularly.

To save the time for routine work, we've set up GitHub Dependabot to update packages provided by @marp-team automatically.

Notice that the auto-update for external packages is not setting up. These still are going to update manually because may met some breaking changes.

> We have auto-update setting for GitHub Actions too, but it would not open PR because Dependabot forces specific version against the best practice of GitHub Actions. Setting loose version always can use the latest major version with no updating.