### PR TITLE
Create HTML for Puppeteer-based conversion in Docker into /tmp instead of home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Create HTML for Puppeteer-based conversion in official Docker image into `/tmp` instead of home directory ([#360](https://github.com/marp-team/marp-cli/issues/360), [#379](https://github.com/marp-team/marp-cli/pull/379))
+
 ### Changed
 
 - Reduce dependencies ([#375](https://github.com/marp-team/marp-cli/pull/375))

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -457,9 +457,10 @@ export class Converter {
       )
 
       // Snapd Chromium cannot access from sandbox container to user-land `/tmp`
-      // directory so create tmp file to home directory if in Linux.
+      // directory so create tmp file to home directory if in Linux. (There is
+      // an exception for an official docker image)
       return baseFile.saveTmpFile({
-        home: process.platform === 'linux',
+        home: process.platform === 'linux' && !process.env.IS_DOCKER,
         extension: '.html',
       })
     })()


### PR DESCRIPTION
When trying Puppeteer-based conversion in Linux, Marp CLI will create HTML tmpfile into a home directory instead of `/tmp`. It is important because Chromium that is installed through snap cannot read a local file from `/tmp` by a snap container confinement. (https://github.com/marp-team/marp-cli/issues/201#issuecomment-586725940)

However, I've found this behavior will break a workflow on Docker with `MARP_USER` env. Marp CLI image does not know about a specified user so `os.homedir()` will return a path that has no permissions for reading files by Chrome.

Thus, I changed to create HTML tmpfile into `/tmp` when used an official Docker image. Fix #360.