### PR TITLE
Expose Marp Core instance to functional engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Experimental transitions for bespoke template ([#382](https://github.com/marp-team/marp-cli/issues/382), [#381](https://github.com/marp-team/marp-cli/pull/381))
+- Expose Marp Core instance to functional engine via `marp` getter ([#386](https://github.com/marp-team/marp-cli/pull/386)))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -372,29 +372,44 @@ Notice that Marpit has not provided theme. It would be good to include inline st
 
 ### Functional engine
 
-When you specify the path to JavaScript file in `--engine` option, you may use more customized engine by JS.
+When you specified the path to JavaScript file in `--engine` option, you may use more customized engine by a JavaScript function.
 
-It would be useful to convert with a customized engine for supporting the additional syntax that is out of Marp Markdown specification.
+#### Spec
+
+The functional engine should export a function with one parameter, which is a constructor option of Marpit. The function must return an instance of Marpit-based engine made by the passed parameter.
+
+```javascript
+module.exports = function (constructorOption) {
+  return new MarpitBasedEngine(constructorOption)
+}
+```
+
+Marp CLI also exposes `marp` getter property to the parameter. It returns a prepared instance of the built-in Marp Core engine, so you can apply several customizations to Marp engine with simple declarations.
+
+```javascript
+module.exports = ({ marp }) => marp.use(marpPlugin).use(andMorePlugin)
+```
+
+It allows converting Markdown with additional syntaxes that were provided by Marp (or compatible markdown-it) plugins.
 
 #### Example: [markdown-it-mark](https://github.com/markdown-it/markdown-it-mark)
 
 ```javascript
 // engine.js
-const { Marp } = require('@marp-team/marp-core')
 const markdownItMark = require('markdown-it-mark')
 
-module.exports = (opts) => new Marp(opts).use(markdownItMark)
+module.exports = ({ marp }) => marp.use(markdownItMark)
 ```
 
 ```bash
-# Install Marp Core and markdown-it-mark
-npm install @marp-team/marp-core markdown-it-mark --save-dev
+# Install markdown-it-mark
+npm install markdown-it-mark --save
 
 # Specify the path to functional engine
 marp --engine ./engine.js slide-deck.md
 ```
 
-The customized engine would convert `==marked==` to `<mark>marked</mark>`.
+The customized engine will convert `==marked==` to `<mark>marked</mark>`.
 
 ### Confirm engine version
 
@@ -434,12 +449,11 @@ pdf: true
 
 ```javascript
 // marp.config.js
-const { Marp } = require('@marp-team/marp-core')
-const container = require('markdown-it-container')
+const markdownItContainer = require('markdown-it-container')
 
 module.exports = {
   // Customize engine on configuration file directly
-  engine: (opts) => new Marp(opts).use(container, 'custom'),
+  engine: ({ marp }) => marp.use(markdownItContainer, 'custom'),
 }
 ```
 
@@ -491,7 +505,9 @@ The advanced options that cannot specify through CLI options can be configured b
 
 `options` can set the base options for the constructor of the used engine. You can fine-tune constructor options for [Marp Core](https://github.com/marp-team/marp-core#constructor-options) / [Marpit](https://marpit-api.marp.app/marpit).
 
-For example, the below configuration will set constructor option for Marp Core as specified:
+##### Example
+
+The below configuration will set constructor option for Marp Core as specified:
 
 - Disables [Marp Core's line breaks conversion](https://github.com/marp-team/marp-core#marp-markdown) (`\n` to `<br />`) to match for CommonMark, by passing [markdown-it's `breaks` option](https://markdown-it.github.io/markdown-it/#MarkdownIt.new) as `false`.
 - Disable minification for rendered theme CSS to make debug your style easily, by passing [`minifyCSS`](https://github.com/marp-team/marp-core#minifycss-boolean) as `false`.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import fs from 'fs'
 import path from 'path'
-import { Marp } from '@marp-team/marp-core'
 import chalk from 'chalk'
 import { cosmiconfig } from 'cosmiconfig'
 import { osLocale } from 'os-locale'
 import { info, warn } from './cli'
 import { ConverterOption, ConvertType } from './converter'
-import resolveEngine, { ResolvableEngine, ResolvedEngine } from './engine'
+import { ResolvableEngine, ResolvedEngine } from './engine'
 import { keywordsAsArray } from './engine/meta-plugin'
 import { error } from './error'
 import { TemplateOption } from './templates'
@@ -77,11 +76,11 @@ export class MarpCLIConfig {
     if (args.configFile !== false) await conf.loadConf(args.configFile)
 
     conf.engine = await (() => {
-      if (conf.args.engine) return resolveEngine(conf.args.engine)
+      if (conf.args.engine) return ResolvedEngine.resolve(conf.args.engine)
       if (conf.conf.engine)
-        return resolveEngine(conf.conf.engine, conf.confPath)
+        return ResolvedEngine.resolve(conf.conf.engine, conf.confPath)
 
-      return resolveEngine(['@marp-team/marp-core', Marp])
+      return ResolvedEngine.resolveDefaultEngine()
     })()
 
     return conf

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,15 +1,17 @@
 import { version as bundledCoreVer } from '@marp-team/marp-core/package.json'
 import { name, version } from '../package.json'
 import { MarpCLIConfig } from './config'
+import { ResolvedEngine } from './engine'
 
-export const isMarpCore = async (klass: any): Promise<boolean> =>
-  klass === (await import('@marp-team/marp-core')).Marp
+export const isMarpCore = async (engine: ResolvedEngine): Promise<boolean> =>
+  engine.package?.name === '@marp-team/marp-core' ||
+  engine === (await ResolvedEngine.resolveDefaultEngine())
 
 export default async function outputVersion(config: MarpCLIConfig): Promise<0> {
   let engineVer = ''
   const { engine } = config
 
-  if (await isMarpCore(engine.klass)) {
+  if (await isMarpCore(engine)) {
     engineVer = `@marp-team/marp-core v${bundledCoreVer}`
 
     if (engine.package && engine.package.version !== bundledCoreVer) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,21 +1,21 @@
-import { Marp } from '@marp-team/marp-core'
 import { version as bundledCoreVer } from '@marp-team/marp-core/package.json'
 import { name, version } from '../package.json'
 import { MarpCLIConfig } from './config'
 
-export const isMarpCore = (klass: any): boolean => klass === Marp
+export const isMarpCore = async (klass: any): Promise<boolean> =>
+  klass === (await import('@marp-team/marp-core')).Marp
 
 export default async function outputVersion(config: MarpCLIConfig): Promise<0> {
   let engineVer = ''
   const { engine } = config
 
-  if (isMarpCore(engine.klass)) {
+  if (await isMarpCore(engine.klass)) {
     engineVer = `@marp-team/marp-core v${bundledCoreVer}`
 
     if (engine.package && engine.package.version !== bundledCoreVer) {
       engineVer = `user-installed @marp-team/marp-core v${engine.package.version}`
     }
-  } else if (engine.package && engine.package.name && engine.package.version) {
+  } else if (engine.package?.name && engine.package.version) {
     engineVer = `customized engine in ${engine.package.name} v${engine.package.version}`
   } else {
     engineVer = `customized engine`

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -1,18 +1,47 @@
 import Marp from '@marp-team/marp-core'
-import resolve from '../src/engine'
+import importFrom from 'import-from'
+import { ResolvedEngine } from '../src/engine'
 
-describe('Engine', () => {
-  describe('.resolve', () => {
+afterEach(() => jest.restoreAllMocks())
+
+describe('ResolvedEngine', () => {
+  describe('#resolve', () => {
     it('returns ResolvedEngine class with resolved class', async () => {
-      const resolvedEngine = await resolve(Marp)
+      const resolvedEngine = await ResolvedEngine.resolve(Marp)
 
       expect(resolvedEngine.klass).toBe(Marp)
-      expect((await resolve('@marp-team/marp-core')).klass).toBe(
+      expect((await ResolvedEngine.resolve('@marp-team/marp-core')).klass).toBe(
         resolvedEngine.klass
       )
 
       // Return with the first resolved class
-      expect((await resolve(['__invalid_module__', Marp])).klass).toBe(Marp)
+      expect(
+        (await ResolvedEngine.resolve(['__invalid_module__', Marp])).klass
+      ).toBe(Marp)
+    })
+  })
+
+  describe('#resolveDefaultEngine', () => {
+    it('returns ResolvedEngine class with Marp Core which is resolved from current directory', async () => {
+      const importFromSpy = jest.spyOn(importFrom, 'silent')
+      const resolvedEngine = await ResolvedEngine.resolveDefaultEngine()
+
+      expect(importFromSpy).toHaveBeenCalledWith(
+        process.cwd(),
+        '@marp-team/marp-core'
+      )
+
+      const marpCoreModule: typeof import('@marp-team/marp-core') =
+        importFromSpy.mock.results[0].value
+
+      expect(resolvedEngine.klass).toBe(marpCoreModule.default)
+    })
+
+    it('returns ResolvedEngine class with a natively-bundled Marp Core if failed to resolve from current directory', async () => {
+      jest.spyOn(importFrom, 'silent').mockImplementationOnce(() => undefined)
+
+      const resolvedEngine = await ResolvedEngine.resolveDefaultEngine()
+      expect(resolvedEngine.klass).toBe(Marp)
     })
   })
 })

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -79,7 +79,7 @@ describe('Marp CLI', () => {
 
       it('outputs package versions about cli and bundled core', async () => {
         // isMarpCore does not return correct result in Windows environment
-        jest.spyOn(version, 'isMarpCore').mockImplementation(() => true)
+        jest.spyOn(version, 'isMarpCore').mockResolvedValue(true)
 
         expect(await marpCli([cmd])).toBe(0)
         expect(log).toHaveBeenCalledWith(
@@ -95,9 +95,9 @@ describe('Marp CLI', () => {
         const pkgPath = '../node_modules/@marp-team/marp-core/package.json'
 
         beforeEach(() => {
-          jest.spyOn(version, 'isMarpCore').mockImplementation(() => true)
+          jest.spyOn(version, 'isMarpCore').mockResolvedValue(true)
 
-          findClassPath.mockImplementation(() =>
+          mockEnginePath(
             assetFn('../node_modules/@marp-team/marp-core/lib/marp.js')
           )
 


### PR DESCRIPTION
Improved a functional engine to allow using built-in Marp Core instance by non enumerable `marp` getter. Importing Marp Core installed by user is no longer required for simple customization.

## Example: markdown-it-mark

### Previous version

```javascript
// engine.js
const { Marp } = require('@marp-team/marp-core')
const markdownItMark = require('markdown-it-mark')

module.exports = (opts) => new Marp(opts).use(markdownItMark)
```

```bash
# Install Marp Core and markdown-it-mark
npm install @marp-team/marp-core markdown-it-mark --save-dev

# Specify the path to functional engine
marp --engine ./engine.js slide-deck.md
```

### Current

```javascript
// engine.js
module.exports = ({ marp }) => marp.use(require('markdown-it-mark'))
```

```bash
# Install markdown-it-mark
npm install markdown-it-mark --save-dev

# Specify the path to functional engine
marp --engine ./engine.js slide-deck.md
```

A previous way is still available and useful for full-customization.

---

In addition, importing Marp Core has put off until needed. It means making faster CLI startup (especially `--help`).