### PR TITLE
Retry spawning Chromium with WebSocket connection if failed to connect through pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve reliability of connection to Chromium process for conversion ([#395](https://github.com/marp-team/marp-cli/issues/395), [#400](https://github.com/marp-team/marp-cli/pull/400))
+
 ### Changed
 
 - Upgrade Marpit to [v2.1.2](https://github.com/marp-team/marpit/releases/tag/v2.1.2) ([#399](https://github.com/marp-team/marp-cli/pull/399))

--- a/test/utils/_executable_mocks/shebang-chromium
+++ b/test/utils/_executable_mocks/shebang-chromium
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/bin/chromium-browser "$@"

--- a/test/utils/_executable_mocks/shebang-snapd-chromium
+++ b/test/utils/_executable_mocks/shebang-snapd-chromium
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /snap/bin/chromium "$@"


### PR DESCRIPTION
If failed to connect to Chromium with pipe option with a known error (`Target.setDiscoverTargets`), Marp CLI will retry to spawn chromium with using WebSockets instead (`pipe: false`).

It might mitigate some conversion issues reported in marp-team/marp#165 and marp-team/marp#198. Close #395.

> This PR is also including refactor for #317. The warning had no longer  outputted in the snap binary that was installed by `apt` due to the shebang script for proxy. 