### PR TITLE
Throw better error when spawning snap Chromium from another snap app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Throw better error when spawning snap Chromium from another snap app ([#317](https://github.com/marp-team/marp-cli/pull/317))
+
 ## v0.23.0 - 2020-12-05
 
 ### Changed

--- a/src/error.ts
+++ b/src/error.ts
@@ -18,6 +18,7 @@ export enum CLIErrorCode {
   GENERAL_ERROR = 1,
   NOT_FOUND_CHROMIUM = 2,
   LISTEN_PORT_IS_ALREADY_USED = 3,
+  CANNOT_SPAWN_SNAP_CHROMIUM = 4,
 }
 
 export function error(

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -100,7 +100,7 @@ export const launchPuppeteer = async (
         /^need to run as root or suid$/im.test(e.message)
       ) {
         error(
-          'Marp CLI has detected trying to spawn Chromium browser installed by snap, from the confined environment like another snap app. At least either of Chrome/Chromium or terminal must be non snap app.',
+          'Marp CLI has detected trying to spawn Chromium browser installed by snap, from the confined environment like another snap app. At least either of Chrome/Chromium or the shell environment must be non snap app.',
           CLIErrorCode.CANNOT_SPAWN_SNAP_CHROMIUM
         )
       }

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -10,6 +10,9 @@ import { isWSL, resolveWindowsEnv } from './wsl'
 let executablePath: string | undefined | false = false
 let wslTmp: string | undefined
 
+const isSnapBrowser = (path: string | undefined) =>
+  !!(process.platform === 'linux' && path?.startsWith('/snap/'))
+
 export const generatePuppeteerDataDirPath = async (
   name: string,
   { wslHost }: { wslHost?: boolean } = {}
@@ -63,7 +66,7 @@ export const generatePuppeteerLaunchArgs = () => {
   return {
     executablePath,
     args: [...args],
-    pipe: !isWSL(),
+    pipe: !(isWSL() || isSnapBrowser(executablePath)),
 
     // Workaround to avoid force-extensions policy for Chrome enterprise (SET CHROME_ENABLE_EXTENSIONS=1)
     // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-windows
@@ -75,8 +78,8 @@ export const generatePuppeteerLaunchArgs = () => {
   }
 }
 
-export const launchPuppeteer = (
-  ...args: Parameters<typeof puppeteer['launch']>
+export const launchPuppeteer = async (
+  ...[options]: Parameters<typeof puppeteer['launch']>
 ) => {
   const { arch } = os
 
@@ -88,7 +91,22 @@ export const launchPuppeteer = (
       return arch()
     }
 
-    return puppeteer.launch(...args)
+    return await puppeteer.launch(options)
+  } catch (e) {
+    if (e instanceof Error) {
+      if (
+        options?.executablePath &&
+        isSnapBrowser(options.executablePath) &&
+        /^need to run as root or suid$/im.test(e.message)
+      ) {
+        error(
+          'Marp CLI has detected trying to spawn Chromium browser installed by snap, from the confined environment like another snap app. At least either of Chrome/Chromium or terminal must be non snap app.',
+          CLIErrorCode.CANNOT_SPAWN_SNAP_CHROMIUM
+        )
+      }
+    }
+
+    throw e
   } finally {
     os.arch = arch
   }


### PR DESCRIPTION
If the shell environment is working in restricted by snap app (enabled AppArmor), Marp CLI may not spawn Chromium through installed from Snap store. (#287)
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1849753

This PR will throw better error spawning snap Chromium from the restricted shell environment, such as another snap app. This is useful to show warning in the combination of snap version of VS Code + Marp for VS Code.