### PR TITLE
Handle --no-config-file option to prevent looking up for a configuration file

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,7 @@ interface IMarpCLIArguments {
     osc?: boolean
     progress?: boolean
   }
-  configFile?: string
+  configFile?: string | false
   description?: string
   engine?: string
   html?: boolean
@@ -63,13 +63,13 @@ export class MarpCLIConfig {
   confPath?: string
   engine!: ResolvedEngine
 
-  static moduleName = 'marp'
+  static moduleName = 'marp' as const
 
   static async fromArguments(args: IMarpCLIArguments) {
     const conf = new MarpCLIConfig()
     conf.args = args
 
-    await conf.loadConf(args.configFile)
+    if (args.configFile !== false) await conf.loadConf(args.configFile)
 
     conf.engine = await (() => {
       if (conf.args.engine) return resolveEngine(conf.args.engine)

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -74,10 +74,16 @@ export const marpCli = async (
           type: 'string',
         },
         'config-file': {
-          alias: 'c',
-          describe: 'Specify path to configuration file',
+          alias: ['config', 'c'],
+          describe: 'Specify path to a configuration file',
           group: OptionGroup.Basic,
           type: 'string',
+        },
+        'no-config-file': {
+          alias: ['no-config'],
+          type: 'boolean',
+          describe: 'Prevent looking up for a configuration file',
+          group: OptionGroup.Basic,
         },
         watch: {
           alias: 'w',

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -667,6 +667,25 @@ describe('Marp CLI', () => {
         expect(html).toContain('<b>html</b>')
       })
 
+      it('prevents looking up for configuration file if --no-config-file option is passed', async () => {
+        const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
+
+        for (const opt of ['--no-config-file', '--no-config']) {
+          stdout.mockClear()
+
+          jest.spyOn(console, 'warn').mockImplementation()
+          jest
+            .spyOn(process, 'cwd')
+            .mockImplementation(() => assetFn('_configs/basic/'))
+
+          expect(await marpCli(['md.md', opt, '-o', '-'])).toBe(0)
+
+          // html option in a configuration file should not work
+          const html = stdout.mock.calls[0][0].toString()
+          expect(html).toContain('&lt;b&gt;html&lt;/b&gt;')
+        }
+      })
+
       it('uses marp section in package.json that is found in process.cwd()', async () => {
         const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
 
@@ -681,7 +700,7 @@ describe('Marp CLI', () => {
         expect(html).toContain('@theme b')
       })
 
-      describe('when --config-file / -c option is passed', () => {
+      describe('when --config-file / --config / -c option is passed', () => {
         it('prints error when specified config is not found', async () => {
           const error = jest.spyOn(console, 'error').mockImplementation()
 
@@ -703,7 +722,7 @@ describe('Marp CLI', () => {
           jest.spyOn(console, 'warn').mockImplementation()
 
           const conf = assetFn('_configs/marpit/config.js')
-          expect(await marpCli(['-c', conf, onePath, '-o', '-'])).toBe(0)
+          expect(await marpCli(['--config', conf, onePath, '-o', '-'])).toBe(0)
 
           const html = stdout.mock.calls[0][0].toString()
           expect(html).toContain('@theme a')


### PR DESCRIPTION
When Marp CLI installed in the local Node.js project, sometimes user may want to ignore a project-wide configuration file.

In this PR we will handle a negated  `--config-file` option. We won't look up a configuration file through cosmiconfig if passed `--no-config-file` option.

We also added an `--config` alias to `--config-file` option, for compatibllity with some CLI tools. It means that negated `--no-config-file` and `--no-config` will work as expected too.