### PR TITLE
Fix invalid permission flag in package script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix invalid permission flag in package script ([#256](https://github.com/marp-team/marp-cli/issues/256), [#257](https://github.com/marp-team/marp-cli/pull/257))
+
 ## v0.19.0 - 2020-07-18
 
 ### Added

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -17,7 +17,7 @@ const os = (process.env.MATRIX_OS || 'linux,macos,windows').toLowerCase()
 const packToTarGz = (binary) => {
   const pack = tar.pack()
 
-  pack.entry({ name: binaryName, mode: 755 }, binary)
+  pack.entry({ name: binaryName, mode: 0o755 }, binary)
   pack.finalize()
 
   return pack.pipe(zlib.createGzip())


### PR DESCRIPTION
While migrating to ESLint in #250, there was wrong replacement in the permission flag: Octal `0755` to decimal `755`.

`0755` is invalid number in the strict mode of JS, so we must use `0o755` instead.

Closes #256.