### PR TITLE
Downgrade Codecov uploader from latest to v0.1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.2.0
+  codecov: codecov/codecov@3.2.2
 
 executors:
   node:
@@ -94,7 +94,8 @@ commands:
           environment:
             JEST_JUNIT_OUTPUT_DIR: tmp/test-results
 
-      - codecov/upload
+      - codecov/upload:
+          version: v0.1.15
 
       - store_test_results:
           path: tmp/test-results

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: windows
+          version: v0.1.15


### PR DESCRIPTION
The latest Codecov uploader will miss some of coverage outputs. https://github.com/codecov/uploader/issues/614