### PR TITLE
Optimize bespoke template for bfcache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Optimize bespoke template for bfcache ([#323](https://github.com/marp-team/marp-cli/pull/323))
+
 ## v0.23.2 - 2021-02-11
 
 ### Changed

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -12,13 +12,16 @@ import bespokeProgress from './progress'
 import bespokeState from './state'
 import bespokeSync from './sync'
 import bespokeTouch from './touch'
-import { getViewMode, popQuery, setQuery, setViewMode, ViewMode } from './utils'
+import { getViewMode, popQuery, setViewMode, ViewMode } from './utils'
 import bespokeWakeLock from './wake-lock'
 
 const pattern = [ViewMode.Normal, ViewMode.Presenter, ViewMode.Next] as const
 
 const parse = (
-  ...patterns: [[boolean, boolean, boolean], (...args: unknown[]) => void][]
+  ...patterns: [
+    [normalView: boolean, presnterView: boolean, nextView: boolean],
+    (...args: unknown[]) => void
+  ][]
 ) => {
   const idx = pattern.findIndex((v) => getViewMode() === v)
   if (idx < 0) throw new Error('Invalid view')
@@ -55,11 +58,6 @@ export default function bespokeTemplate(
       [[x, x, _], bespokeWakeLock]
     )
   )
-
-  window.addEventListener('beforeunload', () =>
-    setQuery({ sync: deck.syncKey })
-  )
-  window.addEventListener('pagehide', () => deck.destroy())
 
   return deck
 }

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -59,7 +59,7 @@ export default function bespokeTemplate(
   window.addEventListener('beforeunload', () =>
     setQuery({ sync: deck.syncKey })
   )
-  window.addEventListener('unload', () => deck.destroy())
+  window.addEventListener('pagehide', () => deck.destroy())
 
   return deck
 }

--- a/src/templates/bespoke/bespoke.ts
+++ b/src/templates/bespoke/bespoke.ts
@@ -15,15 +15,15 @@ import bespokeTouch from './touch'
 import { getViewMode, popQuery, setViewMode, ViewMode } from './utils'
 import bespokeWakeLock from './wake-lock'
 
-const pattern = [ViewMode.Normal, ViewMode.Presenter, ViewMode.Next] as const
-
 const parse = (
   ...patterns: [
     [normalView: boolean, presnterView: boolean, nextView: boolean],
     (...args: unknown[]) => void
   ][]
 ) => {
-  const idx = pattern.findIndex((v) => getViewMode() === v)
+  const idx = [ViewMode.Normal, ViewMode.Presenter, ViewMode.Next].findIndex(
+    (v) => getViewMode() === v
+  )
   if (idx < 0) throw new Error('Invalid view')
 
   return patterns.map(([pat, plugin]) => pat[idx] && plugin).filter((p) => p)

--- a/src/templates/bespoke/presenter/next-view.ts
+++ b/src/templates/bespoke/presenter/next-view.ts
@@ -20,5 +20,4 @@ export default function nextView(deck) {
   }
 
   window.addEventListener('message', listener)
-  deck.on('destroy', () => window.removeEventListener('message', listener))
 }

--- a/src/templates/bespoke/sync.ts
+++ b/src/templates/bespoke/sync.ts
@@ -38,8 +38,10 @@ export default function bespokeSync(opts: BespokeSyncOption = {}) {
     return newState
   }
 
-  const initialize = () =>
+  const initialize = () => {
+    window.removeEventListener('pageshow', initialize)
     setState((prev) => ({ reference: (prev.reference || 0) + 1 }))
+  }
 
   return (deck) => {
     initialize()
@@ -90,14 +92,11 @@ export default function bespokeSync(opts: BespokeSyncOption = {}) {
       }
     }
 
-    deck.on('destroy', destructor)
-
-    window.addEventListener('pagehide', (e) => {
-      if (e.persisted) {
-        window.removeEventListener('pageshow', initialize)
-        window.addEventListener('pageshow', initialize)
-      }
+    window.addEventListener('pagehide', (e: PageTransitionEvent) => {
+      if (e.persisted) window.addEventListener('pageshow', initialize)
       destructor()
     })
+
+    deck.on('destroy', destructor)
   }
 }

--- a/src/templates/bespoke/utils.ts
+++ b/src/templates/bespoke/utils.ts
@@ -63,8 +63,8 @@ export const setQuery = (
 
   try {
     options.setter(
-      null,
-      document.title,
+      { ...(window.history.state ?? {}) },
+      '',
       generateURLfromParams(params, options.location)
     )
   } catch (e) {
@@ -72,6 +72,9 @@ export const setQuery = (
     console.error(e)
   }
 }
+
+export const setHistoryState = (state: Record<string, any>) =>
+  setQuery({}, { setter: (s, ...r) => replacer({ ...s, ...state }, ...r) })
 
 export const setViewMode = () =>
   document.body.setAttribute(

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -970,6 +970,8 @@ describe("Bespoke template's browser context", () => {
     beforeEach(() => render(markdown))
 
     it('defines auto-generated deck.syncKey', () => {
+      jest.spyOn(history, 'state', 'get').mockImplementation(() => null)
+
       const deck = bespoke()
       expect(typeof deck.syncKey).toBe('string')
     })

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -15,6 +15,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
+  window.dispatchEvent(new Event('pagehide'))
   window.dispatchEvent(new Event('unload'))
   jest.restoreAllMocks()
   jest.clearAllTimers()

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -15,7 +15,9 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  window.dispatchEvent(new Event('pagehide'))
+  window.dispatchEvent(
+    new PageTransitionEvent('pagehide', { persisted: false })
+  )
   window.dispatchEvent(new Event('unload'))
   jest.restoreAllMocks()
   jest.clearAllTimers()
@@ -1064,6 +1066,25 @@ describe("Bespoke template's browser context", () => {
         deck.next()
         await updateStore('test', { reference: 2 })
         expect(deck.slide()).toBe(2)
+      })
+    })
+
+    describe('when leaved from the slide with bfcache', () => {
+      it('adds event listener for pageshow event to increment reference count', () => {
+        replaceLocation('/?sync=bfcache', () => {
+          bespoke()
+          expect(getStore('bfcache').reference).toBe(1)
+
+          window.dispatchEvent(
+            new PageTransitionEvent('pagehide', { persisted: true })
+          )
+          expect(getStore('bfcache')).toBeNull()
+
+          window.dispatchEvent(
+            new PageTransitionEvent('pageshow', { persisted: true })
+          )
+          expect(getStore('bfcache').reference).toBe(1)
+        })
       })
     })
 


### PR DESCRIPTION
[Back/forward cache](https://web.dev/bfcache/) (a.k.a bfcache) is the browser optimization for enabling instant back and forward navigation. Firefox and Safari have enabled while a long time, and recently it has added to Chrome for mobile.

Marp CLI's bespoke template has disabled bfcache by adding `unload` event. So I refactored some bespoke plugins to use new Page Lifecycle API. A notable change is in sync plugin: Persist sync key between navigation, through history state instead of URL query parameter.

By this change, the slide HTML can get a 100% Lighthouse Best Practice score.