### PR TITLE
Set `png` as the default type for CLI image options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Upgrade Marpit to [v2.2.1](https://github.com/marp-team/marpit/releases/tag/v2.2.1) ([#408](https://github.com/marp-team/marp-cli/pull/408))
 - Upgrade Marp Core to [v2.3.1](https://github.com/marp-team/marp-core/releases/tag/v2.3.1) ([#408](https://github.com/marp-team/marp-cli/pull/408))
 - Upgrade dependent packages to the latest version ([#408](https://github.com/marp-team/marp-cli/pull/408))
+- Set `png` as the default type for CLI image options ([#416](https://github.com/marp-team/marp-cli/pull/416))
 
 ## v1.5.0 - 2021-11-27
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -133,7 +133,11 @@ export const marpCli = async (
           describe: 'Convert the first slide page into an image file',
           group: OptionGroup.Converter,
           choices: ['png', 'jpeg'],
-          coerce: (type: string) => (type === 'jpg' ? 'jpeg' : type),
+          coerce: (type: string) => {
+            if (type === '') return 'png'
+            if (type === 'jpg') return 'jpeg'
+            return type
+          },
           type: 'string',
         },
         images: {
@@ -141,7 +145,11 @@ export const marpCli = async (
           describe: 'Convert slide deck into multiple image files',
           group: OptionGroup.Converter,
           choices: ['png', 'jpeg'],
-          coerce: (type: string) => (type === 'jpg' ? 'jpeg' : type),
+          coerce: (type: string) => {
+            if (type === '') return 'png'
+            if (type === 'jpg') return 'jpeg'
+            return type
+          },
           type: 'string',
         },
         'image-scale': {
@@ -266,7 +274,7 @@ export const marpCli = async (
     const cvtOpts = converter.options
 
     // Find target markdown files
-    const finder = async () => {
+    const finder = async (): Promise<File[]> => {
       if (cvtOpts.inputDir) {
         if (config.files.length > 0) {
           cli.error('Cannot pass files together with input directory.')
@@ -283,8 +291,8 @@ export const marpCli = async (
       const stdin = args.stdin ? await File.stdin() : undefined
 
       // Regular file finding powered by globby
-      return <File[]>(
-        [stdin, ...(await File.find(...config.files))].filter((f) => f)
+      return [stdin, ...(await File.find(...config.files))].filter(
+        (f): f is File => !!f
       )
     }
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -608,6 +608,11 @@ describe('Marp CLI', () => {
         expect((await conversion(...cmd)).options.type).toBe(ConvertType.png)
       })
 
+      it('converts file with PNG type if the type was not specified', async () => {
+        const cmd = [onePath, '--image']
+        expect((await conversion(...cmd)).options.type).toBe(ConvertType.png)
+      })
+
       it('converts file with JPEG type by specified jpeg', async () => {
         const cmd = [onePath, '--image=jpeg']
         expect((await conversion(...cmd)).options.type).toBe(ConvertType.jpeg)
@@ -629,6 +634,12 @@ describe('Marp CLI', () => {
     describe('with --images option', () => {
       it('converts file with PNG type and enabled pages option by specified png', async () => {
         const converter = await conversion(onePath, '--images', 'png')
+        expect(converter.options.type).toBe(ConvertType.png)
+        expect(converter.options.pages).toBe(true)
+      })
+
+      it('converts file with PNG type if the type was not specified', async () => {
+        const converter = await conversion(onePath, '--images')
         expect(converter.options.type).toBe(ConvertType.png)
         expect(converter.options.pages).toBe(true)
       })


### PR DESCRIPTION
In every following cases that have omitted image type, Marp CLI automatically chooses image(s) conversion for PNG:

```
marp test.md --image
marp --image -- test.md
marp --image --html test.md

marp test.md --images
marp --images -- test.md
marp --images --html test.md
```

