### PR TITLE
Make public improved API interface for Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Make public improved API interface for Node.js ([#260](https://github.com/marp-team/marp-cli/pull/260))
 - Added info about [Chocolatey](https://chocolatey.org/packages/marp-cli) and [Scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/marp.json) packages into Readme ([#263](https://github.com/marp-team/marp-cli/pull/263) by [@zverev-iv](https://github.com/zverev-iv))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -459,6 +459,34 @@ For example, the below configuration will set constructor option for Marp Core a
 
 > :warning: Some options may be overridden by used template.
 
+## API _(EXPERIMENTAL)_
+
+You can use Marp CLI through Node.js [if installed Marp CLI into your local project](#local-installation).
+
+```js
+const { marpCli } = require('@marp-team/marp-cli')
+
+marpCli(['test.md', '--pdf'])
+  .then((exitStatus) => {
+    if (exitStatus > 0) {
+      console.error(`Failure (Exit status: ${exitStatus})`)
+    } else {
+      console.log('Success')
+    }
+  })
+  .catch(console.error)
+```
+
+`marpCli()` accepts an argument of CLI options as array, and returns `Promise` to resolve an expected exit status in CLI. It would be rejected with the instance of `Error` if CLI met an error to suspend the conversion process.
+
+> :warning: _Marp CLI API is still not stable._ Please be aware that currently some observations would continue in background after resolved `Promise` (e.g. Watch mode, server mode, and preview window). We don't yet ensure safe behavior if used them.
+
+### Error handling
+
+We have exported [`CLIError` class and `CLIErrorCode` enum](https://github.com/marp-team/marp-cli/blob/master/src/error.ts) from `@marp-team/marp-cli`, to allow handling for specific errors that have already known by Marp CLI.
+
+If `CLIError` instance was thrown, you can identify the reason why CLI throwed error by checking `errorCode` member.
+
 ## Contributing
 
 Are you interested in contributing? Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) and [the common contributing guideline for Marp team](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -495,13 +495,34 @@ marpCli(['test.md', '--pdf'])
 
 `marpCli()` accepts an argument of CLI options as array, and returns `Promise` to resolve an expected exit status in CLI. It would be rejected with the instance of `Error` if CLI met an error to suspend the conversion process.
 
-> :warning: _Marp CLI API is still not stable._ Please be aware that currently some observations would continue in background after resolved `Promise` (e.g. Watch mode, server mode, and preview window). We don't yet ensure safe behavior if used them.
-
 ### Error handling
 
 We have exported [`CLIError` class and `CLIErrorCode` enum](https://github.com/marp-team/marp-cli/blob/master/src/error.ts) from `@marp-team/marp-cli`, to allow handling for specific errors that have already known by Marp CLI.
 
 If `CLIError` instance was thrown, you can identify the reason why CLI throwed error by checking `errorCode` member.
+
+### Wait for observation
+
+`marpCli()` would not be resolved initiatively if started some observation: Watch mode, server mode, and preview window.
+
+`waitForObservation()` is helpful to handle them. It returns `Promise` that would be resolved with helper object when ready to observe resources in `marpCli()`.
+
+```javascript
+const { marpCli, waitForObservation } = require('@marp-team/marp-cli')
+
+marpCli(['--server', './slides/'])
+  .then((exitCode) => console.log(`Done with exit code ${exitCode}`))
+  .catch(console.error)
+
+waitForObservation().then(({ stop }) => {
+  console.log('Observed')
+
+  // Stop observations to resolve marpCli()'s Promise
+  stop()
+})
+```
+
+The resolved helper has `stop()` method for telling Marp CLI to stop observation and resolve `Promise`.
 
 ## Contributing
 

--- a/marp-cli.js
+++ b/marp-cli.js
@@ -4,5 +4,5 @@
 
 require('v8-compile-cache')
 require('./lib/marp-cli.js')
-  .default(process.argv.slice(2))
+  .cliInterface(process.argv.slice(2))
   .then((exitCode) => process.on('exit', () => process.exit(exitCode)))

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "engines": {
     "node": ">=10"
   },
-  "main": "lib/marp-cli.js",
-  "types": "types/src/marp-cli.d.ts",
+  "main": "lib/index.js",
+  "types": "types/src/index.d.ts",
   "files": [
     "marp-cli.js",
     "lib/",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,7 +42,10 @@ const plugins = (opts = {}) => [
   }),
   pugPlugin({ pugRuntime: 'pug-runtime' }),
   url({ sourceDir: path.join(__dirname, 'lib') }),
-  compact && terser(),
+  compact &&
+    terser({
+      keep_classnames: /^CLIError$/,
+    }),
 ]
 
 const browser = {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,8 @@ import pugPlugin from 'rollup-plugin-pug'
 import { terser } from 'rollup-plugin-terser'
 import { dependencies } from './package.json'
 
+const compact = !process.env.ROLLUP_WATCH
+
 const external = (deps) => (id) =>
   deps.some((dep) => dep === id || id.startsWith(`${dep}/`))
 
@@ -40,7 +42,7 @@ const plugins = (opts = {}) => [
   }),
   pugPlugin({ pugRuntime: 'pug-runtime' }),
   url({ sourceDir: path.join(__dirname, 'lib') }),
-  !process.env.ROLLUP_WATCH && terser(),
+  compact && terser(),
 ]
 
 const browser = {
@@ -57,21 +59,21 @@ export default [
   {
     ...browser,
     input: 'src/templates/bespoke.js',
-    output: { file: 'lib/bespoke.js', format: 'iife' },
+    output: { compact, file: 'lib/bespoke.js', format: 'iife' },
   },
   {
     ...browser,
     input: 'src/templates/watch.js',
-    output: { file: 'lib/watch.js', format: 'iife' },
+    output: { compact, file: 'lib/watch.js', format: 'iife' },
   },
   {
     ...browser,
     input: 'src/server/server-index.js',
-    output: { file: 'lib/server/server-index.js', format: 'iife' },
+    output: { compact, file: 'lib/server/server-index.js', format: 'iife' },
   },
   {
     ...cli,
-    input: 'src/marp-cli.ts',
-    output: { exports: 'named', file: 'lib/marp-cli.js', format: 'cjs' },
+    input: ['src/marp-cli.ts', 'src/index.ts'],
+    output: { compact, dir: 'lib', exports: 'named', format: 'cjs' },
   },
 ]

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import osLocale from 'os-locale'
 import { info, warn } from './cli'
 import { ConverterOption, ConvertType } from './converter'
 import resolveEngine, { ResolvableEngine, ResolvedEngine } from './engine'
-import { CLIError } from './error'
+import { error } from './error'
 import { TemplateOption } from './templates'
 import { Theme, ThemeSet } from './theme'
 
@@ -213,10 +213,9 @@ export class MarpCLIConfig {
       // Fallback to input arguments in server mode
       if (this.args.server || this.conf.server) {
         if (Array.isArray(this.args._)) {
-          if (this.args._.length > 1)
-            throw new CLIError(
-              'Server mode have to specify just one directory.'
-            )
+          if (this.args._.length > 1) {
+            error('Server mode have to specify just one directory.')
+          }
           if (this.args._.length === 1) return path.resolve(this.args._[0])
         }
       }
@@ -229,10 +228,10 @@ export class MarpCLIConfig {
       stat = await lstat(dir)
     } catch (e) {
       if (e.code !== 'ENOENT') throw e
-      throw new CLIError(`Input directory "${dir}" is not found.`)
+      error(`Input directory "${dir}" is not found.`)
     }
 
-    if (!stat.isDirectory()) throw new CLIError(`"${dir}" is not directory.`)
+    if (!stat.isDirectory()) error(`"${dir}" is not directory.`)
 
     return dir
   }
@@ -250,7 +249,7 @@ export class MarpCLIConfig {
         this.conf = ret.config
       }
     } catch (e) {
-      throw new CLIError(
+      error(
         [
           'Could not find or parse configuration file.',
           e.name !== 'Error' && `(${e.name})`,
@@ -289,9 +288,7 @@ export class MarpCLIConfig {
             theme.advice.insteadOf
           } to make theme CSS available from directory.`
         )
-        throw new CLIError(
-          `Directory cannot pass to theme option. (${theme.path})`
-        )
+        error(`Directory cannot pass to theme option. (${theme.path})`)
       }
 
       if (e.code !== 'ENOENT') throw e

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { Marpit } from '@marp-team/marpit'
 import importFrom from 'import-from'
 import pkgUp from 'pkg-up'
-import { CLIError } from './error'
+import { error } from './error'
 
 export type Engine = typeof Marpit
 export type ResolvableEngine = Engine | string
@@ -41,7 +41,7 @@ export class ResolvedEngine {
       return resolved
     })
 
-    if (!resolved) throw new CLIError(`The specified engine has not resolved.`)
+    if (!resolved) error(`The specified engine has not resolved.`)
     return resolved
   }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -13,6 +13,15 @@ export class CLIError implements Error {
   }
 }
 
-export function error(msg: string, errorCode = 1): never {
+export enum CLIErrorCode {
+  GENERAL_ERROR = 1,
+  NOT_FOUND_CHROMIUM = 2,
+  LISTEN_PORT_IS_ALREADY_USED = 3,
+}
+
+export function error(
+  msg: string,
+  errorCode = CLIErrorCode.GENERAL_ERROR
+): never {
   throw new CLIError(msg, errorCode)
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,9 +1,10 @@
-export class CLIError implements Error {
+export class CLIError extends Error {
   readonly errorCode: number
   readonly message: string
   readonly name = 'CLIError'
 
   constructor(message: string, errorCode = 1) {
+    super()
     this.message = message
     this.errorCode = errorCode
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { apiInterface } from './marp-cli'
 
+export { ObservationHelper, waitForObservation } from './marp-cli'
 export { CLIError, CLIErrorCode } from './error'
 
 export const marpCli = apiInterface

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+import { apiInterface } from './marp-cli'
+
+export { CLIError, CLIErrorCode } from './error'
+
+export const marpCli = apiInterface
+export default apiInterface

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -20,8 +20,8 @@ enum OptionGroup {
   Marp = 'Marp / Marpit Options:',
 }
 
-interface MarpCLIInternalOptions {
-  readStdin: boolean
+export interface MarpCLIInternalOptions {
+  stdin: boolean
   throwErrorAlways: boolean
 }
 
@@ -31,9 +31,9 @@ Usage:
   marp [options] -I <dir>
 `.trim()
 
-const marpCli = async (
+export const marpCli = async (
   argv: string[],
-  { readStdin, throwErrorAlways }: MarpCLIInternalOptions
+  { stdin: defaultStdin, throwErrorAlways }: MarpCLIInternalOptions
 ): Promise<number> => {
   let watcherInstance: Watcher | undefined
 
@@ -94,7 +94,7 @@ const marpCli = async (
           type: 'boolean',
         },
         stdin: {
-          default: readStdin,
+          default: defaultStdin,
           describe: 'Read Markdown from stdin',
           hidden: true, // It is an escape-hatch for advanced user
           group: OptionGroup.Basic,
@@ -354,13 +354,13 @@ const marpCli = async (
 
 export const apiInterface = (argv: string[] = []) =>
   marpCli(argv, {
-    readStdin: false,
+    stdin: false,
     throwErrorAlways: true,
   })
 
 export const cliInterface = (argv: string[] = []) =>
   marpCli(argv, {
-    readStdin: true,
+    stdin: true,
     throwErrorAlways: false,
   })
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -25,6 +25,10 @@ export interface MarpCLIInternalOptions {
   throwErrorAlways: boolean
 }
 
+export type ObservationHelper = { stop: () => void }
+
+const resolversForObservation: Array<(helper: ObservationHelper) => void> = []
+
 const usage = `
 Usage:
   marp [options] <files...>
@@ -35,6 +39,7 @@ export const marpCli = async (
   argv: string[],
   { stdin: defaultStdin, throwErrorAlways }: MarpCLIInternalOptions
 ): Promise<number> => {
+  let server: Server | undefined
   let watcherInstance: Watcher | undefined
 
   try {
@@ -281,58 +286,70 @@ export const marpCli = async (
 
     // Watch mode / Server mode
     if (cvtOpts.watch) {
-      watcherInstance = watcher(
-        [
-          ...(cvtOpts.inputDir ? [cvtOpts.inputDir] : config.files),
-          ...cvtOpts.themeSet.fnForWatch,
-        ],
-        {
-          converter,
-          finder,
-          events: {
-            onConverted,
-            onError: (e) =>
-              cli.error(`Failed converting Markdown. (${e.message})`),
-          },
-          mode: cvtOpts.server
-            ? Watcher.WatchMode.Notify
-            : Watcher.WatchMode.Convert,
-        }
-      )
+      return await new Promise<number>((res, rej) =>
+        (async () => {
+          watcherInstance = watcher(
+            [
+              ...(cvtOpts.inputDir ? [cvtOpts.inputDir] : config.files),
+              ...cvtOpts.themeSet.fnForWatch,
+            ],
+            {
+              converter,
+              finder,
+              events: {
+                onConverted,
+                onError: (e) =>
+                  cli.error(`Failed converting Markdown. (${e.message})`),
+              },
+              mode: cvtOpts.server
+                ? Watcher.WatchMode.Notify
+                : Watcher.WatchMode.Convert,
+            }
+          )
 
-      // Preview window
-      const preview = new Preview()
-      preview.on('exit', () => process.exit())
-      preview.on('opening', (location: string) => {
-        const loc = location.substr(0, 50)
-        const msg = `[Preview] (EXPERIMENTAL) Opening ${loc}...`
-        cli.info(chalk.cyan(msg))
-      })
+          // Preview window
+          const preview = new Preview()
+          preview.on('exit', () => res(0))
+          preview.on('opening', (location: string) => {
+            const loc = location.substr(0, 50)
+            const msg = `[Preview] (EXPERIMENTAL) Opening ${loc}...`
+            cli.info(chalk.cyan(msg))
+          })
 
-      if (cvtOpts.server) {
-        const server = new Server(converter, {
-          directoryIndex: ['index.md', 'PITCHME.md'], // GitPitch compatible
-        })
-        server.on('converted', onConverted)
-        server.on('error', (e) => cli.error(e.toString()))
+          if (cvtOpts.server) {
+            server = new Server(converter, {
+              directoryIndex: ['index.md', 'PITCHME.md'], // GitPitch compatible
+            })
+            server.on('converted', onConverted)
+            server.on('error', (e) => cli.error(e.toString()))
 
-        await server.start()
+            await server.start()
 
-        const url = `http://localhost:${server.port}`
-        const message = `[Server mode] Start server listened at ${url}/ ...`
+            const url = `http://localhost:${server.port}`
+            const message = `[Server mode] Start server listened at ${url}/ ...`
 
-        cli.info(chalk.green(message))
-        if (cvtOpts.preview) await preview.open(url)
-      } else {
-        cli.info(chalk.green('[Watch mode] Start watching...'))
+            cli.info(chalk.green(message))
+            if (cvtOpts.preview) await preview.open(url)
+          } else {
+            cli.info(chalk.green('[Watch mode] Start watching...'))
 
-        if (cvtOpts.preview) {
-          for (const file of convertedFiles) {
-            if (cvtOpts.type === ConvertType.pptx) continue
-            await preview.open(fileToURI(file, cvtOpts.type))
+            if (cvtOpts.preview) {
+              for (const file of convertedFiles) {
+                if (cvtOpts.type === ConvertType.pptx) continue
+                await preview.open(fileToURI(file, cvtOpts.type))
+              }
+            }
           }
-        }
-      }
+
+          let resolverForObservation:
+            | ((helper: ObservationHelper) => void)
+            | undefined
+
+          while ((resolverForObservation = resolversForObservation.shift())) {
+            resolverForObservation({ stop: () => res(0) })
+          }
+        })().catch(rej)
+      )
     }
 
     return 0
@@ -341,18 +358,24 @@ export const marpCli = async (
 
     cli.error(e.message)
 
-    // Stop running notifier and watcher to exit process correctly
-    // (NOTE: Don't close in the finally block to keep watching)
-    notifier.stop()
-    if (watcherInstance) watcherInstance.chokidar.close()
-
     return e.errorCode
   } finally {
-    await Converter.closeBrowser()
+    notifier.stop()
+
+    await Promise.all([
+      Converter.closeBrowser(),
+      server?.stop(),
+      watcherInstance?.chokidar.close(),
+    ])
   }
 }
 
-export const apiInterface = (argv: string[] = []) =>
+export const waitForObservation = () =>
+  new Promise<ObservationHelper>((res) => {
+    resolversForObservation.push(res)
+  })
+
+export const apiInterface = async (argv: string[] = []) =>
   marpCli(argv, {
     stdin: false,
     throwErrorAlways: true,

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -4,7 +4,7 @@ import { nanoid } from 'nanoid'
 import puppeteer from 'puppeteer-core'
 import favicon from './assets/favicon.png'
 import { ConvertType, mimeTypes } from './converter'
-import { CLIError } from './error'
+import { error } from './error'
 import { File, FileType } from './file'
 import {
   generatePuppeteerDataDirPath,
@@ -188,5 +188,5 @@ export function fileToURI(file: File, type: ConvertType) {
     return `data:${mimeTypes[type]};base64,${file.buffer.toString('base64')}`
   }
 
-  throw new CLIError('Processing file is not convertible to URI for preview.')
+  error('Processing file is not convertible to URI for preview.')
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import {
   ConvertType,
   mimeTypes,
 } from './converter'
-import { error, CLIError } from './error'
+import { CLIError, CLIErrorCode, error } from './error'
 import { File, markdownExtensions } from './file'
 import serverIndex from './server/index.pug'
 import style from './server/index.scss'
@@ -57,7 +57,12 @@ export class Server extends TypedEventEmitter<Server.Events> {
         httpServer.close()
 
         if (err['code'] === 'EADDRINUSE') {
-          rej(new CLIError(err.message))
+          rej(
+            new CLIError(
+              `Listen port ${this.port} is already used in the other process. Try again after closing the relevant process, or specify another port number through PORT env.`,
+              CLIErrorCode.LISTEN_PORT_IS_ALREADY_USED
+            )
+          )
         } else {
           rej(err)
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/export, @typescript-eslint/no-namespace */
 import fs from 'fs'
+import { Server as HttpServer } from 'http'
 import path from 'path'
 import querystring from 'querystring'
 import url from 'url'
@@ -29,6 +30,7 @@ export class Server extends TypedEventEmitter<Server.Events> {
   readonly port: number
 
   directoryIndex: string[]
+  httpServer: HttpServer | undefined
   server: Express | undefined
 
   private static script: string | undefined
@@ -50,24 +52,39 @@ export class Server extends TypedEventEmitter<Server.Events> {
     this.setup()
 
     return new Promise<void>((res, rej) => {
-      const httpServer = this.server!.listen(this.port) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      this.httpServer = this.server!.listen(this.port) // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-      httpServer.on('listening', res)
-      httpServer.on('error', (err) => {
-        httpServer.close()
+      this.httpServer.on('listening', res)
+      this.httpServer.on('error', (err) =>
+        (async () => {
+          await this.stop()
 
-        if (err['code'] === 'EADDRINUSE') {
-          rej(
-            new CLIError(
-              `Listen port ${this.port} is already used in the other process. Try again after closing the relevant process, or specify another port number through PORT env.`,
-              CLIErrorCode.LISTEN_PORT_IS_ALREADY_USED
+          if (err['code'] === 'EADDRINUSE') {
+            rej(
+              new CLIError(
+                `Listen port ${this.port} is already used in the other process. Try again after closing the relevant process, or specify another port number through PORT env.`,
+                CLIErrorCode.LISTEN_PORT_IS_ALREADY_USED
+              )
             )
-          )
-        } else {
-          rej(err)
-        }
-      })
+          } else {
+            rej(err)
+          }
+        })()
+      )
     })
+  }
+
+  async stop() {
+    if (this.httpServer) {
+      try {
+        await promisify(this.httpServer.close.bind(this.httpServer))()
+      } catch (e) {
+        if (e instanceof Error && e['code'] !== 'ERR_SERVER_NOT_RUNNING')
+          throw e
+      }
+
+      this.httpServer = undefined
+    }
   }
 
   private async convertMarkdown(

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -3,7 +3,8 @@ import os from 'os'
 import path from 'path'
 import { promisify } from 'util'
 import { Launcher } from 'chrome-launcher'
-import { CLIError } from '../error'
+import { warn } from '../cli'
+import { CLIErrorCode, error } from '../error'
 
 const execPromise = promisify(exec)
 
@@ -54,12 +55,17 @@ export const generatePuppeteerLaunchArgs = () => {
       // Use already known path within Marp CLI official Docker image
       executablePath = '/usr/bin/chromium-browser'
     } else {
-      ;[executablePath] = Launcher.getInstallations()
+      try {
+        ;[executablePath] = Launcher.getInstallations()
+      } catch (e) {
+        if (e instanceof Error) warn(e.message)
+      }
     }
 
     if (!executablePath) {
-      throw new CLIError(
-        'You have to install Google Chrome or Chromium to convert slide deck with current options.'
+      error(
+        'You have to install Google Chrome or Chromium to convert slide deck with current options.',
+        CLIErrorCode.NOT_FOUND_CHROMIUM
       )
     }
   }

--- a/test/__mocks__/express.ts
+++ b/test/__mocks__/express.ts
@@ -1,13 +1,15 @@
+import { EventEmitter } from 'events'
+
 const express = jest.requireActual('express')
 
 express.application.listen = jest.fn(() => {
-  // no ops
-})
+  const serverMock = Object.assign(new EventEmitter(), {
+    close: (callback) => callback(),
+  })
 
-express.application.listen.mockReturnValue({
-  on: (_, callback) => {
-    callback()
-  },
+  setTimeout(() => serverMock.emit('listening'), 0)
+
+  return serverMock
 })
 
 module.exports = express

--- a/test/__mocks__/get-stdin.ts
+++ b/test/__mocks__/get-stdin.ts
@@ -1,3 +1,3 @@
 module.exports = {
-  buffer: () => Promise.resolve(''),
+  buffer: jest.fn().mockResolvedValue(''),
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,44 @@
+import path from 'path'
+import { buffer as stdinBuffer } from 'get-stdin'
+import api, { CLIError } from '../src/index'
+import * as marpCli from '../src/marp-cli'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
+
+describe('Marp CLI API interface', () => {
+  it('runs Marp CLI with specific options', async () => {
+    const marpCliSpy = jest.spyOn(marpCli, 'marpCli').mockResolvedValue(0)
+    const ret = await api([])
+
+    expect(ret).toBe(0)
+    expect(marpCliSpy).toHaveBeenCalled()
+
+    const opts: marpCli.MarpCLIInternalOptions = marpCliSpy.mock.calls[0][1]
+
+    expect(opts.stdin).toBe(false)
+    expect(opts.throwErrorAlways).toBe(true)
+  })
+
+  it('does not read input from stdin if called API', async () => {
+    jest.spyOn(console, 'error').mockImplementation()
+
+    await marpCli.cliInterface([])
+    expect(stdinBuffer).toHaveBeenCalled()
+    ;(stdinBuffer as jest.Mock).mockClear()
+
+    await api([])
+    expect(stdinBuffer).not.toHaveBeenCalled()
+  })
+
+  it('always throws error if CLI met an error to suspend', async () => {
+    jest.spyOn(console, 'error').mockImplementation()
+
+    const fakePath = path.resolve(__dirname, '__fake')
+
+    expect(await marpCli.cliInterface(['-c', fakePath])).toBeGreaterThan(0)
+    await expect(api(['-c', fakePath])).rejects.toBeInstanceOf(CLIError)
+  })
+})

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -11,14 +11,29 @@ import { Converter, ConvertType } from '../src/converter'
 import { ResolvedEngine } from '../src/engine'
 import { CLIError } from '../src/error'
 import { File } from '../src/file'
-import marpCli from '../src/marp-cli' // eslint-disable-line import/no-named-as-default
+import {
+  ObservationHelper,
+  cliInterface as marpCli,
+  waitForObservation,
+} from '../src/marp-cli'
 import { Preview } from '../src/preview'
 import { Server } from '../src/server'
 import { ThemeSet } from '../src/theme'
 import * as version from '../src/version'
 import { Watcher } from '../src/watcher'
 
+const observationHelpers: ObservationHelper[] = []
 const previewEmitter = new EventEmitter() as Preview
+
+const runForObservation = async (argv: string[]) => {
+  const ret = await Promise.race([marpCli(argv), waitForObservation()])
+
+  if (typeof ret !== 'object')
+    throw new Error('runForObservation should observe')
+
+  observationHelpers.push(ret)
+  return ret
+}
 
 jest.mock('fs')
 jest.mock('mkdirp')
@@ -33,6 +48,12 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  let observationHelper: ObservationHelper | undefined
+
+  while ((observationHelper = observationHelpers.shift())) {
+    observationHelper.stop()
+  }
+
   jest.restoreAllMocks()
   jest.clearAllMocks()
 })
@@ -278,7 +299,7 @@ describe('Marp CLI', () => {
         const serverStart = jest.spyOn<any, any>(Server.prototype, 'start')
         serverStart.mockResolvedValue(0)
 
-        await marpCli(['--input-dir', files, '--server'])
+        await runForObservation(['--input-dir', files, '--server'])
         expect(info.mock.calls.map(([m]) => m)).toContainEqual(
           expect.stringContaining('http://localhost:8080/')
         )
@@ -293,7 +314,7 @@ describe('Marp CLI', () => {
 
       describe('with --preview option', () => {
         const run = () =>
-          marpCli(['--input-dir', files, '--server', '--preview'])
+          runForObservation(['--input-dir', files, '--server', '--preview'])
 
         beforeEach(() => {
           jest.spyOn(cli, 'info').mockImplementation()
@@ -626,7 +647,7 @@ describe('Marp CLI', () => {
         jest.spyOn(cli, 'info').mockImplementation()
         ;(<any>fs).__mockWriteFile()
 
-        expect(await marpCli([onePath, '-w'])).toBe(0)
+        await runForObservation([onePath, '-w'])
         expect(Watcher.watch).toHaveBeenCalledWith([onePath], expect.anything())
       })
     })
@@ -728,7 +749,7 @@ describe('Marp CLI', () => {
       )
 
       it('opens preview window through Preview.open()', async () => {
-        await marpCli([onePath, '-p', '--no-output'])
+        await runForObservation([onePath, '-p', '--no-output'])
         expect(Preview.prototype.open).toHaveBeenCalledTimes(1)
 
         // Simualte opening event
@@ -740,7 +761,7 @@ describe('Marp CLI', () => {
 
       describe('when PPTX conversion is enabled', () => {
         it('does not open PPTX in preview window', async () => {
-          await marpCli([onePath, '-p', '--pptx', '--no-output'])
+          await runForObservation([onePath, '-p', '--pptx', '--no-output'])
           expect(Preview.prototype.open).not.toHaveBeenCalled()
         }, 30000)
       })
@@ -814,7 +835,7 @@ describe('Marp CLI', () => {
         const serverStart = jest.spyOn<any, any>(Server.prototype, 'start')
         serverStart.mockResolvedValue(0)
 
-        await marpCli(['--server', assetFn('_files')])
+        await runForObservation(['--server', assetFn('_files')])
         expect(serverStart).toHaveBeenCalledTimes(1)
 
         const server: any = serverStart.mock.instances[0]
@@ -827,7 +848,7 @@ describe('Marp CLI', () => {
         it('opens served address through Preview.open()', async () => {
           jest.spyOn(console, 'warn').mockImplementation()
 
-          await marpCli(['--server', assetFn('_files'), '--preview'])
+          await runForObservation(['--server', assetFn('_files'), '--preview'])
           expect(Preview.prototype.open).toHaveBeenCalledTimes(1)
           expect(Preview.prototype.open).toHaveBeenCalledWith(
             expect.stringMatching(/^http:\/\/localhost:/)
@@ -855,7 +876,7 @@ describe('Marp CLI', () => {
       it('opens 2 preview windows through Preview.open()', async () => {
         jest.spyOn(console, 'warn').mockImplementation()
 
-        await marpCli([...baseArgs, '--preview', '--no-output'])
+        await runForObservation([...baseArgs, '--preview', '--no-output'])
         expect(Preview.prototype.open).toHaveBeenCalledTimes(2)
       })
     })

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -11,7 +11,7 @@ import { Converter, ConvertType } from '../src/converter'
 import { ResolvedEngine } from '../src/engine'
 import { CLIError } from '../src/error'
 import { File } from '../src/file'
-import marpCli from '../src/marp-cli'
+import marpCli from '../src/marp-cli' // eslint-disable-line import/no-named-as-default
 import { Preview } from '../src/preview'
 import { Server } from '../src/server'
 import { ThemeSet } from '../src/theme'
@@ -21,7 +21,6 @@ import { Watcher } from '../src/watcher'
 const previewEmitter = new EventEmitter() as Preview
 
 jest.mock('fs')
-jest.mock('get-stdin')
 jest.mock('mkdirp')
 jest.mock('../src/preview')
 jest.mock('../src/watcher', () => jest.genMockFromModule('../src/watcher'))


### PR DESCRIPTION
The undocumented Marp CLI's API interface, that is used in Marp for VS Code, is hard to use by several reason:

- It does never respond whenever there is not added `--no-stdin` argument manually, and it is not documented too.
- `CLIError` has not thrown because it would be catched to display error into users. Developer has to rely to the exit code `0` or `1` that has limited informations.

By these reasons, Marp for VS Code often shows helpless error `Marp CLI throwed unexpected error with exit code 1`. By googling Marp for VS Code that message shows as related search keyword. :sob:

So I've improved API interface, to throw any kind of errors that includes `CLIError`. In addition, some `CLIError`s have discriminable exit code.

The default `stdin` option will change from running which interface, CLI (=`true`) or API (=`false`).

### ToDo

- [x] Add tests for API interface