### PR TITLE
Revert codecov-node to v3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "builtin-modules": "^3.1.0",
     "chalk": "^4.1.0",
     "cheerio": "^1.0.0-rc.3",
-    "codecov": "^3.7.1",
+    "codecov": "3.7.0",
     "cssnano": "^4.1.10",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,10 +1971,10 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
-codecov@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.7.1.tgz#434cb8d55f18ef01672e5739d3d266696bebc202"
-  integrity sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==
+codecov@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.7.0.tgz#4a09939cde24447a43f36d068e8b4e0188dc3f27"
+  integrity sha512-uIixKofG099NbUDyzRk1HdGtaG8O+PBUAg3wfmjwXw2+ek+PZp+puRvbTohqrVfuudaezivJHFgTtSC3M8MXww==
   dependencies:
     argv "0.0.2"
     ignore-walk "3.0.3"


### PR DESCRIPTION
After updating codecov-node to v3.7.1, we have met unexpected decrease in coverage.
https://codecov.io/gh/marp-team/marp-cli/commits

![](https://user-images.githubusercontent.com/3993388/87861051-763c9c00-c97d-11ea-9eff-04a6a5756e4b.png)

![](https://user-images.githubusercontent.com/3993388/87861055-7e94d700-c97d-11ea-8aae-f643c36e02fa.png)

We should report this to Codecov. Until to be fixed, we will have to stick into v3.7.0 for getting better looking in badge.