### PR TITLE
Prevent outputting a warning about CHROME_PATH if fallbacked to Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent outputting a warning about `CHROME_PATH` env if fallbacked to Edge ([#388](https://github.com/marp-team/marp-cli/pull/388))
+
 ## v1.4.0 - 2021-08-29
 
 ### Added

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -42,6 +42,8 @@ export const generatePuppeteerLaunchArgs = () => {
 
   // Resolve Chrome path to execute
   if (executablePath === false) {
+    let findChromeError: Error | undefined
+
     if (process.env.IS_DOCKER) {
       // Use already known path within Marp CLI official Docker image
       executablePath = '/usr/bin/chromium-browser'
@@ -49,7 +51,7 @@ export const generatePuppeteerLaunchArgs = () => {
       try {
         executablePath = findChromeInstallation()
       } catch (e) {
-        if (e instanceof Error) warn(e.message)
+        if (e instanceof Error) findChromeError = e
       }
     }
 
@@ -58,6 +60,8 @@ export const generatePuppeteerLaunchArgs = () => {
       executablePath = findEdgeInstallation()
 
       if (!executablePath) {
+        if (findChromeError) warn(findChromeError.message)
+
         error(
           'You have to install Google Chrome, Chromium, or Microsoft Edge to convert slide deck with current options.',
           CLIErrorCode.NOT_FOUND_CHROMIUM


### PR DESCRIPTION
The Chrome finder by `chrome-launcher` will reject with an error instance containing a message to require setting `CHROME_PATH` env if rejected. Marp CLI has been outputted this error as warning immediately, but it just brings confusion if the user still had a compatible fallback such as Microsoft Edge.