### PR TITLE
Allow to set timeout for Puppeteer actions by `PUPPETEER_TIMEOUT` env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow to set timeout for Puppeteer actions by `PUPPETEER_TIMEOUT` env ([#409](https://github.com/marp-team/marp-cli/pull/409))
+
 ### Changed
 
 - Upgrade Marpit to [v2.2.1](https://github.com/marp-team/marpit/releases/tag/v2.2.1) ([#408](https://github.com/marp-team/marp-cli/pull/408))

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,11 +214,20 @@ export class MarpCLIConfig {
       return scale
     })()
 
+    const puppeteerTimeout = (() => {
+      if (process.env['PUPPETEER_TIMEOUT']) {
+        const envTimeout = Number.parseInt(process.env['PUPPETEER_TIMEOUT'], 10)
+        if (!Number.isNaN(envTimeout)) return envTimeout
+      }
+      return undefined
+    })()
+
     return {
       imageScale,
       inputDir,
       output,
       preview,
+      puppeteerTimeout,
       server,
       template,
       templateOption,

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -491,7 +491,9 @@ export class Converter {
     })()
 
     try {
-      const browser = await Converter.runBrowser()
+      const browser = await Converter.runBrowser({
+        timeout: this.puppeteerTimeout,
+      })
 
       const uri = await (async () => {
         if (tmpFile) {
@@ -571,12 +573,13 @@ export class Converter {
 
   private static browser?: puppeteer.Browser
 
-  private static async runBrowser() {
+  private static async runBrowser({ timeout }: { timeout?: number }) {
     if (!Converter.browser) {
       const baseArgs = generatePuppeteerLaunchArgs()
 
       Converter.browser = await launchPuppeteer({
         ...baseArgs,
+        timeout,
         userDataDir: await generatePuppeteerDataDirPath('marp-cli-conversion', {
           wslHost: isChromeInWSLHost(baseArgs.executablePath),
         }),

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -84,6 +84,7 @@ describe('Converter', () => {
   describe('get #puppeteerTimeout', () => {
     it('returns specified timeout', () => {
       expect(instance({ puppeteerTimeout: 1000 }).puppeteerTimeout).toBe(1000)
+      expect(instance({ puppeteerTimeout: 0 }).puppeteerTimeout).toBe(0)
     })
 
     it('returns the default timeout 30000ms if not specified', () => {

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -8,6 +8,7 @@ import { Options } from '@marp-team/marpit'
 import cheerio from 'cheerio'
 import { imageSize } from 'image-size'
 import { PDFDocument, PDFDict, PDFName, PDFHexString } from 'pdf-lib'
+import { TimeoutError } from 'puppeteer-core'
 import { Page } from 'puppeteer-core/lib/cjs/puppeteer/common/Page'
 import yauzl from 'yauzl'
 import { Converter, ConvertType, ConverterOption } from '../src/converter'
@@ -77,6 +78,16 @@ describe('Converter', () => {
     it('throws CLIError when specified template is not defined', () => {
       const throwErr = () => instance({ template: 'not_defined' }).template
       expect(throwErr).toThrow(CLIError)
+    })
+  })
+
+  describe('get #puppeteerTimeout', () => {
+    it('returns specified timeout', () => {
+      expect(instance({ puppeteerTimeout: 1000 }).puppeteerTimeout).toBe(1000)
+    })
+
+    it('returns the default timeout 30000ms if not specified', () => {
+      expect(instance().puppeteerTimeout).toBe(30000)
     })
   })
 
@@ -516,6 +527,19 @@ describe('Converter', () => {
           expect(annotation.get(PDFName.of('T'))).toStrictEqual(
             PDFHexString.fromText('author')
           )
+        })
+      })
+
+      describe('with custom puppeteer timeout', () => {
+        it('follows setting timeout', async () => {
+          ;(fs as any).__mockWriteFile()
+
+          await expect(
+            pdfInstance({
+              output: 'test.pdf',
+              puppeteerTimeout: 1,
+            }).convertFile(new File(onePath))
+          ).rejects.toThrow(TimeoutError)
         })
       })
     })

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -920,6 +920,30 @@ describe('Marp CLI', () => {
         )
       })
     })
+
+    describe('with PUPPETEER_TIMEOUT env', () => {
+      beforeEach(() => {
+        process.env.PUPPETEER_TIMEOUT = '12345'
+      })
+
+      afterEach(() => {
+        delete process.env.PUPPETEER_TIMEOUT
+      })
+
+      it('follows specified timeout in conversion that is using Puppeteer', async () => {
+        expect(
+          (await conversion(onePath, '--pdf')).options.puppeteerTimeout
+        ).toBe(12345)
+      })
+
+      it('does not follows specified timeout if the env value is not valid number', async () => {
+        process.env.PUPPETEER_TIMEOUT = 'invalid'
+
+        expect(
+          (await conversion(onePath, '--pdf')).options.puppeteerTimeout
+        ).toBeUndefined()
+      })
+    })
   })
 
   describe('with passing directory', () => {


### PR DESCRIPTION
Allowed set timeout for Puppeteer by `PUPPETEER_TIMEOUT` env.

```
PUPPETEER_TIMEOUT=60000 marp --pdf large-markdown.md
```

By this setting, every actions by `puppeteer-core` (such as launching Chrome, page navigation, and PDF creation) will be timed out in 60 seconds. The default is 30s.

`PUPPETEER_TIMEOUT=0` means every actions will never be timed out.

> This option is maken assuming that it is used for debug a trouble while converting like https://github.com/marp-team/marp/discussions/225, so this setting cannot modify by CLI option and configuration file.