### PR TITLE
Apply metadata and presenter notes to PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npx @marp-team/marp-cli@latest -w slide-deck.md
 npx @marp-team/marp-cli@latest -s ./slides
 ```
 
-> :information_source: You have to install [Google Chrome], [Chromium], [Microsoft Edge], or a Chromium based browser to convert slide deck into PDF, PPTX, and image(s).
+> :information_source: You have to install [Google Chrome], [Chromium], or [Microsoft Edge] to convert slide deck into PDF, PPTX, and image(s).
 
 [google chrome]: https://www.google.com/chrome/
 [chromium]: https://www.chromium.org/

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ marp slide-deck.md -o converted.pdf
 
 [google chrome canary]: https://www.google.com/chrome/canary/
 
+If your slide deck had included [Marpit presenter notes] as HTML comment, you can add note annotations to the lower left by using `--pdf-notes` option together with `--pdf`.
+
+[marpit presenter notes]: https://marpit.marp.app/usage?id=presenter-notes
+
 ### Convert to PowerPoint document (`--pptx`)
 
 Do you want more familiar way to present and share your deck? PPTX conversion to create PowerPoint document is available by passing `--pptx` option or specify the output path with PPTX extension.
@@ -141,7 +145,7 @@ marp --pptx slide-deck.md
 marp slide-deck.md -o converted.pptx
 ```
 
-A created PPTX includes rendered Marp slide pages and the support of [Marpit presenter notes](https://marpit.marp.app/usage?id=presenter-notes). It can open with PowerPoint, Keynote, Google Slides, LibreOffice Impress, and so on...
+A created PPTX includes rendered Marp slide pages and the support of [Marpit presenter notes]. It can open with PowerPoint, Keynote, Google Slides, LibreOffice Impress, and so on...
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/marp-team/marp-cli/main/docs/images/pptx.png" height="300" />
@@ -274,19 +278,19 @@ marp --template bare --engine @marp-team/marpit slide-deck.md
 
 ## Metadata
 
-We recommend setting metadata of the slide deck if you want to host the outputted HTML on the web. To optimize the converted web page for SEO and social sharing, passed meta values will use in `<title>`, `<link>`, and `<meta>` tags.
+Through [global directives] or CLI options, you can set metadata for a converted HTML, PDF, and PPTX slide deck.
 
-| [Global directives] |   CLI option    | Description                           | Metadata                                      |
-| :-----------------: | :-------------: | :------------------------------------ | :-------------------------------------------- |
-|       `title`       |    `--title`    | Define title of the slide deck.       | `<title>`, `og:title`                         |
-|    `description`    | `--description` | Define description of the slide deck. | `<meta name="description">`, `og:description` |
-|        `url`        |     `--url`     | Define [canonical URL].               | `<link rel="canonical">`, `og:url`            |
-|       `image`       |  `--og-image`   | Define [Open Graph] image URL.        | `og:image`                                    |
+| [Global directives] |   CLI option    | Description                     | Available in    |
+| :-----------------: | :-------------: | :------------------------------ | :-------------- |
+|       `title`       |    `--title`    | Define title of the slide deck  | HTML, PDF, PPTX |
+|    `description`    | `--description` | Define description of the slide | HTML, PDF, PPTX |
+|        `url`        |     `--url`     | Define [canonical URL] \*       | HTML            |
+|       `image`       |  `--og-image`   | Define [Open Graph] image URL   | HTML            |
+
+> \*: If could not parse a specified value as valid, the URL will be ignored.
 
 [canonical url]: https://en.wikipedia.org/wiki/Canonical_link_element
 [open graph]: http://ogp.me/
-
-> :information_source: The passed canonical URL will be ignored when cannot parse as valid URL.
 
 ### By [global directives]
 
@@ -457,6 +461,7 @@ If you want to prevent looking up a configuration file, you can pass `--no-confi
 | `options`         |           object            |                       | The base options for the constructor of engine                                                         |
 | `output`          |           string            |    `--output` `-o`    | Output file path (or directory when input-dir is passed)                                               |
 | `pdf`             |           boolean           |        `--pdf`        | Convert slide deck into PDF                                                                            |
+| `pdfNotes`        |           boolean           |     `--pdf-notes`     | Add [presenter notes][marpit presenter notes] to PDF as annotations                                    |
 | `preview`         |           boolean           |   `--preview` `-p`    | Open preview window                                                                                    |
 | `server`          |           boolean           |    `--server` `-s`    | Enable server mode                                                                                     |
 | `template`        |     `bare` \| `bespoke`     |     `--template`      | Choose template (`bespoke` by default)                                                                 |

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "cosmiconfig": "^7.0.0",
     "express": "^4.17.1",
     "import-from": "^4.0.0",
+    "pdf-lib": "^1.16.0",
     "pptxgenjs": "^3.7.1",
     "puppeteer-core": "10.1.0",
     "serve-index": "^1.9.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ interface IMarpCLIArguments {
   ogImage?: string
   output?: string | false
   pdf?: boolean
+  pdfNotes?: boolean
   pptx?: boolean
   preview?: boolean
   server?: boolean
@@ -155,6 +156,9 @@ export class MarpCLIConfig {
       if (lowerOutput.endsWith('.jpg') || lowerOutput.endsWith('.jpeg'))
         return ConvertType.jpeg
 
+      // Prefer PDF than HTML if enabled presenter notes for PDF
+      if (this.args.pdfNotes || this.conf.pdfNotes) return ConvertType.pdf
+
       return ConvertType.html
     })()
 
@@ -216,6 +220,7 @@ export class MarpCLIConfig {
       lang: this.conf.lang || (await osLocale()).replace(/@/g, '-'),
       options: this.conf.options || {},
       pages: !!(this.args.images || this.conf.images),
+      pdfNotes: !!(this.args.pdfNotes || this.conf.pdfNotes),
       watch: (this.args.watch ?? this.conf.watch) || preview || server || false,
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -150,6 +150,8 @@ export class MarpCLIConfig {
 
       // Detect from filename
       const lowerOutput = (output || '').toLowerCase()
+      if (lowerOutput.endsWith('.html') || lowerOutput.endsWith('.htm'))
+        return ConvertType.html
       if (lowerOutput.endsWith('.pdf')) return ConvertType.pdf
       if (lowerOutput.endsWith('.png')) return ConvertType.png
       if (lowerOutput.endsWith('.pptx')) return ConvertType.pptx

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -151,13 +151,13 @@ export const marpCli = async (
         },
         'jpeg-quality': {
           defaultDescription: '85',
-          describe: 'Setting JPEG image quality',
+          describe: 'Set JPEG image quality',
           group: OptionGroup.Converter,
           type: 'number',
         },
         'allow-local-files': {
           describe:
-            'Allow to access local files from Markdown while converting PDF and image (NOT SECURE)',
+            'Allow to access local files from Markdown while converting PDF, PPTX, or image (NOT SECURE)',
           group: OptionGroup.Converter,
           type: 'boolean',
         },
@@ -199,6 +199,11 @@ export const marpCli = async (
           describe: 'Define Open Graph image URL',
           group: OptionGroup.Meta,
           type: 'string',
+        },
+        'pdf-notes': {
+          describe: 'Add presenter notes to PDF as annotations',
+          group: OptionGroup.Meta,
+          type: 'boolean',
         },
         engine: {
           describe: 'Select Marpit based engine by module name or path',

--- a/test/_files/3.markdown
+++ b/test/_files/3.markdown
@@ -1,1 +1,3 @@
 ### three
+
+<!-- presenter note -->

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,6 +1198,20 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pdf-lib/standard-fonts@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
+  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
+  dependencies:
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
+
 "@rollup/plugin-alias@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.4.tgz#47774f4ff0eab5937f7acb392cf2b89921f03b7d"
@@ -5844,7 +5858,7 @@ package-name-regex@2.0.1:
   resolved "https://registry.yarnpkg.com/package-name-regex/-/package-name-regex-2.0.1.tgz#69e5e5412a7d5367d3cb965da6c4e480e5e9ffa4"
   integrity sha512-U+K6/cuwHwr/8pUQrpNpKOIFSdS/EluTRSmtn92mug1UiPcff4t9AHs36e2xXJtpEtRfbg+JOj3Y/GLX+mzT6w==
 
-pako@~1.0.2:
+pako@^1.0.10, pako@^1.0.11, pako@^1.0.6, pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -5949,6 +5963,16 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pdf-lib@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.16.0.tgz#63cacec0d6139bf7a670dea8bad747ebf4c1fb42"
+  integrity sha512-P/1SSmElOBKrPlbc+Sn7UxikRQbzVA64+4Dh6/uczPscvq/NatP9eryoOguyBTpTnzICNiG8EnMH4Ziqp2TnFA==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^1.0.0"
+    "@pdf-lib/upng" "^1.0.1"
+    pako "^1.0.11"
+    tslib "^1.11.1"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -7921,7 +7945,7 @@ tslib@2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tslib@^1.8.1:
+tslib@^1.11.1, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
* Set `title` and `description` metadata to PDF
* Add presenter notes to PDF as annotations (if enabled `--pdf-notes` option)

```markdown
---
title: PDF metadata and annotations
description: By using pdf-lib, an outputted PDF has better metadata.
theme: uncover
---

# PDF metadata and annotations

By using pdf-lib, an outputted PDF has better metadata.

By setting `--pdf-notes` option, presenter notes can add to PDF as annotations.

<!-- Defined presenter notes can see from the annotation at the lower left 😆 -->
```

```
marp slide.md --pdf --pdf-notes
```

![pdfjs](https://user-images.githubusercontent.com/3993388/128602977-61e98f9d-b9a6-42be-bb79-de86aaea91ee.png)

Check out [meta.pdf](https://github.com/marp-team/marp-cli/files/6949207/meta.pdf).

Now in progress of #261 and #367. Author and keywords metadata are going to be added by another PR.

### ToDo

- [x] Add tests
- [x] Update README.md