### PR TITLE
Disable pipe for Puppeteer when running on WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Fixed
 
 - Fix invalid permission flag in package script ([#256](https://github.com/marp-team/marp-cli/issues/256), [#257](https://github.com/marp-team/marp-cli/pull/257))
-- Get more reliability of connection from Puppeteer to Chrome by using pipe rather than WebSocket ([#259](https://github.com/marp-team/marp-cli/pull/259))
+- Get more reliability of connection from Puppeteer to Chrome by using pipe rather than WebSocket ([#259](https://github.com/marp-team/marp-cli/pull/259), [#264](https://github.com/marp-team/marp-cli/pull/264))
 
 ## v0.19.0 - 2020-07-18
 

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -43,7 +43,9 @@ export const generatePuppeteerDataDirPath = async (
     // In WSL environment, Marp CLI will use Chrome on Windows. Thus, we have to
     // specify Windows path when converting within WSL.
     if (wslTmp === undefined) {
-      const tmpRet = (await execFilePromise('cmd.exe', ['/c', 'SET', 'TMP'])).stdout.trim()
+      const tmpRet = (
+        await execFilePromise('cmd.exe', ['/c', 'SET', 'TMP'])
+      ).stdout.trim()
       if (tmpRet.startsWith('TMP=')) wslTmp = tmpRet.slice(4)
     }
     if (wslTmp !== undefined) {

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -14,7 +14,6 @@ let isWsl: number | undefined
 let wslTmp: string | undefined
 
 export function isWSL(): number {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   if (isWsl === undefined) {
     if (require('is-wsl')) {
       isWsl = 1


### PR DESCRIPTION
In WSL environment, Puppeteer cannot connect into Windows Chrome through the pipe. I've disabled pipe when running Puppeteer on WSL.

This PR also includes refactoring for handling WSL.

Please be aware Marp CLI over WSL 2 is still not working. Puppeteer does not have a workaround for WSL 2. We have the basic code to detect WSL 2 in the future, but it is also not shipped.