### PR TITLE
Update Bespoke navigation plugin to adjust wheel sensitivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "supertest": "^6.1.3",
     "tar-stream": "^2.2.0",
     "ts-jest": "^26.5.5",
-    "ts-keycode-enum": "^1.0.6",
+    "ts-key-enum": "^2.0.7",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4",
     "vhtml": "^2.2.0",

--- a/src/templates/bespoke/fullscreen.ts
+++ b/src/templates/bespoke/fullscreen.ts
@@ -8,7 +8,7 @@ export default function bespokeFullscreen(deck) {
   document.addEventListener('keydown', (e) => {
     // `f` or F11 without modifier key Alt, Control, and Command
     if (
-      (e.which === 70 || e.which === 122) &&
+      (e.key === 'f' || e.key === 'F11') &&
       !e.altKey &&
       !e.ctrlKey &&
       !e.metaKey &&

--- a/src/templates/bespoke/navigation.ts
+++ b/src/templates/bespoke/navigation.ts
@@ -8,28 +8,30 @@ enum Direction {
 }
 
 export default function bespokeNavigation({
-  interval = 200,
+  interval = 250,
 }: BespokeNavigationOption = {}) {
   return (deck) => {
     document.addEventListener('keydown', (e) => {
-      if (e.which === 32 && e.shiftKey) {
-        // Space + Shift: Previous page
-        deck.prev()
-      } else if (e.which === 33 || e.which === 37 || e.which === 38) {
-        // Page Up | LEFT | UP: Previous page (Skip fragments if holding shift)
-        deck.prev({ fragment: !e.shiftKey })
-      } else if (e.which === 32 && !e.shiftKey) {
-        // Space: Next page
-        deck.next()
-      } else if (e.which === 34 || e.which === 39 || e.which === 40) {
-        // Page Down | RIGHT | DOWN: Next page (Skip fragments if holding shift)
-        deck.next({ fragment: !e.shiftKey })
-      } else if (e.which === 35) {
-        // END: Jump to last page
-        deck.slide(deck.slides.length - 1, { fragment: -1 })
-      } else if (e.which === 36) {
-        // HOME: Jump to first page
-        deck.slide(0)
+      if (e.key === ' ' && e.shiftKey) {
+        deck.prev() // Previous page
+      } else if (
+        e.key === 'ArrowLeft' ||
+        e.key === 'ArrowUp' ||
+        e.key === 'PageUp'
+      ) {
+        deck.prev({ fragment: !e.shiftKey }) // Previous page (Skip fragments if holding shift)
+      } else if (e.key === ' ' && !e.shiftKey) {
+        deck.next() // Next page
+      } else if (
+        e.key === 'ArrowRight' ||
+        e.key === 'ArrowDown' ||
+        e.key === 'PageDown'
+      ) {
+        deck.next({ fragment: !e.shiftKey }) // Next page (Skip fragments if holding shift)
+      } else if (e.key === 'End') {
+        deck.slide(deck.slides.length - 1, { fragment: -1 }) // Jump to last page
+      } else if (e.key === 'Home') {
+        deck.slide(0) // Jump to first page
       } else {
         return
       }
@@ -54,6 +56,9 @@ export default function bespokeNavigation({
       if (scrollable) return
 
       e.preventDefault()
+
+      // Prevent too sensitive navigation on trackpad
+      if (Math.abs(e.wheelDelta) < 20) return
 
       // Suppress momentum scrolling by trackpad
       if (wheelIntervalTimer) clearTimeout(wheelIntervalTimer)

--- a/src/templates/bespoke/presenter/normal-view.ts
+++ b/src/templates/bespoke/presenter/normal-view.ts
@@ -20,7 +20,7 @@ export default function normalView(deck) {
   if (storage.available)
     document.addEventListener('keydown', (e) => {
       // `p` without modifier key (Alt, Control, and Command)
-      if (e.which === 80 && !e.altKey && !e.ctrlKey && !e.metaKey) {
+      if (e.key === 'p' && !e.altKey && !e.ctrlKey && !e.metaKey) {
         e.preventDefault()
         deck.openPresenterView()
       }

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -2,7 +2,7 @@
 import Marp from '@marp-team/marp-core'
 import { Element as MarpitElement } from '@marp-team/marpit'
 import { default as screenfull, Screenfull } from 'screenfull'
-import { Key } from 'ts-keycode-enum'
+import { Key } from 'ts-key-enum'
 import bespoke from '../../src/templates/bespoke/bespoke'
 import { classes } from '../../src/templates/bespoke/presenter/presenter-view'
 import { _clearCachedWakeLockApi } from '../../src/templates/bespoke/wake-lock'
@@ -235,12 +235,12 @@ describe("Bespoke template's browser context", () => {
     })
 
     it('toggles fullscreen by hitting f key', () => {
-      keydown({ which: Key.F })
+      keydown({ key: 'f' })
       expect((screenfull as Screenfull).toggle).toHaveBeenCalled()
     })
 
     it('toggles fullscreen by hitting F11 key', () => {
-      keydown({ which: Key.F11 })
+      keydown({ key: Key.F11 })
       expect((screenfull as Screenfull).toggle).toHaveBeenCalled()
     })
   })
@@ -339,12 +339,12 @@ describe("Bespoke template's browser context", () => {
         const deck = bespoke()
 
         keydown(
-          { bubbles: true, which: Key.RightArrow },
+          { bubbles: true, key: Key.ArrowRight },
           document.getElementById('element')! // eslint-disable-line @typescript-eslint/no-non-null-assertion
         )
         expect(deck.slide()).toBe(0)
 
-        keydown({ bubbles: true, which: Key.RightArrow }, deck.slides[0])
+        keydown({ bubbles: true, key: Key.ArrowRight }, deck.slides[0])
         expect(deck.slide()).toBe(1)
       })
     }
@@ -368,34 +368,34 @@ describe("Bespoke template's browser context", () => {
       render()
       const deck = bespoke()
 
-      keydown({ which: Key.RightArrow })
+      keydown({ key: Key.ArrowRight })
       expect(deck.slide()).toBe(1)
 
-      keydown({ which: Key.LeftArrow })
+      keydown({ key: Key.ArrowLeft })
       expect(deck.slide()).toBe(0)
 
-      keydown({ which: Key.Space })
+      keydown({ key: ' ' })
       expect(deck.slide()).toBe(1)
 
-      keydown({ which: Key.Space, shiftKey: true })
+      keydown({ key: ' ', shiftKey: true })
       expect(deck.slide()).toBe(0)
 
-      keydown({ which: Key.PageDown })
+      keydown({ key: Key.PageDown })
       expect(deck.slide()).toBe(1)
 
-      keydown({ which: Key.PageUp })
+      keydown({ key: Key.PageUp })
       expect(deck.slide()).toBe(0)
 
-      keydown({ which: Key.DownArrow })
+      keydown({ key: Key.ArrowDown })
       expect(deck.slide()).toBe(1)
 
-      keydown({ which: Key.UpArrow })
+      keydown({ key: Key.ArrowUp })
       expect(deck.slide()).toBe(0)
 
-      keydown({ which: Key.End })
+      keydown({ key: Key.End })
       expect(deck.slide()).toBe(2)
 
-      keydown({ which: Key.Home })
+      keydown({ key: Key.Home })
       expect(deck.slide()).toBe(0)
     })
 
@@ -403,34 +403,34 @@ describe("Bespoke template's browser context", () => {
       render('* A\n* B\n* C\n\n---\n\n* D\n* E')
       const deck = bespoke()
 
-      keydown({ which: Key.RightArrow, shiftKey: true })
+      keydown({ key: Key.ArrowRight, shiftKey: true })
       expect(deck.slide()).toBe(0)
       expect(deck.fragmentIndex).toBe(3)
 
-      keydown({ which: Key.DownArrow, shiftKey: true })
+      keydown({ key: Key.ArrowDown, shiftKey: true })
       expect(deck.slide()).toBe(1)
       expect(deck.fragmentIndex).toBe(2)
 
-      keydown({ which: Key.LeftArrow, shiftKey: true })
+      keydown({ key: Key.ArrowLeft, shiftKey: true })
       expect(deck.slide()).toBe(0)
       expect(deck.fragmentIndex).toBe(3)
 
-      keydown({ which: Key.RightArrow })
+      keydown({ key: Key.ArrowRight })
       expect(deck.slide()).toBe(1)
       expect(deck.fragmentIndex).toBe(0)
 
-      keydown({ which: Key.PageDown, shiftKey: true })
+      keydown({ key: Key.PageDown, shiftKey: true })
       expect(deck.fragmentIndex).toBe(2)
 
-      keydown({ which: Key.UpArrow, shiftKey: true })
+      keydown({ key: Key.ArrowUp, shiftKey: true })
       expect(deck.slide()).toBe(0)
       expect(deck.fragmentIndex).toBe(3)
 
-      keydown({ which: Key.RightArrow })
+      keydown({ key: Key.ArrowRight })
       expect(deck.slide()).toBe(1)
       expect(deck.fragmentIndex).toBe(0)
 
-      keydown({ which: Key.PageUp, shiftKey: true })
+      keydown({ key: Key.PageUp, shiftKey: true })
       expect(deck.slide()).toBe(0)
       expect(deck.fragmentIndex).toBe(3)
     })
@@ -711,13 +711,13 @@ describe("Bespoke template's browser context", () => {
 
       it('opens presenter view by hitting p key', () => {
         bespoke()
-        keydown({ which: Key.P })
+        keydown({ key: 'p' })
         expect(window.open).toHaveBeenCalled()
 
         // Ignore hitting p key with modifier
         ;(window.open as jest.Mock).mockClear()
 
-        keydown({ which: Key.P, ctrlKey: true })
+        keydown({ key: 'p', ctrlKey: true })
         expect(window.open).not.toHaveBeenCalled()
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -9143,10 +9143,10 @@ ts-jest@^26.5.5:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-keycode-enum@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ts-keycode-enum/-/ts-keycode-enum-1.0.6.tgz#aeefd1c2fc7b0557f86a0e696e300905bbb4c1c1"
-  integrity sha512-DF8+Cf/FJJnPRxwz8agCoDelQXKZWQOS/gnnwx01nZ106tPJdB3BgJ9QTtLwXgR82D8O+nTjuZzWgf0Rg4vuRA==
+ts-key-enum@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/ts-key-enum/-/ts-key-enum-2.0.7.tgz#ea2c6f3bd770257a3d70fd60625bc3e99d19ab1e"
+  integrity sha512-i5K1p6o5J2EMNS3DVpVdpsJnFMWNE01kBjnw5evS/XgBYiu/oo/mxamOOEVYn/uPbIaxl5iDVSbAcFCDY55tmw==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
This PR includes changed for adjustment wheel sensitivity, and stopped using deprecated `event.which`.

Resolves #340.

## Wheel sensitivity

Based on the feedback in #340, the navigation through mouse wheel has updated to make a threshold of wheel delta for triggering page navigation.

Multi-touch device such as Magic Trackpad and Magic Mouse will tell a wheel event in much high resolution (wheel delta 3) than the common wheel mouse (wheel delta 120). So the wheel event for navigation was emitted sensitively because events were triggered by a slightly move of a finger, especially on the Magic Mouse.

We should follow these requirements:

- Must not too sensitive to a slight movement of a finger on Magic Mouse.
- Must not too insensitive to the scroll/swipe gesture on Magic Trackpad and Magic Mouse.
- The wheel navigation by the regular mouse must work as usual like the other presentation software.

This PR will change not to trigger the navigation against the wheel event with the delta value that was less than 20. It should be reduced unexpected navigation from the fine movement of a finger on Magic Mouse.

For the trackpad user, this change may feel like making insensitive against the scroll/swipe gesture. Welcome the feedback continuously.