### PR TITLE
Hide Chocolately repository from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,16 @@ Also you can use the package manager to install/update Marp CLI standalone binar
 #### Windows
 
 - **[Scoop](https://scoop.sh/)**: `scoop install marp` ([Refer to the manifest in official Main bucket...](https://github.com/ScoopInstaller/Main/blob/master/bucket/marp.json))
+
+<!--
+
+[Marp team must not recommend a way to install for vulnerable outdated version.]
+
 - **[Chocolatey](https://chocolatey.org/)**: `choco install marp-cli` ([Refer to the package information...](https://chocolatey.org/packages/marp-cli))
 
 > _Disclaimer: These packages and manifests are maintained by the others, not Marp team._
+
+-->
 
 [releases]: https://github.com/marp-team/marp-cli/releases
 


### PR DESCRIPTION
Chocolately repository is not maintained actively: https://github.com/zverev-iv/choco-marp-cli/issues/13

Marp team is thinking user's security first, and the latest version has included some vulneribillity fixes. _We must not recommend a way to install for vulnerable outdated version in README._