### PR TITLE
Patch os.arch() to fix Puppeteer issue on Apple M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Compatibility with Apple Silicon ([#301](https://github.com/marp-team/marp-cli/issues/301), [#305](https://github.com/marp-team/marp-cli/pull/305))
+
 ## v0.22.0 - 2020-10-18
 
 ### Added

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -21,6 +21,7 @@ import { ThemeSet } from './theme'
 import {
   generatePuppeteerDataDirPath,
   generatePuppeteerLaunchArgs,
+  launchPuppeteer,
 } from './utils/puppeteer'
 import { isChromeInWSLHost, resolveWSLPathToHost } from './utils/wsl'
 import { notifier } from './watcher'
@@ -461,7 +462,7 @@ export class Converter {
     if (!Converter.browser) {
       const baseArgs = generatePuppeteerLaunchArgs()
 
-      Converter.browser = await puppeteer.launch({
+      Converter.browser = await launchPuppeteer({
         ...baseArgs,
         userDataDir: await generatePuppeteerDataDirPath('marp-cli-conversion', {
           wslHost: isChromeInWSLHost(baseArgs.executablePath),

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -9,6 +9,7 @@ import { File, FileType } from './file'
 import {
   generatePuppeteerDataDirPath,
   generatePuppeteerLaunchArgs,
+  launchPuppeteer,
 } from './utils/puppeteer'
 import TypedEventEmitter from './utils/typed-event-emitter'
 import { isChromeInWSLHost } from './utils/wsl'
@@ -135,7 +136,7 @@ export class Preview extends TypedEventEmitter<Preview.Events> {
   private async launch() {
     const baseArgs = generatePuppeteerLaunchArgs()
 
-    this.puppeteerInternal = await puppeteer.launch({
+    this.puppeteerInternal = await launchPuppeteer({
       ...baseArgs,
       args: [
         ...baseArgs.args,


### PR DESCRIPTION
Apply workaround for Apple M1 by patching to `os.arch()`.

The current Puppeteer will override custom Chrome path when running on arm64: https://github.com/puppeteer/puppeteer/issues/6634

Test cases with Apple M1 have become all green.