### PR TITLE
Add installation guide for Homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Installation guide for Homebrew ([#353](https://github.com/marp-team/marp-cli/pull/353))
+
+### Removed
+
+- Installation guide for not-maintained Chocolatey ([#350](https://github.com/marp-team/marp-cli/pull/350))
+
 ## v1.1.1 - 2021-05-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm install -g @marp-team/marp-cli
 You can use the package manager to install/update Marp CLI easily.
 
 - **macOS**
-  - **[Homebrew](https://brew.sh/)**: `brew install marp-cli` ([Refer to the formulae...](https://github.com/Homebrew/homebrew-core/blob/master/Formula/marp-cli.rb))
+  - **[Homebrew](https://brew.sh/)**: `brew install marp-cli` ([Refer to the formula...](https://github.com/Homebrew/homebrew-core/blob/master/Formula/marp-cli.rb))
 
 * **Windows**
   - **[Scoop](https://scoop.sh/)**: `scoop install marp` ([Refer to the manifest in Main bucket...](https://github.com/ScoopInstaller/Main/blob/master/bucket/marp.json))

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm install --save-dev @marp-team/marp-cli
 
 The installed `marp` command is available in [npm-scripts](https://docs.npmjs.com/misc/scripts) or `npx marp`.
 
-### Global installation
+#### Global installation
 
 You can install with `-g` option if you want to use `marp` command globally.
 
@@ -75,27 +75,23 @@ You can install with `-g` option if you want to use `marp` command globally.
 npm install -g @marp-team/marp-cli
 ```
 
+### Use package manager
+
+You can use the package manager to install/update Marp CLI easily.
+
+- **macOS**
+  - **[Homebrew](https://brew.sh/)**: `brew install marp-cli` ([Refer to the formula...](https://github.com/Homebrew/homebrew-core/blob/master/Formula/marp-cli.rb))
+
+* **Windows**
+  - **[Scoop](https://scoop.sh/)**: `scoop install marp` ([Refer to the manifest in Main bucket...](https://github.com/ScoopInstaller/Main/blob/master/bucket/marp.json))
+
+_Disclaimer: Package manifests are maintained by the community, not Marp team._
+
 ### [Standalone binary][releases]
 
-Do you never want to install any dependent tools? We also provide executable binaries for Linux, macOS, and Windows.
+We also provide standalone binaries for Linux, macOS, and Windows.
 
 **[:fast_forward: Download the latest standalone binary from release page.][releases]**
-
-Also you can use the package manager to install/update Marp CLI standalone binary.
-
-#### Windows
-
-- **[Scoop](https://scoop.sh/)**: `scoop install marp` ([Refer to the manifest in official Main bucket...](https://github.com/ScoopInstaller/Main/blob/master/bucket/marp.json))
-
-<!--
-
-[Marp team must not recommend a way to install for vulnerable outdated version.]
-
-- **[Chocolatey](https://chocolatey.org/)**: `choco install marp-cli` ([Refer to the package information...](https://chocolatey.org/packages/marp-cli))
-
-> _Disclaimer: These packages and manifests are maintained by the others, not Marp team._
-
--->
 
 [releases]: https://github.com/marp-team/marp-cli/releases
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm install -g @marp-team/marp-cli
 You can use the package manager to install/update Marp CLI easily.
 
 - **macOS**
-  - **[Homebrew](https://brew.sh/)**: `brew install marp-cli` ([Refer to the formula...](https://github.com/Homebrew/homebrew-core/blob/master/Formula/marp-cli.rb))
+  - **[Homebrew](https://brew.sh/)**: `brew install marp-cli` ([Refer to the formulae...](https://github.com/Homebrew/homebrew-core/blob/master/Formula/marp-cli.rb))
 
 * **Windows**
   - **[Scoop](https://scoop.sh/)**: `scoop install marp` ([Refer to the manifest in Main bucket...](https://github.com/ScoopInstaller/Main/blob/master/bucket/marp.json))


### PR DESCRIPTION
Do you remember [the (outdated) Marp app had been able to install by `brew install marp --cask`](https://github.com/yhatt/marp/tree/ae6dffad7dde68f10936a68a18622c211c143777#install) until 2019? Now Marp is getting back to Homebrew! 🎉 

We have confirmed the contribution to Homebrew formula in homebrew/homebrew-core#77702 so added installation guide for macOS Homebrew.

### The other notable change

- Chocolatey package (#263) is seems no longer maintained so we've completely removed from README.md: https://github.com/zverev-iv/choco-marp-cli/issues/13.