### PR TITLE
Follow up: the draggable splitter in the presenter view

### DIFF
--- a/src/templates/bespoke/bespoke.scss
+++ b/src/templates/bespoke/bespoke.scss
@@ -194,14 +194,13 @@ $progress-height: 5px;
 
       // Grid layout for presenter view
       display: grid;
-
-      --bespoke-marp-presenter-split-ratio: 66%;
-
       grid-template:
         'current dragbar next' minmax(140px, 1fr)
         'current dragbar note' 2fr
         'info    dragbar note' 3em;
-      grid-template-columns: var(--bespoke-marp-presenter-split-ratio) 0 1fr;
+      grid-template-columns:
+        minmax(3px, var(--bespoke-marp-presenter-split-ratio, 66%))
+        0 minmax(3px, 1fr);
 
       .bespoke-marp-parent {
         grid-area: current;
@@ -227,16 +226,21 @@ $progress-height: 5px;
       .bespoke-marp-presenter-dragbar-container {
         grid-area: dragbar;
         background: #0288d1; // Marp brand color
-        cursor: ew-resize;
+        cursor: col-resize;
         width: 6px;
         margin-left: -3px;
         position: relative;
-        z-index: 1;
+        z-index: 10;
         opacity: 0;
         transition: opacity 0.4s linear 0.1s;
 
         &:hover {
           opacity: 1;
+        }
+
+        &.active {
+          opacity: 1;
+          transition-delay: 0s;
         }
       }
 
@@ -274,6 +278,7 @@ $progress-height: 5px;
         color: $text-color;
         position: relative;
         grid-area: note;
+        z-index: 1;
 
         button {
           @extend %button;

--- a/src/templates/bespoke/presenter/presenter-view.tsx
+++ b/src/templates/bespoke/presenter/presenter-view.tsx
@@ -103,15 +103,37 @@ const presenterView = (deck) => {
   }
 
   const subscribe = (deck) => {
+    // Splitter
+    let isDragging = false
+
+    const startDragging = () => {
+      isDragging = true
+      $(classes.dragbar).classList.add('active')
+    }
+
+    const endDragging = () => {
+      isDragging = false
+      $(classes.dragbar).classList.remove('active')
+    }
+
+    const onDragging = (event: MouseEvent) => {
+      if (!isDragging) return
+
+      const splitRatio =
+        (event.clientX / document.documentElement.clientWidth) * 100
+
+      $(classes.container).style.setProperty(
+        '--bespoke-marp-presenter-split-ratio',
+        `${Math.max(0, Math.min(100, splitRatio))}%`
+      )
+    }
+
+    $(classes.dragbar).addEventListener('mousedown', startDragging)
+    window.addEventListener('mouseup', endDragging)
+    window.addEventListener('mousemove', onDragging)
+
     // Next slide view
     $(classes.nextContainer).addEventListener('click', () => deck.next())
-    $(classes.dragbar).addEventListener('mousedown', startDragging)
-    $(classes.container).addEventListener('mouseup', endDragging)
-    $(classes.container).addEventListener('mousemove', onDragging)
-    $(classes.infoTimer).addEventListener(
-      'click',
-      () => (startTime = new Date())
-    )
 
     const nextIframe = $(classes.next) as HTMLIFrameElement
     const nextNav = createNavigateFunc(nextIframe)
@@ -202,8 +224,9 @@ const presenterView = (deck) => {
         fragmentIndex === fragments.length - 1
     })
 
-    // Current time
+    // Current time and presenter timer
     let startTime = new Date()
+
     const update = () => {
       const time = new Date()
 
@@ -222,22 +245,10 @@ const presenterView = (deck) => {
 
     update()
     setInterval(update, 250)
-  }
 
-  let isDragging = false
-
-  const startDragging = () => (isDragging = true)
-  const endDragging = () => (isDragging = false)
-
-  const onDragging = (event: MouseEvent) => {
-    if (!isDragging) return
-
-    $(classes.container).style.setProperty(
-      '--bespoke-marp-presenter-split-ratio',
-      `${(event.clientX / document.documentElement.clientWidth) * 100}%`
-    )
-
-    event.preventDefault()
+    $(classes.infoTimer).addEventListener('click', () => {
+      startTime = new Date()
+    })
   }
 
   document.body.appendChild(buildContainer(deck.parent))

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -992,32 +992,35 @@ describe("Bespoke template's browser context", () => {
 
       describe('Drag resize', () => {
         let spy
+
         beforeAll(() => {
           spy = jest
             .spyOn(document.documentElement, 'clientWidth', 'get')
             .mockReturnValue(1000)
         })
+
         afterAll(() => {
           spy.mockRestore()
         })
+
         it('resizes on drag', () =>
-          testPresenterView(({ deck }) => {
+          testPresenterView(() => {
             $p(classes.dragbar).dispatchEvent(new MouseEvent('mousedown'))
-            $p(classes.container).dispatchEvent(
-              new MouseEvent('mousemove', { clientX: 200 })
-            )
+            window.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }))
+
             expect(
               $p(classes.container).style.getPropertyValue(
                 '--bespoke-marp-presenter-split-ratio'
               )
             ).toBe('20%')
-            $p(classes.container).dispatchEvent(new MouseEvent('mouseup'))
+
+            window.dispatchEvent(new MouseEvent('mouseup'))
           }))
+
         it('no resize without drag', () =>
-          testPresenterView(({ deck }) => {
-            $p(classes.container).dispatchEvent(
-              new MouseEvent('mousemove', { clientX: 200 })
-            )
+          testPresenterView(() => {
+            window.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }))
+
             expect(
               $p(classes.container).style.getPropertyValue(
                 '--bespoke-marp-presenter-split-ratio'


### PR DESCRIPTION
This is following up of #427.

- [x] Fix locked dragging state when dropped splitter to the out of window
- [x] Improve interaction of the splitter by using `.active` class
- [x] Leave full width of splitter if it was in the edge, to avoid mixing up with window resize handle
- [x] Prettify the code: Align the code block, and define declarations before use as possible
- [ ] Update CHANGELOG.md