### PR TITLE
Improved WSL 2 detection and browser resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allow to set timeout for Puppeteer actions by `PUPPETEER_TIMEOUT` env ([#409](https://github.com/marp-team/marp-cli/pull/409))
 
+### Fixed
+
+- Improved WSL 2 detection and browser resolution ([#410](https://github.com/marp-team/marp-cli/pull/410))
+
 ### Changed
 
 - Upgrade Marpit to [v2.2.1](https://github.com/marp-team/marpit/releases/tag/v2.2.1) ([#408](https://github.com/marp-team/marp-cli/pull/408))

--- a/src/utils/chrome-finder.ts
+++ b/src/utils/chrome-finder.ts
@@ -7,9 +7,13 @@ import {
 import { isWSL } from './wsl'
 
 // A lightweight version of Launcher.getFirstInstallation()
-// https://github.com/GoogleChrome/chrome-launcher/blob/master/src/chrome-launcher.ts#L175
+// https://github.com/GoogleChrome/chrome-launcher/blob/30755cde8627b7aad6caff1594c9752f80a39a4d/src/chrome-launcher.ts#L189-L192
 export const findChromeInstallation = () => {
-  const platform = isWSL() ? 'wsl' : process.platform
+  // 'wsm' platform will resolve Chrome from Windows. In WSL 2, Puppeteer cannot
+  // communicate with Chrome spawned in the host OS so should follow the
+  // original platform ('linux') if CLI was executed in WSL 2.
+  const platform = isWSL() === 1 ? 'wsl' : process.platform
+
   const installations = (() => {
     switch (platform) {
       /* istanbul ignore next: CI is not testing against darwin */

--- a/src/utils/chrome-finder.ts
+++ b/src/utils/chrome-finder.ts
@@ -9,7 +9,7 @@ import { isWSL } from './wsl'
 // A lightweight version of Launcher.getFirstInstallation()
 // https://github.com/GoogleChrome/chrome-launcher/blob/30755cde8627b7aad6caff1594c9752f80a39a4d/src/chrome-launcher.ts#L189-L192
 export const findChromeInstallation = () => {
-  // 'wsm' platform will resolve Chrome from Windows. In WSL 2, Puppeteer cannot
+  // 'wsl' platform will resolve Chrome from Windows. In WSL 2, Puppeteer cannot
   // communicate with Chrome spawned in the host OS so should follow the
   // original platform ('linux') if CLI was executed in WSL 2.
   const platform = isWSL() === 1 ? 'wsl' : process.platform

--- a/src/utils/edge-finder.ts
+++ b/src/utils/edge-finder.ts
@@ -14,7 +14,8 @@ export const findAccessiblePath = (paths: string[]): string | undefined =>
   })
 
 const linux = (): string | undefined => {
-  if (isWSL()) {
+  // WSL 1 should find Edge executable from host OS
+  if (isWSL() === 1) {
     const localAppData = resolveWindowsEnvSync('LOCALAPPDATA')
 
     return win32({

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -50,8 +50,8 @@ export const generatePuppeteerDataDirPath = async (
 ): Promise<string> => {
   const dataDir = await (async () => {
     if (isWSL() && wslHost) {
-      // In WSL environment, Marp CLI will use Chrome on Windows. Thus, we have to
-      // specify Windows path when converting within WSL.
+      // In WSL environment, Marp CLI may use Chrome on Windows. If Chrome has
+      // located in host OS (Windows), we have to specify Windows path.
       if (wslTmp === undefined) wslTmp = await resolveWindowsEnv('TMP')
       if (wslTmp !== undefined) return path.win32.resolve(wslTmp, name)
     }

--- a/src/utils/wsl.ts
+++ b/src/utils/wsl.ts
@@ -35,12 +35,19 @@ export const isWSL = (): number => {
     if (require('is-wsl')) {
       isWsl = 1
 
-      try {
-        // https://github.com/microsoft/WSL/issues/423#issuecomment-611086412
-        const release = readFileSync('/proc/sys/kernel/osrelease').toString()
-        if (release.includes('WSL2')) isWsl = 2
-      } catch (e: unknown) {
-        // no ops
+      // Detect whether WSL version is 2
+      // https://github.com/microsoft/WSL/issues/4555#issuecomment-700213318
+      if (process.env.WSL_DISTRO_NAME && process.env.WSL_INTEROP) {
+        isWsl = 2
+      } else {
+        try {
+          const versionString = readFileSync('/proc/version', 'utf8')
+          const gccMatched = versionString.match(/gcc version (\d+)\.\d+\.\d+/i)
+
+          if (gccMatched && Number.parseInt(gccMatched[1], 10) >= 8) isWsl = 2
+        } catch (e: unknown) {
+          // no ops
+        }
       }
     } else {
       isWsl = 0

--- a/src/utils/wsl.ts
+++ b/src/utils/wsl.ts
@@ -33,22 +33,23 @@ export const resolveWindowsEnvSync = (key: string): string | undefined => {
 export const isWSL = (): number => {
   if (isWsl === undefined) {
     if (require('is-wsl')) {
-      isWsl = 1
-
       // Detect whether WSL version is 2
       // https://github.com/microsoft/WSL/issues/4555#issuecomment-700213318
-      if (process.env.WSL_DISTRO_NAME && process.env.WSL_INTEROP) {
-        isWsl = 2
-      } else {
-        try {
-          const versionString = readFileSync('/proc/version', 'utf8')
-          const gccMatched = versionString.match(/gcc version (\d+)\.\d+\.\d+/i)
+      const isWSL2 = (() => {
+        if (process.env.WSL_DISTRO_NAME && process.env.WSL_INTEROP) return true
 
-          if (gccMatched && Number.parseInt(gccMatched[1], 10) >= 8) isWsl = 2
+        try {
+          const verStr = readFileSync('/proc/version', 'utf8').toLowerCase()
+          if (verStr.includes('microsoft-standard-wsl2')) return true
+
+          const gccMatched = verStr.match(/gcc[^,]+?(\d+)\.\d+\.\d+/)
+          if (gccMatched && Number.parseInt(gccMatched[1], 10) >= 8) return true
         } catch (e: unknown) {
           // no ops
         }
-      }
+      })()
+
+      isWsl = isWSL2 ? 2 : 1
     } else {
       isWsl = 0
     }


### PR DESCRIPTION
Improved WSL2 detection by using multiple heuristics.

Marp CLI will find out the browser for PDF/PPTX/image conversion automatically from the host OS (Windows). It works in WSL 1 but Puppeteer in WSL 2 cannot communicate with the browser spawned in the host OS.

I've updated `isWSL()` utility method for more reliable WSL 2 detection. We have no longer resolved Puppeteer from the host OS if WSL 2 was detected.

WSL2 detection is based on multiple heuristics on WSL environment:

- If there are both of `WSL_DISTRO_NAME` and `WSL_INTEROP` environment values.
- Else if the string of `/proc/version` is including `Microsoft-Standard-WSL2`.
- Else if it shows that the kernel was compiled by GCC v8 and later versions.

Related to marp-team/marp#113, and may resolve marp-team/marp#247.