### PR TITLE
Update Dockerfile to copy pre-built code in `/lib` into image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
         default: false
       version:
         type: string
-        default: lts
+        default: '16.13.0' # Specify LTS version for development
     docker:
       - image: circleci/node:<< parameters.version >><<# parameters.browser >>-browsers<</ parameters.browser >>
         entrypoint:
@@ -102,6 +102,18 @@ commands:
           path: ./coverage
           destination: coverage
 
+  build:
+    steps:
+      - checkout
+      - install
+
+      - run: yarn build
+
+      - persist_to_workspace:
+          root: ~/marp-cli
+          paths:
+            - lib
+
   docker:
     parameters:
       tag:
@@ -118,6 +130,9 @@ commands:
         default: false
     steps:
       - checkout
+
+      - attach_workspace:
+          at: ~/marp-cli
 
       - unless:
           condition: << parameters.machine >>
@@ -150,7 +165,6 @@ commands:
             docker buildx build --no-cache --platform linux/amd64,linux/arm64 --progress plain --push -t marpteam/marp-cli:<< parameters.tag >> .
           environment:
             DOCKER_CLI_EXPERIMENTAL: enabled
-          no_output_timeout: 20m
 
 jobs:
   audit:
@@ -178,27 +192,35 @@ jobs:
     executor:
       name: node
       browser: true
-      version: '16.13.0' # Specify LTS version for development
     steps:
       - test
+
+  docker-build-latest:
+    executor: node
+    steps:
+      - build
 
   docker-image-latest:
     executor: docker
     steps:
       - docker:
-          machine: true
           tag: latest
+
+  docker-build-tag:
+    executor: node
+    steps:
+      - build
 
   docker-image-tag:
     executor: docker
     steps:
       - docker:
-          machine: true
           tag: $CIRCLE_TAG
 
 workflows:
   test:
     jobs:
+      # Test
       - audit
       - test-node12:
           requires:
@@ -209,7 +231,9 @@ workflows:
       - test-node16:
           requires:
             - audit
-      - docker-image-latest:
+
+      # Docker (latest)
+      - docker-build-latest:
           requires:
             - test-node12
             - test-node14
@@ -217,9 +241,19 @@ workflows:
           filters:
             branches:
               only: main
-      - docker-image-tag:
+
+      - docker-image-latest:
+          requires:
+            - docker-build-latest
+
+      # Docker (tag)
+      - docker-build-tag:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - docker-image-tag:
+          requires:
+            - docker-build-tag

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,7 @@
 **/*
-!src/
+!lib/
 !docker-entrypoint
 !LICENSE
 !marp-cli.js
 !package.json
-!rollup.config.js
-!tsconfig.json
 !yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Upgrade Marpit to [v2.1.2](https://github.com/marp-team/marpit/releases/tag/v2.1.2) ([#399](https://github.com/marp-team/marp-cli/pull/399))
 - Upgrade Marp Core to [v2.2.0](https://github.com/marp-team/marp-core/releases/tag/v2.2.0) ([#399](https://github.com/marp-team/marp-cli/pull/399))
 - Upgrade development Node LTS and dependencies to the latest ([#399](https://github.com/marp-team/marp-cli/pull/399))
-- Update `Dockerfile` to make a image with multi-stage builds ([#401](https://github.com/marp-team/marp-cli/pull/401))
+- Update how to build Docker image to make faster publishing an updated version ([#402](https://github.com/marp-team/marp-cli/pull/402))
 
 ## v1.4.1 - 2021-09-26
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-ARG NODE_VERSION=16.13.0
-
-########## Build Marp CLI
-
-FROM node:${NODE_VERSION} AS builder
-WORKDIR /usr/src/marp
-COPY . .
-RUN yarn install --frozen-lockfile && yarn build && rm -rf node_modules src rollup.config.js tsconfig.json
-
-########## Build the image
-
-FROM node:${NODE_VERSION}-alpine
+FROM node:16.13.0-alpine
 LABEL maintainer "Marp team"
 
 RUN apk update && apk upgrade && \
@@ -39,7 +28,7 @@ USER marp
 ENV CHROME_PATH /usr/bin/chromium-browser
 
 WORKDIR /home/marp/.cli
-COPY --from=builder --chown=marp:marp /usr/src/marp .
+COPY --chown=marp:marp . .
 RUN yarn install --production --frozen-lockfile && yarn cache clean && node marp-cli.js --version
 
 # Setup workspace for user


### PR DESCRIPTION
#401 has not improved the build time for multi-arch image. Thus, I've implemented the second approach: Build source code in CI, and `docker build` just copies the pre-built outputs.

It can remove a build phase in `Dockerfile` so make faster publishing updated Docker image.