### PR TITLE
Reset cached executable Chrome path if using Marp CLI through API interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Upgrade Node.js to 14 ([#309](https://github.com/marp-team/marp-cli/pull/309))
 - Upgrade dependent packages to the latest version ([#309](https://github.com/marp-team/marp-cli/pull/309))
 
+### Fixed
+
+- Reset cached executable Chrome path if using Marp CLI through API interface ([#310](https://github.com/marp-team/marp-cli/pull/310))
+
 ## v0.22.1 - 2020-11-28
 
 ### Added

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -9,6 +9,7 @@ import { File, FileType } from './file'
 import { Preview, fileToURI } from './preview'
 import { Server } from './server'
 import templates from './templates'
+import { resetExecutablePath } from './utils/puppeteer'
 import version from './version'
 import watcher, { Watcher, notifier } from './watcher'
 
@@ -384,11 +385,14 @@ export const waitForObservation = () =>
     resolversForObservation.push(res)
   })
 
-export const apiInterface = async (argv: string[] = []) =>
-  marpCli(argv, {
+export const apiInterface = (argv: string[] = []) => {
+  resetExecutablePath()
+
+  return marpCli(argv, {
     stdin: false,
     throwErrorAlways: true,
   })
+}
 
 export const cliInterface = (argv: string[] = []) =>
   marpCli(argv, {

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -93,3 +93,7 @@ export const launchPuppeteer = (
     os.arch = arch
   }
 }
+
+export const resetExecutablePath = () => {
+  executablePath = false
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { buffer as stdinBuffer } from 'get-stdin'
 import api, { CLIError } from '../src/index'
 import * as marpCli from '../src/marp-cli'
+import * as puppeteerUtil from '../src/utils/puppeteer'
 
 afterEach(() => {
   jest.restoreAllMocks()
@@ -40,5 +41,19 @@ describe('Marp CLI API interface', () => {
 
     expect(await marpCli.cliInterface(['-c', fakePath])).toBeGreaterThan(0)
     await expect(api(['-c', fakePath])).rejects.toBeInstanceOf(CLIError)
+  })
+
+  it('resets cached Chrome path every time', async () => {
+    const resetExecutablePathSpy = jest.spyOn(
+      puppeteerUtil,
+      'resetExecutablePath'
+    )
+    jest.spyOn(marpCli, 'marpCli').mockResolvedValue(0)
+
+    await api([])
+    expect(resetExecutablePathSpy).toHaveBeenCalledTimes(1)
+
+    await api([])
+    expect(resetExecutablePathSpy).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
Marp CLI's API interface on Marp for VS Code is requiring restart of VS Code after changed the custom Chrome path because of cached executable path.

This PR makes to reset cached path  every time when calling API interface.
