### PR TITLE
Add fallback to Microsoft Edge for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for fallback into Microsoft Edge in Linux ([#296](https://github.com/marp-team/marp-cli/issues/296), [#307](https://github.com/marp-team/marp-cli/pull/307))
+
 ### Fixed
 
 - Compatibility with Apple Silicon ([#301](https://github.com/marp-team/marp-cli/issues/301), [#305](https://github.com/marp-team/marp-cli/pull/305))

--- a/src/utils/edge-finder.ts
+++ b/src/utils/edge-finder.ts
@@ -24,9 +24,12 @@ const linux = (): string | undefined => {
     })
   }
 
-  // TODO: Find out Microsoft Edge for Linux
-  // https://www.microsoftedgeinsider.com/en-us/download?platform=linux
-  return undefined
+  return findAccessiblePath([
+    '/opt/microsoft/msedge-canary/msedge',
+    '/opt/microsoft/msedge-dev/msedge',
+    '/opt/microsoft/msedge-beta/msedge',
+    '/opt/microsoft/msedge/msedge',
+  ])
 }
 
 const darwin = (): string | undefined =>

--- a/test/utils/edge-finder.ts
+++ b/test/utils/edge-finder.ts
@@ -117,8 +117,22 @@ describe('#findEdgeInstallation', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' })
     })
 
-    it('returns undefined', () => {
-      expect(edgeFinder.findEdgeInstallation()).toBeUndefined()
+    it('finds out the first accessible Edge from specific paths', () => {
+      const findAccessiblePath = jest
+        .spyOn(edgeFinder, 'findAccessiblePath')
+        .mockImplementation(() => '/opt/microsoft/msedge/msedge')
+
+      expect(edgeFinder.findEdgeInstallation()).toBe(
+        '/opt/microsoft/msedge/msedge'
+      )
+      expect(findAccessiblePath.mock.calls[0][0]).toMatchInlineSnapshot(`
+        Array [
+          "/opt/microsoft/msedge-canary/msedge",
+          "/opt/microsoft/msedge-dev/msedge",
+          "/opt/microsoft/msedge-beta/msedge",
+          "/opt/microsoft/msedge/msedge",
+        ]
+      `)
     })
 
     describe('on Windows WSL', () => {


### PR DESCRIPTION
Now the fallback to Microsoft Edge supports Linux binary. Marp CLI will find out the executable path from following if Linux is not running on WSL.

-  `/opt/microsoft/msedge-canary/msedge`
- `/opt/microsoft/msedge-dev/msedge`
- `/opt/microsoft/msedge-beta/msedge`
- `/opt/microsoft/msedge/msedge`

Resolves #296.