### PR TITLE
Mark bespoke template as not-printable and apply fallback if Puppeteer is required in bespoke template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Better support for custom Chrome path via `CHROME_PATH` env in WSL ([#288](https://github.com/marp-team/marp-cli/issues/288), [#292](https://github.com/marp-team/marp-cli/pull/292))
+- Apply workaround of printable template fallback, for broken background images caused by regression in Chrome >= 85 ([#293](https://github.com/marp-team/marp-cli/issues/293), [#294](https://github.com/marp-team/marp-cli/pull/294))
 
 ## v0.21.1 - 2020-09-12
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -78,6 +78,7 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
           return await page.close()
         } catch (e) {
           // Ignore raising error if a target page has already close
+          /* istanbul ignore next */
           if (!e.message.includes('Target closed.')) throw e
         }
       },

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -48,9 +48,11 @@ export interface TemplateResult {
   result: string
 }
 
-export type Template<T = TemplateOption> = (
+export type Template<T = TemplateOption> = ((
   locals: TemplateCoreOption & T
-) => Promise<TemplateResult>
+) => Promise<TemplateResult>) & {
+  printable?: boolean
+}
 
 export const bare: Template<TemplateBareOption> = async (opts) => {
   const rendered = opts.renderer({
@@ -69,6 +71,8 @@ export const bare: Template<TemplateBareOption> = async (opts) => {
     }),
   }
 }
+
+Object.defineProperty(bare, 'printable', { value: true })
 
 export const bespoke: Template<TemplateBespokeOption> = async (opts) => {
   const rendered = opts.renderer({
@@ -92,6 +96,9 @@ export const bespoke: Template<TemplateBespokeOption> = async (opts) => {
     }),
   }
 }
+
+// Sometimes bespoke template cannot render background images since Chrome 85
+Object.defineProperty(bespoke, 'printable', { value: false })
 
 async function libJs(fn: string) {
   return (await readFile(path.resolve(__dirname, fn))).toString()


### PR DESCRIPTION
Original report: marp-team/marp-vscode#175

Set `printable` flag to each templates, and fallback into `bare` template if tried Puppeteer conversion in not-printable template.

We've found sometimes background images using `![bg]()` are not rendered in PDF if using bespoke template and Chrome >= 85. I've recognized this problem as a regression by Chromium, and we should take this workaround until Chrome was fixed.

We could have taken to always use bare template in Puppeteer required conversion, but we have a mid term plan for the new printable handout template (#261) so `printable` flag is smart solution to keep multiple printable templates.

(Probably) we can close #293.