### PR TITLE
Fallback to Microsoft Edge if not installed Chrome / Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Fallback to Microsoft Edge if not installed Chrome ([#199](https://github.com/marp-team/marp-cli/issues/199), [#292](https://github.com/marp-team/marp-cli/pull/292))
+
+### Fixed
+
+- Better support for custom Chrome path via `CHROME_PATH` env in WSL ([#288](https://github.com/marp-team/marp-cli/issues/288), [#292](https://github.com/marp-team/marp-cli/pull/292))
+
 ## v0.21.1 - 2020-09-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ npx @marp-team/marp-cli -w slide-deck.md
 npx @marp-team/marp-cli -s ./slides
 ```
 
-> :information_source: You have to install [Google Chrome] (or [Chromium]) to convert slide deck into PDF, PPTX, and image(s).
+> :information_source: You have to install [Google Chrome], [Chromium], or [Microsoft Edge] to convert slide deck into PDF, PPTX, and image(s).
 
 [google chrome]: https://www.google.com/chrome/
 [chromium]: https://www.chromium.org/
+[microsoft edge]: https://www.microsoft.com/edge
 
 ### Docker
 
@@ -113,14 +114,14 @@ When you want to output the converted result to another directory with keeping t
 
 ### Convert to PDF (`--pdf`)
 
-If you passed `--pdf` option or the output filename specified by `--output` (`-o`) option ends with `.pdf`, Marp CLI will try to convert into PDF file by using the installed [Google Chrome] or [Chromium].
+If you passed `--pdf` option or the output filename specified by `--output` (`-o`) option ends with `.pdf`, Marp CLI will try to convert into PDF file by using the installed [Google Chrome], [Chromium], or [Microsoft Edge].
 
 ```bash
 marp --pdf slide-deck.md
 marp slide-deck.md -o converted.pdf
 ```
 
-> :information_source: The all kind of conversions except HTML require [Google Chrome] or [Chromium]. When any problem has occurred while converting, please update your Chrome/Chromium to the latest version or try using [Google Chrome Canary].
+> :information_source: All kind of conversions except HTML require [Google Chrome], [Chromium], or [Microsoft Edge]. When an unexpected problem has occurred while converting, please update your Chrome/Chromium to the latest version or try installing [Google Chrome Canary].
 
 [google chrome canary]: https://www.google.com/chrome/canary/
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -432,9 +432,13 @@ export class Converter {
 
   private static async runBrowser() {
     if (!Converter.browser) {
+      const baseArgs = generatePuppeteerLaunchArgs()
+
       Converter.browser = await puppeteer.launch({
-        ...generatePuppeteerLaunchArgs(),
-        userDataDir: await generatePuppeteerDataDirPath('marp-cli-conversion'),
+        ...baseArgs,
+        userDataDir: await generatePuppeteerDataDirPath('marp-cli-conversion', {
+          wsl: !!baseArgs.executablePath?.match(/^\/mnt\/[a-z]\//),
+        }),
       })
       Converter.browser.once('disconnected', () => {
         Converter.browser = undefined

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -20,9 +20,8 @@ import { ThemeSet } from './theme'
 import {
   generatePuppeteerDataDirPath,
   generatePuppeteerLaunchArgs,
-  isWSL,
-  resolveWSLPath,
 } from './utils/puppeteer'
+import { isWSL, resolveWSLPath } from './utils/wsl'
 import { notifier } from './watcher'
 
 export enum ConvertType {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -142,7 +142,9 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
       ],
       defaultViewport: null,
       headless: process.env.NODE_ENV === 'test',
-      userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview'),
+      userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview', {
+        wsl: !!baseArgs.executablePath?.match(/^\/mnt\/[a-z]\//),
+      }),
     })
 
     // Set Marp icon asynchrnously

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -11,6 +11,7 @@ import {
   generatePuppeteerLaunchArgs,
 } from './utils/puppeteer'
 import TypedEventEmitter from './utils/typed-event-emitter'
+import { isChromeInWSLHost } from './utils/wsl'
 
 export namespace Preview {
   export interface Events {
@@ -143,7 +144,7 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
       defaultViewport: null,
       headless: process.env.NODE_ENV === 'test',
       userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview', {
-        wsl: !!baseArgs.executablePath?.match(/^\/mnt\/[a-z]\//),
+        wslHost: isChromeInWSLHost(baseArgs.executablePath),
       }),
     })
 

--- a/src/utils/edge-finder.ts
+++ b/src/utils/edge-finder.ts
@@ -1,6 +1,6 @@
 import { accessSync } from 'fs'
 import path from 'path'
-import { isWSL, resolveWindowsEnvSync } from './wsl'
+import { isWSL, resolveWindowsEnvSync, resolveWSLPathToGuestSync } from './wsl'
 
 const findAccessiblePath = (paths: string[]): string | undefined =>
   paths.find((p) => {
@@ -15,10 +15,12 @@ const findAccessiblePath = (paths: string[]): string | undefined =>
 
 const linux = (): string | undefined => {
   if (isWSL()) {
+    const localAppData = resolveWindowsEnvSync('LOCALAPPDATA')
+
     return win32({
       programFiles: '/mnt/c/Program Files',
       programFilesX86: '/mnt/c/Program Files (x86)',
-      localAppData: resolveWindowsEnvSync('LOCALAPPDATA') || '',
+      localAppData: localAppData ? resolveWSLPathToGuestSync(localAppData) : '',
     })
   }
 

--- a/src/utils/edge-finder.ts
+++ b/src/utils/edge-finder.ts
@@ -1,0 +1,73 @@
+import { accessSync } from 'fs'
+import path from 'path'
+import { isWSL, resolveWindowsEnvSync } from './wsl'
+
+const findAccessiblePath = (paths: string[]): string | undefined =>
+  paths.find((p) => {
+    try {
+      accessSync(p)
+      return true
+    } catch (e) {
+      // no ops
+    }
+    return false
+  })
+
+const linux = (): string | undefined => {
+  if (isWSL()) {
+    return win32({
+      programFiles: '/mnt/c/Program Files',
+      programFilesX86: '/mnt/c/Program Files (x86)',
+      localAppData: resolveWindowsEnvSync('LOCALAPPDATA') || '',
+    })
+  }
+
+  // TODO: Find out Microsoft Edge for Linux
+  // https://www.microsoftedgeinsider.com/en-us/download?platform=linux
+  return undefined
+}
+
+const darwin = (): string | undefined =>
+  findAccessiblePath([
+    '/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary',
+    '/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev',
+    '/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta',
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+  ])
+
+const win32 = ({
+  programFiles = process.env.PROGRAMFILES,
+  programFilesX86 = process.env['PROGRAMFILES(X86)'],
+  localAppData = process.env.LOCALAPPDATA,
+}: {
+  programFiles?: string
+  programFilesX86?: string
+  localAppData?: string
+} = {}): string | undefined => {
+  const prefixes = [localAppData, programFiles, programFilesX86].filter(
+    (p): p is string => !!p
+  )
+
+  return findAccessiblePath(
+    [
+      path.join('Microsoft', 'Edge SxS', 'Application', 'msedge.exe'),
+      path.join('Microsoft', 'Edge Dev', 'Application', 'msedge.exe'),
+      path.join('Microsoft', 'Edge Beta', 'Application', 'msedge.exe'),
+      path.join('Microsoft', 'Edge', 'Application', 'msedge.exe'),
+    ].reduce<string[]>(
+      (acc, suffix) => [
+        ...acc,
+        ...prefixes.map((prefix) => path.join(prefix, suffix)),
+      ],
+      []
+    )
+  )
+}
+
+export const findEdgeInstallation = (): string | undefined => {
+  if (process.platform === 'linux') return linux()
+  if (process.platform === 'darwin') return darwin()
+  if (process.platform === 'win32') return win32()
+
+  return undefined
+}

--- a/src/utils/edge-finder.ts
+++ b/src/utils/edge-finder.ts
@@ -1,11 +1,11 @@
-import { accessSync } from 'fs'
+import { accessSync, constants } from 'fs'
 import path from 'path'
 import { isWSL, resolveWindowsEnvSync, resolveWSLPathToGuestSync } from './wsl'
 
-const findAccessiblePath = (paths: string[]): string | undefined =>
+export const findAccessiblePath = (paths: string[]): string | undefined =>
   paths.find((p) => {
     try {
-      accessSync(p)
+      accessSync(p, constants.X_OK)
       return true
     } catch (e) {
       // no ops

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -52,7 +52,7 @@ export const generatePuppeteerLaunchArgs = () => {
 
       if (!executablePath) {
         error(
-          'You have to install Google Chrome or Chromium to convert slide deck with current options.',
+          'You have to install Google Chrome, Chromium, or Microsoft Edge to convert slide deck with current options.',
           CLIErrorCode.NOT_FOUND_CHROMIUM
         )
       }

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -1,39 +1,13 @@
-import { execFile } from 'child_process'
-import { readFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
-import { promisify } from 'util'
 import { Launcher } from 'chrome-launcher'
 import { warn } from '../cli'
 import { CLIErrorCode, error } from '../error'
-
-const execFilePromise = promisify(execFile)
+import { findEdgeInstallation } from './edge-finder'
+import { isWSL, resolveWindowsEnv } from './wsl'
 
 let executablePath: string | undefined | false = false
-let isWsl: number | undefined
 let wslTmp: string | undefined
-
-export function isWSL(): number {
-  if (isWsl === undefined) {
-    if (require('is-wsl')) {
-      isWsl = 1
-
-      try {
-        // https://github.com/microsoft/WSL/issues/423#issuecomment-611086412
-        const release = readFileSync('/proc/sys/kernel/osrelease').toString()
-        if (release.includes('WSL2')) isWsl = 2
-      } catch (e) {
-        // no ops
-      }
-    } else {
-      isWsl = 0
-    }
-  }
-  return isWsl
-}
-
-export const resolveWSLPath = async (path: string): Promise<string> =>
-  (await execFilePromise('wslpath', ['-m', path])).stdout.trim()
 
 export const generatePuppeteerDataDirPath = async (
   name: string
@@ -41,15 +15,8 @@ export const generatePuppeteerDataDirPath = async (
   if (isWSL()) {
     // In WSL environment, Marp CLI will use Chrome on Windows. Thus, we have to
     // specify Windows path when converting within WSL.
-    if (wslTmp === undefined) {
-      const tmpRet = (
-        await execFilePromise('cmd.exe', ['/c', 'SET', 'TMP'])
-      ).stdout.trim()
-      if (tmpRet.startsWith('TMP=')) wslTmp = tmpRet.slice(4)
-    }
-    if (wslTmp !== undefined) {
-      return path.win32.resolve(wslTmp, name)
-    }
+    if (wslTmp === undefined) wslTmp = await resolveWindowsEnv('TMP')
+    if (wslTmp !== undefined) return path.win32.resolve(wslTmp, name)
   }
   return path.resolve(os.tmpdir(), name)
 }
@@ -79,10 +46,15 @@ export const generatePuppeteerLaunchArgs = () => {
     }
 
     if (!executablePath) {
-      error(
-        'You have to install Google Chrome or Chromium to convert slide deck with current options.',
-        CLIErrorCode.NOT_FOUND_CHROMIUM
-      )
+      // Find Edge as fallback (Edge has pre-installed to almost Windows)
+      executablePath = findEdgeInstallation()
+
+      if (!executablePath) {
+        error(
+          'You have to install Google Chrome or Chromium to convert slide deck with current options.',
+          CLIErrorCode.NOT_FOUND_CHROMIUM
+        )
+      }
     }
   }
 

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -11,9 +11,9 @@ let wslTmp: string | undefined
 
 export const generatePuppeteerDataDirPath = async (
   name: string,
-  { wsl }: { wsl?: boolean } = {}
+  { wslHost }: { wslHost?: boolean } = {}
 ): Promise<string> => {
-  if (isWSL() && wsl) {
+  if (isWSL() && wslHost) {
     // In WSL environment, Marp CLI will use Chrome on Windows. Thus, we have to
     // specify Windows path when converting within WSL.
     if (wslTmp === undefined) wslTmp = await resolveWindowsEnv('TMP')
@@ -40,7 +40,7 @@ export const generatePuppeteerLaunchArgs = () => {
       executablePath = '/usr/bin/chromium-browser'
     } else {
       try {
-        ;[executablePath] = Launcher.getInstallations()
+        executablePath = Launcher.getFirstInstallation()
       } catch (e) {
         if (e instanceof Error) warn(e.message)
       }

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -10,9 +10,10 @@ let executablePath: string | undefined | false = false
 let wslTmp: string | undefined
 
 export const generatePuppeteerDataDirPath = async (
-  name: string
+  name: string,
+  { wsl }: { wsl?: boolean } = {}
 ): Promise<string> => {
-  if (isWSL()) {
+  if (isWSL() && wsl) {
     // In WSL environment, Marp CLI will use Chrome on Windows. Thus, we have to
     // specify Windows path when converting within WSL.
     if (wslTmp === undefined) wslTmp = await resolveWindowsEnv('TMP')

--- a/src/utils/wsl.ts
+++ b/src/utils/wsl.ts
@@ -1,0 +1,47 @@
+import { execFile, execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { promisify } from 'util'
+
+const execFilePromise = promisify(execFile)
+
+let isWsl: number | undefined
+
+export const resolveWSLPath = async (path: string): Promise<string> =>
+  (await execFilePromise('wslpath', ['-m', path])).stdout.trim()
+
+export const resolveWSLPathSync = (path: string): string =>
+  execFileSync('wslpath', ['-m', path]).trim()
+
+export const resolveWindowsEnv = async (
+  key: string
+): Promise<string | undefined> => {
+  const ret = (
+    await execFilePromise('cmd.exe', ['/c', 'SET', key])
+  ).stdout.trim()
+
+  return ret.startsWith(`${key}=`) ? key.slice(key.length + 1) : undefined
+}
+
+export const resolveWindowsEnvSync = (key: string): string | undefined => {
+  const ret = execFileSync('cmd.exe', ['/c', 'SET', key]).trim()
+  return ret.startsWith(`${key}=`) ? key.slice(key.length + 1) : undefined
+}
+
+export function isWSL(): number {
+  if (isWsl === undefined) {
+    if (require('is-wsl')) {
+      isWsl = 1
+
+      try {
+        // https://github.com/microsoft/WSL/issues/423#issuecomment-611086412
+        const release = readFileSync('/proc/sys/kernel/osrelease').toString()
+        if (release.includes('WSL2')) isWsl = 2
+      } catch (e) {
+        // no ops
+      }
+    } else {
+      isWsl = 0
+    }
+  }
+  return isWsl
+}

--- a/test/utils/edge-finder.ts
+++ b/test/utils/edge-finder.ts
@@ -1,0 +1,173 @@
+import path from 'path'
+import * as edgeFinder from '../../src/utils/edge-finder'
+import * as wsl from '../../src/utils/wsl'
+
+jest.mock('../../src/utils/wsl')
+
+let originalPlatform: NodeJS.Platform | undefined
+
+const winEdgeCanary = ['Microsoft', 'Edge SxS', 'Application', 'msedge.exe']
+const winEdgeDev = ['Microsoft', 'Edge Dev', 'Application', 'msedge.exe']
+const winEdgeBeta = ['Microsoft', 'Edge Beta', 'Application', 'msedge.exe']
+const winEdgeStable = ['Microsoft', 'Edge', 'Application', 'msedge.exe']
+
+beforeEach(() => jest.spyOn(wsl, 'isWSL').mockImplementation())
+afterEach(() => {
+  jest.restoreAllMocks()
+
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  }
+})
+
+describe('#findAccessiblePath', () => {
+  it('return the first accessible path', () => {
+    const unknownFile = path.resolve(__dirname, 'unknown')
+    const marpCliExecutable = path.resolve(__dirname, '../../marp-cli.js')
+
+    expect(
+      edgeFinder.findAccessiblePath([unknownFile, marpCliExecutable])
+    ).toBe(marpCliExecutable)
+    expect(edgeFinder.findAccessiblePath([unknownFile])).toBeUndefined()
+  })
+})
+
+describe('#findEdgeInstallation', () => {
+  describe('Windows', () => {
+    beforeEach(() => {
+      originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+    })
+
+    it('finds out the first accessible Edge from 3 locations', () => {
+      const currentEnv = process.env
+
+      const programFiles = path.join('C:', 'Mock', 'Program Files')
+      const programFilesX86 = path.join('C:', 'Mock', 'Program Files (x86)')
+      const localAppData = path.join('C:', 'Mock', 'Local')
+
+      try {
+        process.env.PROGRAMFILES = programFiles
+        process.env['PROGRAMFILES(X86)'] = programFilesX86
+        process.env.LOCALAPPDATA = localAppData
+
+        const findAccessiblePath = jest
+          .spyOn(edgeFinder, 'findAccessiblePath')
+          .mockImplementation(
+            () => 'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe'
+          )
+
+        expect(edgeFinder.findEdgeInstallation()).toBe(
+          'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe'
+        )
+        expect(findAccessiblePath.mock.calls[0][0]).toStrictEqual([
+          path.join(localAppData, ...winEdgeCanary),
+          path.join(programFiles, ...winEdgeCanary),
+          path.join(programFilesX86, ...winEdgeCanary),
+          path.join(localAppData, ...winEdgeDev),
+          path.join(programFiles, ...winEdgeDev),
+          path.join(programFilesX86, ...winEdgeDev),
+          path.join(localAppData, ...winEdgeBeta),
+          path.join(programFiles, ...winEdgeBeta),
+          path.join(programFilesX86, ...winEdgeBeta),
+          path.join(localAppData, ...winEdgeStable),
+          path.join(programFiles, ...winEdgeStable),
+          path.join(programFilesX86, ...winEdgeStable),
+        ])
+      } finally {
+        delete process.env.PROGRAMFILES
+        delete process.env['PROGRAMFILES(X86)']
+        delete process.env.LOCALAPPDATA
+
+        process.env = currentEnv
+      }
+    })
+  })
+
+  describe('macOS', () => {
+    beforeEach(() => {
+      originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'darwin' })
+    })
+
+    it('finds out the first accessible Edge from specific paths', () => {
+      const findAccessiblePath = jest
+        .spyOn(edgeFinder, 'findAccessiblePath')
+        .mockImplementation(
+          () => '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
+        )
+
+      expect(edgeFinder.findEdgeInstallation()).toBe(
+        '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
+      )
+      expect(findAccessiblePath.mock.calls[0][0]).toMatchInlineSnapshot(`
+        Array [
+          "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
+          "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
+          "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
+          "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        ]
+      `)
+    })
+  })
+
+  describe('Linux', () => {
+    beforeEach(() => {
+      originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+    })
+
+    it('returns undefined', () => {
+      expect(edgeFinder.findEdgeInstallation()).toBeUndefined()
+    })
+
+    describe('on Windows WSL', () => {
+      beforeEach(() => jest.spyOn(wsl, 'isWSL').mockImplementation(() => 1))
+
+      it('finds out the first accessible Edge from mounted Windows location', () => {
+        const findAccessiblePath = jest
+          .spyOn(edgeFinder, 'findAccessiblePath')
+          .mockImplementation()
+
+        const resolveWindowsEnvSync = jest
+          .spyOn(wsl, 'resolveWindowsEnvSync')
+          .mockImplementation(() => 'C:\\Mock\\Local')
+
+        const resolveWSLPathToGuestSync = jest
+          .spyOn(wsl, 'resolveWSLPathToGuestSync')
+          .mockImplementation(() => '/mnt/c/mock/Local')
+
+        edgeFinder.findEdgeInstallation()
+        expect(resolveWindowsEnvSync).toHaveBeenCalledWith('LOCALAPPDATA')
+        expect(resolveWSLPathToGuestSync).toHaveBeenCalledWith(
+          'C:\\Mock\\Local'
+        )
+        expect(findAccessiblePath).toHaveBeenCalledWith([
+          path.join('/mnt/c/mock/Local', ...winEdgeCanary),
+          path.join('/mnt/c/Program Files', ...winEdgeCanary),
+          path.join('/mnt/c/Program Files (x86)', ...winEdgeCanary),
+          path.join('/mnt/c/mock/Local', ...winEdgeDev),
+          path.join('/mnt/c/Program Files', ...winEdgeDev),
+          path.join('/mnt/c/Program Files (x86)', ...winEdgeDev),
+          path.join('/mnt/c/mock/Local', ...winEdgeBeta),
+          path.join('/mnt/c/Program Files', ...winEdgeBeta),
+          path.join('/mnt/c/Program Files (x86)', ...winEdgeBeta),
+          path.join('/mnt/c/mock/Local', ...winEdgeStable),
+          path.join('/mnt/c/Program Files', ...winEdgeStable),
+          path.join('/mnt/c/Program Files (x86)', ...winEdgeStable),
+        ])
+      })
+    })
+  })
+
+  describe('Unknown platform', () => {
+    beforeEach(() => {
+      originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'unknown' })
+    })
+
+    it('returns undefined', () => {
+      expect(edgeFinder.findEdgeInstallation()).toBeUndefined()
+    })
+  })
+})

--- a/test/utils/puppeteer.ts
+++ b/test/utils/puppeteer.ts
@@ -93,7 +93,7 @@ describe('#generatePuppeteerLaunchArgs', () => {
 
     expect(puppeteer().generatePuppeteerLaunchArgs).toThrow(
       new (CLIError())(
-        'You have to install Google Chrome or Chromium to convert slide deck with current options.',
+        'You have to install Google Chrome, Chromium, or Microsoft Edge to convert slide deck with current options.',
         CLIErrorCode.NOT_FOUND_CHROMIUM
       )
     )

--- a/test/utils/puppeteer.ts
+++ b/test/utils/puppeteer.ts
@@ -1,0 +1,103 @@
+import path from 'path'
+import { CLIErrorCode } from '../../src/error'
+
+jest.mock('chrome-launcher')
+jest.mock('../../src/utils/edge-finder')
+
+const Launcher = (): typeof import('chrome-launcher').Launcher =>
+  require('chrome-launcher').Launcher // eslint-disable-line @typescript-eslint/no-var-requires
+
+const CLIError = (): typeof import('../../src/error').CLIError =>
+  require('../../src/error').CLIError // eslint-disable-line @typescript-eslint/no-var-requires
+
+const puppeteer = (): typeof import('../../src/utils/puppeteer') =>
+  require('../../src/utils/puppeteer')
+
+const edgeFinder = (): typeof import('../../src/utils/edge-finder') =>
+  require('../../src/utils/edge-finder')
+
+beforeEach(() => jest.resetModules())
+afterEach(() => jest.restoreAllMocks())
+
+describe('#generatePuppeteerLaunchArgs', () => {
+  it('finds out installed Chrome through chrome-launcher', () => {
+    const getFirstInstallation = jest
+      .spyOn(Launcher(), 'getFirstInstallation')
+      .mockImplementation(() => '/usr/bin/chromium')
+
+    const args = puppeteer().generatePuppeteerLaunchArgs()
+    expect(args.executablePath).toBe('/usr/bin/chromium')
+    expect(getFirstInstallation).toHaveBeenCalledTimes(1)
+
+    // Cache found result
+    puppeteer().generatePuppeteerLaunchArgs()
+    expect(getFirstInstallation).toHaveBeenCalledTimes(1)
+  })
+
+  it('finds out installed Edge as the fallback if not found Chrome', () => {
+    jest.spyOn(Launcher(), 'getFirstInstallation').mockImplementation()
+    jest
+      .spyOn(edgeFinder(), 'findEdgeInstallation')
+      .mockImplementation(() => '/usr/bin/msedge')
+
+    const args = puppeteer().generatePuppeteerLaunchArgs()
+    expect(args.executablePath).toBe('/usr/bin/msedge')
+    expect(edgeFinder().findEdgeInstallation).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws CLIError with specific error code if not found executable path', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation()
+
+    jest.spyOn(Launcher(), 'getFirstInstallation').mockImplementation(() => {
+      throw new Error('Error in chrome-launcher')
+    })
+    jest.spyOn(edgeFinder(), 'findEdgeInstallation').mockImplementation()
+
+    expect(puppeteer().generatePuppeteerLaunchArgs).toThrow(
+      new (CLIError())(
+        'You have to install Google Chrome or Chromium to convert slide deck with current options.',
+        CLIErrorCode.NOT_FOUND_CHROMIUM
+      )
+    )
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Error in chrome-launcher')
+    )
+  })
+
+  it('uses custom executable path if CHROME_PATH environment value was defined as executable path', () => {
+    jest.dontMock('chrome-launcher')
+
+    try {
+      process.env.CHROME_PATH = path.resolve(__dirname, '../../marp-cli.js')
+
+      const args = puppeteer().generatePuppeteerLaunchArgs()
+      expect(args.executablePath).toBe(process.env.CHROME_PATH)
+    } finally {
+      delete process.env.CHROME_PATH
+    }
+  })
+
+  it('uses specific settings if running in the official Docker image', () => {
+    try {
+      process.env.IS_DOCKER = 'true'
+
+      const args = puppeteer().generatePuppeteerLaunchArgs()
+      expect(args.executablePath).toBe('/usr/bin/chromium-browser')
+      expect(args.args).toContain('--no-sandbox')
+      expect(args.args).toContain('--disable-features=VizDisplayCompositor')
+    } finally {
+      delete process.env.IS_DOCKER
+    }
+  })
+
+  it("ignores puppeteer's --disable-extensions option if defined CHROME_ENABLE_EXTENSIONS environment value", () => {
+    try {
+      process.env.CHROME_ENABLE_EXTENSIONS = 'true'
+
+      const args = puppeteer().generatePuppeteerLaunchArgs()
+      expect(args.ignoreDefaultArgs).toContain('--disable-extensions')
+    } finally {
+      delete process.env.CHROME_ENABLE_EXTENSIONS
+    }
+  })
+})

--- a/test/utils/wsl.ts
+++ b/test/utils/wsl.ts
@@ -1,0 +1,135 @@
+import childProcess from 'child_process'
+import fs from 'fs'
+
+jest.mock('is-wsl')
+
+const wsl = (): typeof import('../../src/utils/wsl') =>
+  require('../../src/utils/wsl')
+
+beforeEach(() => jest.resetModules())
+afterEach(() => jest.restoreAllMocks())
+
+describe('#resolveWSLPathToHost', () => {
+  it('resolves WSL path to Windows path by running wslpath', async () => {
+    expect.assertions(3)
+
+    jest
+      .spyOn(childProcess, 'execFile')
+      .mockImplementation((fn, args, cb: any): any => {
+        expect(fn).toBe('wslpath')
+        expect(args).toStrictEqual(['-m', '/mnt/c/Users/foo/bar'])
+        cb(null, '\nC:/Users/foo/bar\n', '')
+      })
+
+    expect(await wsl().resolveWSLPathToHost('/mnt/c/Users/foo/bar')).toBe(
+      'C:/Users/foo/bar'
+    )
+  })
+})
+
+describe('#resolveWSLPathToGuestSync', () => {
+  it('resolves Windows path to WSL path by running wslpath', () => {
+    expect.assertions(3)
+
+    jest
+      .spyOn(childProcess, 'spawnSync')
+      .mockImplementation((fn, args): any => {
+        expect(fn).toBe('wslpath')
+        expect(args).toStrictEqual(['-u', 'C:\\Users\\foo\\bar'])
+
+        return { stdout: '\n/mnt/c/Users/foo/bar\n' }
+      })
+
+    expect(wsl().resolveWSLPathToGuestSync('C:\\Users\\foo\\bar')).toBe(
+      '/mnt/c/Users/foo/bar'
+    )
+  })
+})
+
+describe('#resolveWindowsEnv', () => {
+  it('resolves Windows environment value by running cmd.exe', async () => {
+    expect.assertions(6)
+
+    jest
+      .spyOn(childProcess, 'execFile')
+      .mockImplementation((fn, args, cb: any): any => {
+        expect(fn).toBe('cmd.exe')
+        expect(args).toStrictEqual(['/c', 'SET', expect.any(String)])
+        cb(null, '\nTMP=123\n', '')
+      })
+
+    expect(await wsl().resolveWindowsEnv('TMP')).toBe('123')
+    expect(await wsl().resolveWindowsEnv('XXX')).toBeUndefined()
+  })
+})
+
+describe('#resolveWindowsEnvSync', () => {
+  it('resolves Windows environment value by running cmd.exe', () => {
+    expect.assertions(6)
+
+    jest
+      .spyOn(childProcess, 'spawnSync')
+      .mockImplementation((fn, args): any => {
+        expect(fn).toBe('cmd.exe')
+        expect(args).toStrictEqual(['/c', 'SET', expect.any(String)])
+
+        return { stdout: '\nTMP=123\n' }
+      })
+
+    expect(wsl().resolveWindowsEnvSync('TMP')).toBe('123')
+    expect(wsl().resolveWindowsEnvSync('XXX')).toBeUndefined()
+  })
+})
+
+describe('#isWSL', () => {
+  afterEach(() => jest.dontMock('is-wsl'))
+
+  it('returns 0 if is-wsl module returned false', () => {
+    jest.doMock('is-wsl', () => false)
+    expect(wsl().isWSL()).toBe(0)
+  })
+
+  it('returns 1 if running on WSL 1', () => {
+    jest.doMock('is-wsl', () => true)
+
+    const readFileSync = jest
+      .spyOn(fs, 'readFileSync')
+      .mockImplementation(() => '4.19.128-microsoft-standard')
+
+    expect(wsl().isWSL()).toBe(1)
+    expect(readFileSync).toHaveBeenCalledTimes(1)
+
+    // Returns cached result to prevent excessive file I/O
+    wsl().isWSL()
+    expect(readFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 2 if running on WSL 2', () => {
+    jest.doMock('is-wsl', () => true)
+
+    // https://github.com/microsoft/WSL/issues/423#issuecomment-611086412
+    jest
+      .spyOn(fs, 'readFileSync')
+      .mockImplementation(() => '4.19.128-microsoft-WSL2-standard')
+
+    expect(wsl().isWSL()).toBe(2)
+  })
+})
+
+describe('#isChromeInWSLHost', () => {
+  it('returns true if executed in WSL environment and the passed path is in WSL host', () => {
+    const isWSL = jest.spyOn(wsl(), 'isWSL')
+    const { isChromeInWSLHost } = wsl()
+
+    isWSL.mockImplementation(() => 1)
+    expect(isChromeInWSLHost('/mnt/c/Programs/Chrome/chrome.exe')).toBe(true)
+    expect(isChromeInWSLHost('/mnt/d/foo/bar/chrome')).toBe(true)
+    expect(isChromeInWSLHost('/usr/bin/chrome')).toBe(false)
+    expect(isChromeInWSLHost('/home/test/.chromium/chrome.exe')).toBe(false)
+    expect(isChromeInWSLHost(undefined)).toBe(false)
+
+    isWSL.mockImplementation(() => 0)
+    expect(isChromeInWSLHost('/mnt/c/Programs/Chrome/chrome.exe')).toBe(false)
+    expect(isChromeInWSLHost('/mnt/d/foo/bar/chrome')).toBe(false)
+  })
+})


### PR DESCRIPTION
Marp CLI will find out the executable path of Microsoft Edge for exporting slide deck into PDF, PPTX, and images if not found out Google Chrome and Chromium via `chrome-launcher` module. Chromium-based Edge is generally pre-installed to Windows 10 so Marp CLI users in Windows do no longer need to install extra Chrome browser just for exporting PDF.

## How to find Microsoft Edge binary

Unlike Google Chrome, Microsoft is not to provide a reusable module for resolving executable path of Edge. But we can refer to the code of [Edge tools for VS Code](https://github.com/microsoft/vscode-edge-devtools/blob/c0da3de89df6ea363fc5fc43bc1489bd0d7cea95/src/utils.ts#L494-L524). It also has made by Microsoft so its logic is sufficiently reliable.

I implemented an original Edge finder similar to [Chrome finder by Google](https://github.com/GoogleChrome/chrome-launcher/blob/master/src/chrome-finder.ts).  Finding paths are based on vscode-edge-devtools, and the priority simulates Google Chrome finder (Prefer canary -> dev -> beta -> stable). In Windows, Marp CLI finds out the binary from 3 different locations, Program files, Program files (x86), and local app data directory (Probably Edge for Windows has different path by environment).

### Linux and WSL

[Edge for Linux](https://www.microsoftedgeinsider.com/download?platform=linux) is not yet released at the moment so the fallback is normally not working on Linux.

However, we can fallback to Edge binary for Windows as same as Chrome finder if Marp CLI is running on WSL. This fallback is only working on WSL1. As I mentioned at #264, be aware Chromium-based browser for Windows over WSL2 is still not working.

In this PR, I've also improved how to create temporary HTML for conversion that has optimized to WSL. Marp CLI will use more reliable conversion setting when using custom  path for Linux Chrome within WSL via `CHROME_PATH` env.

Closes #199 and #288.