### PR TITLE
Connect to Chrome via pipe rather than WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix invalid permission flag in package script ([#256](https://github.com/marp-team/marp-cli/issues/256), [#257](https://github.com/marp-team/marp-cli/pull/257))
+- Get more reliability of connection from Puppeteer to Chrome by using pipe rather than WebSocket ([#259](https://github.com/marp-team/marp-cli/pull/259))
 
 ## v0.19.0 - 2020-07-18
 

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -67,6 +67,7 @@ export const generatePuppeteerLaunchArgs = () => {
   return {
     executablePath,
     args: [...args],
+    pipe: true,
 
     // Workaround to avoid force-extensions policy for Chrome enterprise (SET CHROME_ENABLE_EXTENSIONS=1)
     // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-windows


### PR DESCRIPTION
Recently we met flaky test results again.

This PR sets `puppeteer.launch({ pipe: true })` to get more reliability of connection to Chrome by Puppeteer. `pipe: true` makes connection to Chrome process through process pipe instead of WebSocket, so we could expect decrease of flaky test results caused by unstable network on GitHub Actions environment.