### PR TITLE
Update README.md to prefer Scoop package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Also you can use the package manager to install/update Marp CLI standalone binar
 
 #### Windows
 
-- **[Chocolatey](https://chocolatey.org/)**: `choco install marp-cli` ([Refer to the package information...](https://chocolatey.org/packages/marp-cli))
 - **[Scoop](https://scoop.sh/)**: `scoop install marp` ([Refer to the manifest in official Main bucket...](https://github.com/ScoopInstaller/Main/blob/master/bucket/marp.json))
+- **[Chocolatey](https://chocolatey.org/)**: `choco install marp-cli` ([Refer to the package information...](https://chocolatey.org/packages/marp-cli))
 
 > _Disclaimer: These packages and manifests are maintained by the others, not Marp team._
 


### PR DESCRIPTION
An update of [Scoop's main bucket](https://github.com/ScoopInstaller/Main) is almost automated so reflected a bumped CLI version at least in a day. On the other hand, Chocolatey requires some days to reflect the latest because of [the handmade package](https://github.com/zverev-iv/choco-marp-cli).

**Marp team is always making importance to the security.** This PR will change the first option of Windows package manager to Scoop because we must prefer a choice for delivering the latest version rapidly.