### PR TITLE
Follow up for `--notes` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `--notes` option to export presenter notes as text file ([#278](https://github.com/marp-team/marp-cli/issues/278), [#429](https://github.com/marp-team/marp-cli/pull/429) by [@chrisns](https://github.com/chrisns))
+- `--notes` option to export presenter notes as text file ([#278](https://github.com/marp-team/marp-cli/issues/278), [#429](https://github.com/marp-team/marp-cli/pull/429) by [@chrisns](https://github.com/chrisns), [#432](https://github.com/marp-team/marp-cli/pull/432))
 - Make notes font size changeable in bespoke template ([#428](https://github.com/marp-team/marp-cli/pull/428) by [@chrisns](https://github.com/chrisns), [#431](https://github.com/marp-team/marp-cli/pull/431))
 
 ## v1.6.0 - 2022-02-12

--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ marp slide-deck.md -o title-slide@2x.png --image-scale 2
 >
 > It is also available for PPTX conversion. By default, Marp CLI will use `2` as the default scale factor in PPTX to suppress deterioration of slide rendering in full-screen presentation.
 
+### Export presenter notes (`--notes`)
+
+You can export [presenter notes][marpit presenter notes] in Marp / Marpit Markdown as a text file by using `--notes` option or specifying the output path with TXT extension.
+
+```bash
+# Export presenter notes as a text
+marp --notes slide-deck.md
+marp slide-deck.md -o output.txt
+```
+
 ### Security about local files
 
 Because of [the security reason](https://github.com/marp-team/marp-cli/pull/10#user-content-security), **PDF, PPTX and image(s) conversion cannot use local files by default.**
@@ -491,7 +501,7 @@ If you want to prevent looking up a configuration file, you can pass `--no-confi
 | `jpegQuality`     |           number            |    `--jpeg-quality`    | Setting JPEG image quality (`85` by default)                                                                |
 | `keywords`        |     string \| string[]      |      `--keywords`      | Define keywords for the slide deck (Accepts comma-separated string and array of string)                     |
 | `lang`            |           string            |                        | Define the language of converted HTML                                                                       |
-| `notes`           |           boolean           |       `--notes`        | Convert slide deck into just the text notes                                                                 |
+| `notes`           |           boolean           |       `--notes`        | Convert slide deck notes into a text file                                                                   |
 | `ogImage`         |           string            |      `--og-image`      | Define [Open Graph] image URL                                                                               |
 | `options`         |           object            |                        | The base options for the constructor of engine                                                              |
 | `output`          |           string            |    `--output` `-o`     | Output file path (or directory when input-dir is passed)                                                    |

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -45,6 +45,7 @@ export const mimeTypes = {
   [ConvertType.pptx]:
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   [ConvertType.jpeg]: 'image/jpeg',
+  [ConvertType.notes]: 'text/plain',
 }
 
 export interface ConverterOption {

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -122,15 +122,15 @@ export const marpCli = async (
           group: OptionGroup.Converter,
           type: 'boolean',
         },
-        notes: {
-          conflicts: ['image', 'images', 'pptx', 'pdf'],
-          describe: 'Convert slide deck notes into TXT',
-          group: OptionGroup.Converter,
-          type: 'boolean',
-        },
         pptx: {
           conflicts: ['pdf', 'image', 'images', 'notes'],
           describe: 'Convert slide deck into PowerPoint document',
+          group: OptionGroup.Converter,
+          type: 'boolean',
+        },
+        notes: {
+          conflicts: ['image', 'images', 'pptx', 'pdf'],
+          describe: 'Convert slide deck notes into a text file',
           group: OptionGroup.Converter,
           type: 'boolean',
         },

--- a/src/server.ts
+++ b/src/server.ts
@@ -98,6 +98,8 @@ export class Server extends (EventEmitter as new () => TypedEmitter<Server.Event
       if (queryKeys.includes('png')) return ConvertType.png
       if (queryKeys.includes('jpg') || queryKeys.includes('jpeg'))
         return ConvertType.jpeg
+      if (queryKeys.includes('txt') || queryKeys.includes('notes'))
+        return ConvertType.notes
 
       return ConvertType.html
     })()

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -526,46 +526,6 @@ transition:
       expect(ret.newFile.type).toBe(FileType.StandardIO)
     })
 
-    it('converts markdown file to text and save to specified path when output is defined', async () => {
-      const notesInstance = (opts: Partial<ConverterOption> = {}) =>
-        instance({ ...opts, type: ConvertType.notes })
-      const write = (<any>fs).__mockWriteFile()
-      const output = './specified.txt'
-      const ret = await (<any>notesInstance({ output })).convertFile(
-        new File(threePath),
-        { type: 'notes' }
-      )
-      const notes: Buffer = write.mock.calls[0][1]
-
-      expect(write).toHaveBeenCalled()
-      expect(write.mock.calls[0][0]).toBe('./specified.txt')
-      expect(notes.toString()).toBe('presenter note')
-      expect(ret.newFile?.path).toBe('./specified.txt')
-      expect(ret.newFile?.buffer).toBe(notes)
-    })
-
-    it('converts markdown file to text and save to specified path when output is defined but no notes exist', async () => {
-      const warn = jest.spyOn(console, 'warn').mockImplementation()
-      const notesInstance = (opts: Partial<ConverterOption> = {}) =>
-        instance({ ...opts, type: ConvertType.notes })
-      const write = (<any>fs).__mockWriteFile()
-      const output = './specified.txt'
-      const ret = await (<any>notesInstance({ output })).convertFile(
-        new File(onePath),
-        { type: 'notes' }
-      )
-      const notes: Buffer = write.mock.calls[0][1]
-
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('contains no notes')
-      )
-      expect(write).toHaveBeenCalled()
-      expect(write.mock.calls[0][0]).toBe('./specified.txt')
-      expect(notes.toString()).toBe('')
-      expect(ret.newFile?.path).toBe('./specified.txt')
-      expect(ret.newFile?.buffer).toBe(notes)
-    })
-
     describe('when convert type is PDF', () => {
       const pdfInstance = (opts: Partial<ConverterOption> = {}) =>
         instance({ ...opts, type: ConvertType.pdf })
@@ -983,6 +943,48 @@ transition:
         },
         puppeteerTimeoutMs
       )
+    })
+
+    describe('when convert type is notes', () => {
+      it('converts markdown file to notes text and save to specified path when output is defined', async () => {
+        const notesInstance = (opts: Partial<ConverterOption> = {}) =>
+          instance({ ...opts, type: ConvertType.notes })
+
+        const write = (<any>fs).__mockWriteFile()
+        const output = './specified.txt'
+        const ret = await (<any>notesInstance({ output })).convertFile(
+          new File(threePath)
+        )
+        const notes: Buffer = write.mock.calls[0][1]
+
+        expect(write).toHaveBeenCalled()
+        expect(write.mock.calls[0][0]).toBe('./specified.txt')
+        expect(notes.toString()).toBe('presenter note')
+        expect(ret.newFile?.path).toBe('./specified.txt')
+        expect(ret.newFile?.buffer).toBe(notes)
+      })
+
+      it('converts markdown file to empty text and save to specified path when output is defined but no notes exist', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation()
+        const notesInstance = (opts: Partial<ConverterOption> = {}) =>
+          instance({ ...opts, type: ConvertType.notes })
+
+        const write = (<any>fs).__mockWriteFile()
+        const output = './specified.txt'
+        const ret = await (<any>notesInstance({ output })).convertFile(
+          new File(onePath)
+        )
+        const notes: Buffer = write.mock.calls[0][1]
+
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('contains no notes')
+        )
+        expect(write).toHaveBeenCalled()
+        expect(write.mock.calls[0][0]).toBe('./specified.txt')
+        expect(notes.toString()).toBe('')
+        expect(ret.newFile?.path).toBe('./specified.txt')
+        expect(ret.newFile?.buffer).toBe(notes)
+      })
     })
   })
 

--- a/test/server.ts
+++ b/test/server.ts
@@ -178,6 +178,14 @@ describe('Server', () => {
           const jpegRes = await request(server.server).get('/1.md?jpeg')
           expect(server.converter.options.type).toBe(ConvertType.jpeg)
           expect(jpegRes.type).toBe('image/jpeg')
+
+          const txtRes = await request(server.server).get('/1.md?txt')
+          expect(server.converter.options.type).toBe(ConvertType.notes)
+          expect(txtRes.type).toBe('text/plain')
+
+          const notesRes = await request(server.server).get('/1.md?notes')
+          expect(server.converter.options.type).toBe(ConvertType.notes)
+          expect(notesRes.type).toBe('text/plain')
         })
       })
 


### PR DESCRIPTION
This is following up of #429.

- [x] Modify the order of `--notes` option in CLI help
- [x] Prettify the notes test cases for `Converter` instance
- [x] Add `?notes` query support in server mode
- [x] Update README.md