### PR TITLE
Add `@rollup/plugin-alias` to remove `node:` schema from `require` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,10 @@
 
 ## [Unreleased]
 
-### Breaking
-
-- Now required Node.js 12.20 and later ([#365](https://github.com/marp-team/marp-cli/pull/365))
-
 ### Added
 
 - Installation guide for Homebrew ([#353](https://github.com/marp-team/marp-cli/pull/353))
-- Mention Node.js >= 12.20 requirement in README ([#359](https://github.com/marp-team/marp-cli/issues/359), [#361](https://github.com/marp-team/marp-cli/pull/361) by [@jlevon](https://github.com/jlevon), [#365](https://github.com/marp-team/marp-cli/pull/365))
+- Mention Node.js >= 12 requirement in README ([#359](https://github.com/marp-team/marp-cli/issues/359), [#361](https://github.com/marp-team/marp-cli/pull/361) by [@jlevon](https://github.com/jlevon))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It can convert Marp / Marpit Markdown files into static HTML / CSS, PDF, PowerPo
 
 [npx (`npm exec`)](https://docs.npmjs.com/cli/v7/commands/npx) is the best way to use the latest Marp CLI if you wanted
 one-shot Markdown conversion _without install_. Just run below if you have
-installed [Node.js](https://nodejs.org/) 12.20 and later.
+installed [Node.js](https://nodejs.org/) 12 and later.
 
 ```bash
 # Convert slide deck into HTML
@@ -79,7 +79,7 @@ We recommend to install Marp CLI into your Node project. You may control the CLI
 npm install --save-dev @marp-team/marp-cli
 ```
 
-Node.js 12.20 and later is required to install Marp CLI. The installed `marp` command is available in [npm-scripts](https://docs.npmjs.com/misc/scripts) or `npx marp`.
+Node.js 12 and later is required to install Marp CLI. The installed `marp` command is available in [npm-scripts](https://docs.npmjs.com/misc/scripts) or `npx marp`.
 
 #### Global installation
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.8",
+    "@rollup/plugin-alias": "^3.1.4",
     "@rollup/plugin-commonjs": "^19.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/marp-team/marp-cli"
   },
   "engines": {
-    "node": ">=12.20"
+    "node": ">=12"
   },
   "main": "lib/index.js",
   "types": "types/src/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import alias from '@rollup/plugin-alias'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import nodeResolve from '@rollup/plugin-node-resolve'
@@ -32,6 +33,9 @@ const plugins = (opts = {}) => [
   }),
   commonjs(),
   typescript({ noEmitOnError: false }),
+  alias({
+    entries: [{ find: /^node:(.+)$/, replacement: '$1' }],
+  }),
   postcss({
     inject: false,
     plugins: [
@@ -65,11 +69,7 @@ const browser = (opts = {}) => ({
 })
 
 const cli = {
-  external: external([
-    ...builtinModules,
-    ...builtinModules.map((m) => `node:${m}`),
-    ...Object.keys(dependencies),
-  ]),
+  external: external([...builtinModules, ...Object.keys(dependencies)]),
   plugins: plugins(),
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,6 +1198,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@rollup/plugin-alias@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.4.tgz#47774f4ff0eab5937f7acb392cf2b89921f03b7d"
+  integrity sha512-9YN5h0bWlYFV0zpXwwAWGPUWh/A+kkoCqwrMb43LnuGfhnQqOjsGR+5uh4LGpAZbBBj8qR1Hno6CZadZs7hyCQ==
+  dependencies:
+    slash "^3.0.0"
+
 "@rollup/plugin-commonjs@^19.0.1":
   version "19.0.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.1.tgz#94a2c103d675523d3ab1c60bfbec567b3eb70410"


### PR DESCRIPTION
Fix remaining `node:` schema (used by the latest globby v12: #365) in `require()`, that there are in the result of build.