### PR TITLE
Update Dockerfile to split build into multi-stages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,7 @@ commands:
             docker buildx build --no-cache --platform linux/amd64,linux/arm64 --progress plain --push -t marpteam/marp-cli:<< parameters.tag >> .
           environment:
             DOCKER_CLI_EXPERIMENTAL: enabled
+          no_output_timeout: 20m
 
 jobs:
   audit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Upgrade Marpit to [v2.1.2](https://github.com/marp-team/marpit/releases/tag/v2.1.2) ([#399](https://github.com/marp-team/marp-cli/pull/399))
 - Upgrade Marp Core to [v2.2.0](https://github.com/marp-team/marp-core/releases/tag/v2.2.0) ([#399](https://github.com/marp-team/marp-cli/pull/399))
 - Upgrade development Node LTS and dependencies to the latest ([#399](https://github.com/marp-team/marp-cli/pull/399))
+- Update `Dockerfile` to make a image with multi-stage builds ([#401](https://github.com/marp-team/marp-cli/pull/401))
 
 ## v1.4.1 - 2021-09-26
 


### PR DESCRIPTION
By added multi-arch support for Docker image (#328), CI build has made flaky due to much slower build in emulated ARM architecture.

This PR will update Dockerfile to split build phase into multi-staged. Docker Buildx, that is using in CI now, can run multi-stage build in concurrency. This may be expected getting an improved build stability.