### PR TITLE
Refactor for Node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "is-wsl": "^2.2.0",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
-    "mkdirp": "^1.0.4",
     "nanoid": "^3.1.23",
     "npm-run-all": "^4.1.5",
     "os-locale": "^5.0.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
 import { Marp } from '@marp-team/marp-core'
 import chalk from 'chalk'
 import { cosmiconfig } from 'cosmiconfig'
@@ -12,8 +11,6 @@ import resolveEngine, { ResolvableEngine, ResolvedEngine } from './engine'
 import { error } from './error'
 import { TemplateOption } from './templates'
 import { Theme, ThemeSet } from './theme'
-
-const lstat = promisify(fs.lstat)
 
 type Overwrite<T, U> = Omit<T, Extract<keyof T, keyof U>> & U
 
@@ -248,7 +245,7 @@ export class MarpCLIConfig {
     let stat: fs.Stats
 
     try {
-      stat = await lstat(dir)
+      stat = await fs.promises.lstat(dir)
     } catch (e) {
       if (e.code !== 'ENOENT') throw e
       error(`Input directory "${dir}" is not found.`)

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,9 +20,6 @@ import serverIndex from './server/index.pug'
 import style from './server/index.scss'
 import TypedEventEmitter from './utils/typed-event-emitter'
 
-const stat = promisify(fs.stat)
-const readFile = promisify(fs.readFile)
-
 export class Server extends TypedEventEmitter<Server.Events> {
   readonly converter: Converter
   readonly inputDir: string
@@ -114,7 +111,9 @@ export class Server extends TypedEventEmitter<Server.Events> {
   private async loadScript() {
     if (Server.script === undefined) {
       Server.script = (
-        await readFile(path.resolve(__dirname, './server/server-index.js'))
+        await fs.promises.readFile(
+          path.resolve(__dirname, './server/server-index.js')
+        )
       ).toString()
     }
 
@@ -223,7 +222,7 @@ export class Server extends TypedEventEmitter<Server.Events> {
     // Check file stat
     let stats: fs.Stats | undefined
     try {
-      stats = fetchedStats || (await stat(targetPath))
+      stats = fetchedStats || (await fs.promises.stat(targetPath))
       valid = valid && !!stats?.isFile()
     } catch (e) {
       valid = false

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,13 +1,10 @@
 import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
 import { Element, Options, RenderResult } from '@marp-team/marpit'
 import barePug from './bare/bare.pug'
 import bareScss from './bare/bare.scss'
 import bespokePug from './bespoke/bespoke.pug'
 import bespokeScss from './bespoke/bespoke.scss'
-
-const readFile = promisify(fs.readFile)
 
 type RendererResult = RenderResult &
   TemplateMeta & {
@@ -101,7 +98,7 @@ export const bespoke: Template<TemplateBespokeOption> = async (opts) => {
 Object.defineProperty(bespoke, 'printable', { value: false })
 
 async function libJs(fn: string) {
-  return (await readFile(path.resolve(__dirname, fn))).toString()
+  return (await fs.promises.readFile(path.resolve(__dirname, fn))).toString()
 }
 
 async function watchJs(notifyWS?: string) {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,14 +1,10 @@
 /* eslint-disable import/export, @typescript-eslint/no-namespace */
 import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
 import { Marpit } from '@marp-team/marpit'
 import { hasMagic } from 'globby'
 import { warn } from './cli'
 import { File } from './file'
-
-const lstat = promisify(fs.lstat)
-const readFile = promisify(fs.readFile)
 
 export class Theme {
   readonly filename: string
@@ -36,7 +32,7 @@ export class Theme {
   }
 
   async load() {
-    this.readBuffer = await readFile(this.filename)
+    this.readBuffer = await fs.promises.readFile(this.filename)
   }
 
   private genUniqName() {
@@ -128,7 +124,7 @@ export class ThemeSet {
       // globby's hasMagic (backed by fast-glob) always recognizes "\\" (Windows path separator) as the escape character.
       if (!hasMagic(f.split(path.sep).join('/'))) {
         try {
-          const stat: fs.Stats = await lstat(f)
+          const stat: fs.Stats = await fs.promises.lstat(f)
 
           if (stat.isFile() || stat.isDirectory() || stat.isSymbolicLink())
             fnForWatch.add(path.resolve(f))

--- a/test/__mocks__/express.ts
+++ b/test/__mocks__/express.ts
@@ -2,14 +2,25 @@ import { EventEmitter } from 'events'
 
 const express = jest.requireActual('express')
 
+express.__errorOnListening = undefined
 express.application.listen = jest.fn(() => {
   const serverMock = Object.assign(new EventEmitter(), {
     close: (callback) => callback(),
   })
 
-  setTimeout(() => serverMock.emit('listening'), 0)
+  setTimeout(() => {
+    if (express.__errorOnListening) {
+      serverMock.emit('error', express.__errorOnListening)
+    } else {
+      serverMock.emit('listening')
+    }
+  }, 0)
 
   return serverMock
 })
 
 module.exports = express
+
+beforeEach(() => {
+  express.__errorOnListening = undefined
+})

--- a/test/__mocks__/fs.ts
+++ b/test/__mocks__/fs.ts
@@ -7,7 +7,12 @@ fs.writeFile[promisify.custom] = (path, data) =>
     fs.writeFile(path, data, (e) => (e ? reject(e) : resolve()))
   )
 
-fs.__mockWriteFile = (mockFn = (_, __, callback) => callback()) =>
-  jest.spyOn(fs, 'writeFile').mockImplementation(mockFn)
+fs.__mockWriteFile = (mockFn = (_, __, callback) => callback()) => {
+  jest
+    .spyOn(fs.promises, 'writeFile')
+    .mockImplementation(fs.writeFile[promisify.custom])
+
+  return jest.spyOn(fs, 'writeFile').mockImplementation(mockFn)
+}
 
 module.exports = fs


### PR DESCRIPTION
- Use `fs.promises` functions instead of promisified functions. Node 12 no longer output experimental warning.
- Remove `mkdirp` module and use `fs.mkdir` with `recursive: true` option.
- Cover not tested codes to deal with coverage warning from codecov.