### PR TITLE
Generate output files under configurable ID, e.g. as the current user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !rollup.config.js
 !tsconfig.json
 !yarn.lock
+!entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apk update && apk upgrade && \
       font-noto-devanagari@edge \
       font-noto-arabic@edge \
       font-noto-bengali@edge \
-      nss@edge
+      nss@edge \
+      su-exec
 
 RUN addgroup -S marp && adduser -S -g marp marp \
     && mkdir -p /home/marp/app /home/marp/.cli \
@@ -31,6 +32,10 @@ RUN yarn add puppeteer-core@chrome-$(chromium-browser --version | sed -r 's/^Chr
 RUN yarn install && yarn build && rm -rf ./src ./node_modules && yarn install --production && yarn cache clean \
     && node /home/marp/.cli/marp-cli.js --version
 
+USER root
+
+ENV MARPID marp:marp
+
 WORKDIR /home/marp/app
-ENTRYPOINT ["node", "/home/marp/.cli/marp-cli.js"]
+ENTRYPOINT ["/home/marp/.cli/entrypoint"]
 CMD ["--help"]

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+exec su-exec "$MARPID" node /home/marp/.cli/marp-cli.js "$@"


### PR DESCRIPTION
Currently, the docker image generates output under the ID of the marp user created inside the image at build time. Usually this will be different from the current user, so it fails unless writing to a world writable location. Also, the file generated has a different owner from the current user. 

This PR allows the user to specify a different ID to generate the output. 

I suggest adding to the instructions on docker hub: 

# Convert slide deck into HTML, specifying ownership of output file
docker run --rm -v $PWD:/home/marp/app/ -e LANG=$LANG -e MARPID="$(id -u):$(id -g)" marpteam/marp-cli slide-deck.md


Thanks for an excellent product, it's a lot of fun to use!