### PR TITLE
Use Noto CJK font instead of broken font-ipa in Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Throw better error when spawning snap Chromium from another snap app ([#317](https://github.com/marp-team/marp-cli/pull/317))
 
+### Changed
+
+- Use Noto CJK font instead of broken font-ipa in Docker image ([#318](https://github.com/marp-team/marp-cli/pull/318))
+
 ## v0.23.0 - 2020-12-05
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,11 @@ RUN apk update && apk upgrade && \
       freetype@edge \
       libstdc++@edge \
       harfbuzz@edge \
-      wqy-zenhei@edge \
       ttf-liberation@edge \
+      font-noto-cjk@edge \
       font-noto-devanagari@edge \
       font-noto-arabic@edge \
       font-noto-bengali@edge \
-      font-ipa@edge \
       nss@edge
 
 RUN addgroup -S marp && adduser -S -g marp marp \


### PR DESCRIPTION
Marp CLI official docker image has many international fonts (#26). But [the latest build has broken `font-ipa` font for Japanese](https://app.circleci.com/pipelines/github/marp-team/marp-cli/486/workflows/bfb69491-2512-490f-be40-a74a60a76045/jobs/3774).

Thus, I've updated Dockerfile to install Noto Sans CJK instead of broken `font-ipa` and existing Chinese font `wqy-zenhei`. It includes Chinese, Japanese, and Korean fonts.
