### PR TITLE
Fix regression in --allow-local-files option with Snapd Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix regression in `--allow-local-files` option with Snapd Chromium ([#201](https://github.com/marp-team/marp-cli/issues/201), [#283](https://github.com/marp-team/marp-cli/pull/283))
+
 ## v0.21.0 - 2020-08-20
 
 ### Added

--- a/src/file.ts
+++ b/src/file.ts
@@ -106,10 +106,9 @@ export class File {
   async saveTmpFile(
     opts: { extension?: string; home?: boolean } = {}
   ): Promise<File.TmpFileInterface> {
-    const tmp: string = await tmpNamePromise({
-      dir: opts.home ? os.homedir() : undefined,
-      postfix: opts.extension,
-    })
+    let tmp: string = await tmpNamePromise({ postfix: opts.extension })
+
+    if (opts.home) tmp = path.join(os.homedir(), path.basename(tmp))
 
     await this.saveToFile(tmp)
 


### PR DESCRIPTION
This PR includes these bugfixes:

- We've missed a breaking change in the bumped `tmp` dependency (https://github.com/marp-team/marp-cli/pull/229#commitcomment-42183269) so I fixed the logic for making tmpfile in `--allow-local-files` option.
- Recently Snapd Chromium is prepared the shebang script in `/usr/bin/chromium-browser`. `chrome-launcher` will detect this so we can't detect Snapd Chromium from the executable path. We may still able to detect `snap` by reading the content of script but it requires extra file-reading. Thus, we will always create Snapd-compatible tmpfile for `--allow-local-files` option if used CLI in Linux. A tmpfile will always be placed to home directory.

Fix #201 again.