### PR TITLE
Prevent recursive mkdir to the root path while saving

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,10 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
+        '@typescript-eslint/consistent-type-assertions': [
+          'error',
+          { assertionStyle: 'as' },
+        ],
       },
     },
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cannot output the conversion result into the drive root ([#442](https://github.com/marp-team/marp-cli/issues/442), [#443](https://github.com/marp-team/marp-cli/pull/443))
+
 ### Changed
 
 - Upgrade Marpit to [v2.2.4](https://github.com/marp-team/marpit/releases/tag/v2.2.4) ([#441](https://github.com/marp-team/marp-cli/pull/441))

--- a/src/file.ts
+++ b/src/file.ts
@@ -147,9 +147,12 @@ export class File {
   }
 
   private async saveToFile(savePath: string = this.path) {
-    await fs.promises.mkdir(path.dirname(path.resolve(savePath)), {
-      recursive: true,
-    })
+    const directory = path.dirname(path.resolve(savePath))
+
+    if (path.dirname(directory) !== directory) {
+      await fs.promises.mkdir(directory, { recursive: true })
+    }
+
     await fs.promises.writeFile(savePath, this.buffer!) // eslint-disable-line @typescript-eslint/no-non-null-assertion
   }
 

--- a/src/server/server-index.ts
+++ b/src/server/server-index.ts
@@ -1,8 +1,8 @@
 export const showAllKey = 'marp-cli-show-all'
 
 export default function serverIndex() {
-  const showAll = <HTMLInputElement>document.getElementById('show-all')
-  const index = <HTMLElement>document.getElementById('index')
+  const showAll = document.getElementById('show-all') as HTMLInputElement
+  const index = document.getElementById('index') as HTMLElement
 
   const applyShowAll = (state: boolean) => {
     showAll.checked = state

--- a/src/templates/bespoke/navigation.ts
+++ b/src/templates/bespoke/navigation.ts
@@ -68,8 +68,8 @@ const bespokeNavigation =
         if (elm?.parentElement) detectScrollable(elm.parentElement, dir)
       }
 
-      if (e.deltaX !== 0) detectScrollable(<HTMLElement>e.target, 'X')
-      if (e.deltaY !== 0) detectScrollable(<HTMLElement>e.target, 'Y')
+      if (e.deltaX !== 0) detectScrollable(e.target as HTMLElement, 'X')
+      if (e.deltaY !== 0) detectScrollable(e.target as HTMLElement, 'Y')
       if (scrollable) return
 
       e.preventDefault()

--- a/test/__mocks__/mkdirp.ts
+++ b/test/__mocks__/mkdirp.ts
@@ -1,3 +1,0 @@
-const mkdirp = jest.fn().mockImplementation((path) => Promise.resolve(path))
-
-export default mkdirp

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -58,7 +58,7 @@ describe('Converter', () => {
         globalDirectives: { theme: 'default' },
         imageScale: 2,
         lang: 'fr',
-        options: <Options>{ html: true },
+        options: { html: true } as Options,
         server: false,
         template: 'test-template',
         templateOption: {},
@@ -489,8 +489,8 @@ transition:
       ).rejects.toBeTruthy())
 
     it('converts markdown file and save as html file by default', async () => {
-      const write = (<any>fs).__mockWriteFile()
-      await (<any>instance()).convertFile(new File(onePath))
+      const write = (fs as any).__mockWriteFile()
+      await (instance() as any).convertFile(new File(onePath))
 
       expect(write).toHaveBeenCalledWith(
         `${onePath.slice(0, -3)}.html`,
@@ -500,9 +500,9 @@ transition:
     })
 
     it('converts markdown file and save to specified path when output is defined', async () => {
-      const write = (<any>fs).__mockWriteFile()
+      const write = (fs as any).__mockWriteFile()
       const output = './specified.html'
-      await (<any>instance({ output })).convertFile(new File(twoPath))
+      await (instance({ output }) as any).convertFile(new File(twoPath))
 
       expect(write).toHaveBeenCalledWith(
         output,
@@ -512,11 +512,11 @@ transition:
     })
 
     it('converts markdown file but not save when output is stdout', async () => {
-      const write = (<any>fs).__mockWriteFile()
+      const write = (fs as any).__mockWriteFile()
       const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
 
       const output = '-'
-      const ret = await (<any>instance({ output })).convertFile(
+      const ret = await (instance({ output }) as any).convertFile(
         new File(threePath)
       )
 
@@ -533,7 +533,7 @@ transition:
       it(
         'converts markdown file into PDF',
         async () => {
-          const write = (<any>fs).__mockWriteFile()
+          const write = (fs as any).__mockWriteFile()
           const opts = { output: 'test.pdf' }
           const ret = await pdfInstance(opts).convertFile(new File(onePath))
           const pdf: Buffer = write.mock.calls[0][1]
@@ -551,7 +551,7 @@ transition:
         it(
           'assigns meta info thorugh pdf-lib',
           async () => {
-            const write = (<any>fs).__mockWriteFile()
+            const write = (fs as any).__mockWriteFile()
 
             await pdfInstance({
               output: 'test.pdf',
@@ -580,7 +580,7 @@ transition:
           async () => {
             const file = new File(onePath)
 
-            const fileCleanup = jest.spyOn(<any>File.prototype, 'cleanup')
+            const fileCleanup = jest.spyOn(File.prototype as any, 'cleanup')
             const fileSave = jest
               .spyOn(File.prototype, 'save')
               .mockImplementation()
@@ -614,7 +614,7 @@ transition:
         it(
           'assigns presenter notes as annotation of PDF',
           async () => {
-            const write = (<any>fs).__mockWriteFile()
+            const write = (fs as any).__mockWriteFile()
 
             await pdfInstance({
               output: 'test.pdf',
@@ -637,7 +637,7 @@ transition:
         )
 
         it('sets a comment author to notes if set author global directive', async () => {
-          const write = (<any>fs).__mockWriteFile()
+          const write = (fs as any).__mockWriteFile()
 
           await pdfInstance({
             output: 'test.pdf',
@@ -673,7 +673,7 @@ transition:
       let write: jest.Mock
 
       beforeEach(() => {
-        write = (<any>fs).__mockWriteFile()
+        write = (fs as any).__mockWriteFile()
       })
 
       const converter = (opts: Partial<ConverterOption> = {}) =>
@@ -781,7 +781,7 @@ transition:
       let write: jest.Mock
 
       beforeEach(() => {
-        write = (<any>fs).__mockWriteFile()
+        write = (fs as any).__mockWriteFile()
       })
 
       it(
@@ -851,7 +851,7 @@ transition:
       let write: jest.Mock
 
       beforeEach(() => {
-        write = (<any>fs).__mockWriteFile()
+        write = (fs as any).__mockWriteFile()
       })
 
       it(
@@ -929,7 +929,7 @@ transition:
           pages: true,
           type: ConvertType.png,
         })
-        write = (<any>fs).__mockWriteFile()
+        write = (fs as any).__mockWriteFile()
       })
 
       it(
@@ -950,9 +950,9 @@ transition:
         const notesInstance = (opts: Partial<ConverterOption> = {}) =>
           instance({ ...opts, type: ConvertType.notes })
 
-        const write = (<any>fs).__mockWriteFile()
+        const write = (fs as any).__mockWriteFile()
         const output = './specified.txt'
-        const ret = await (<any>notesInstance({ output })).convertFile(
+        const ret = await (notesInstance({ output }) as any).convertFile(
           new File(threePath)
         )
         const notes: Buffer = write.mock.calls[0][1]
@@ -969,9 +969,9 @@ transition:
         const notesInstance = (opts: Partial<ConverterOption> = {}) =>
           instance({ ...opts, type: ConvertType.notes })
 
-        const write = (<any>fs).__mockWriteFile()
+        const write = (fs as any).__mockWriteFile()
         const output = './specified.txt'
-        const ret = await (<any>notesInstance({ output })).convertFile(
+        const ret = await (notesInstance({ output }) as any).convertFile(
           new File(onePath)
         )
         const notes: Buffer = write.mock.calls[0][1]
@@ -991,7 +991,7 @@ transition:
   describe('#convertFiles', () => {
     describe('with multiple files', () => {
       it('converts passed files', async () => {
-        const write = (<any>fs).__mockWriteFile()
+        const write = (fs as any).__mockWriteFile()
 
         await instance().convertFiles([new File(onePath), new File(twoPath)])
         expect(write).toHaveBeenCalledTimes(2)
@@ -1008,7 +1008,7 @@ transition:
         ).rejects.toBeInstanceOf(CLIError))
 
       it('converts passed files when output is stdout', async () => {
-        const write = (<any>fs).__mockWriteFile()
+        const write = (fs as any).__mockWriteFile()
         const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
         const files = [new File(onePath), new File(twoPath)]
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -38,7 +38,6 @@ const runForObservation = async (argv: string[]) => {
 }
 
 jest.mock('fs')
-jest.mock('mkdirp')
 jest.mock('../src/preview')
 jest.mock('../src/watcher', () => jest.createMockFromModule('../src/watcher'))
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -224,7 +224,7 @@ describe('Marp CLI', () => {
     const files = assetFn('_files')
 
     let writeFile: jest.Mock
-    beforeEach(() => (writeFile = (<any>fs).__mockWriteFile()))
+    beforeEach(() => (writeFile = (fs as any).__mockWriteFile()))
 
     it('converts files in specified dir', async () => {
       jest.spyOn(cli, 'info').mockImplementation()
@@ -372,7 +372,7 @@ describe('Marp CLI', () => {
       info = jest.spyOn(cli, 'info')
 
       info.mockImplementation()
-      ;(<any>fs).__mockWriteFile()
+      ;(fs as any).__mockWriteFile()
     })
 
     describe('when passed value is theme name', () => {
@@ -395,7 +395,7 @@ describe('Marp CLI', () => {
         const { css } = (await convert.mock.results[0].value).rendered
         expect(css).toContain('/* @theme a */')
 
-        const converter = <Converter>convert.mock.instances[0]
+        const converter: Converter = convert.mock.instances[0]
         const { themeSet } = converter.options
         const theme = themeSet.themes.get(cssFile)
 
@@ -441,7 +441,7 @@ describe('Marp CLI', () => {
       observeSpy = jest.spyOn(ThemeSet.prototype, 'observe')
 
       jest.spyOn(cli, 'info').mockImplementation()
-      ;(<any>fs).__mockWriteFile()
+      ;(fs as any).__mockWriteFile()
     })
 
     describe('with specified single file', () => {
@@ -555,7 +555,7 @@ describe('Marp CLI', () => {
         await marpCli(cmd)
         expect(cvtFiles).toHaveBeenCalled()
 
-        return <any>cvtFiles.mock.instances[0]
+        return cvtFiles.mock.instances[0] as any
       } finally {
         cvtFiles.mockRestore()
         cliInfo.mockRestore()
@@ -564,7 +564,7 @@ describe('Marp CLI', () => {
 
     it('converts file', async () => {
       const cliInfo = jest.spyOn(cli, 'info').mockImplementation()
-      ;(<any>fs).__mockWriteFile()
+      ;(fs as any).__mockWriteFile()
 
       expect(await marpCli([onePath])).toBe(0)
 
@@ -764,7 +764,7 @@ describe('Marp CLI', () => {
     describe('with -w option', () => {
       it('starts watching by Watcher.watch()', async () => {
         jest.spyOn(cli, 'info').mockImplementation()
-        ;(<any>fs).__mockWriteFile()
+        ;(fs as any).__mockWriteFile()
 
         await runForObservation([onePath, '-w'])
         expect(Watcher.watch).toHaveBeenCalledWith([onePath], expect.anything())
@@ -1070,7 +1070,7 @@ describe('Marp CLI', () => {
         .mockResolvedValue(Buffer.from('# markdown'))
 
       // reset cached stdin buffer
-      ;(<any>File).stdinBuffer = undefined
+      ;(File as any).stdinBuffer = undefined
     })
 
     it('converts markdown came from stdin and outputs to stdout', async () => {

--- a/test/server/server-index.ts
+++ b/test/server/server-index.ts
@@ -13,8 +13,8 @@ describe('JavaScript for server index', () => {
       <ul id="index"></ul>
     `.trim()
 
-    index = <HTMLUListElement>document.getElementById('index')
-    showAll = <HTMLInputElement>document.getElementById('show-all')
+    index = document.getElementById('index') as HTMLUListElement
+    showAll = document.getElementById('show-all') as HTMLInputElement
   })
 
   const checkShowAll = (state: boolean) => {

--- a/test/theme.ts
+++ b/test/theme.ts
@@ -75,7 +75,7 @@ describe('ThemeSet', () => {
           expect(themeSet.onThemeUpdated).toHaveBeenCalledWith('testA2.md')
 
           // It does no longer trigger after #unobserve
-          ;(<jest.Mock>themeSet.onThemeUpdated).mockClear()
+          ;(themeSet.onThemeUpdated as jest.Mock).mockClear()
           themeSet.unobserve('testA.md')
 
           await themeSet.load(themeA)

--- a/test/watcher.ts
+++ b/test/watcher.ts
@@ -33,7 +33,7 @@ describe('Watcher', () => {
   const file = new File('test.md')
 
   const createThemeSet = () => {
-    const instance = new (<any>ThemeSet)()
+    const instance = new (ThemeSet as any)()
 
     instance.findPath.mockResolvedValue(['test.css'])
     instance.themes = { delete: jest.fn() }
@@ -42,12 +42,12 @@ describe('Watcher', () => {
   }
 
   const createWatcher = (opts: Partial<Watcher.Options> = {}) =>
-    Watcher.watch(['test.md'], <any>{
+    Watcher.watch(['test.md'], {
       finder: async () => [file],
       converter: {
         convertFiles: jest.fn(),
         options: { themeSet: createThemeSet() },
-      },
+      } as any,
       events: {
         onConverted: jest.fn(),
         onError: jest.fn(),
@@ -68,7 +68,7 @@ describe('Watcher', () => {
       expect(notifier.start).toHaveBeenCalled()
 
       // Chokidar events
-      const on = <jest.Mock>watcher.chokidar.on
+      const on = watcher.chokidar.on as jest.Mock
 
       expect(on).toHaveBeenCalledWith('change', expect.any(Function))
       expect(on).toHaveBeenCalledWith('add', expect.any(Function))
@@ -79,8 +79,8 @@ describe('Watcher', () => {
       const onUnlink = on.mock.calls.find(([e]) => e === 'unlink')[1]
 
       // Callbacks
-      const conv = jest.spyOn(<any>watcher, 'convert').mockImplementation()
-      const del = jest.spyOn(<any>watcher, 'delete').mockImplementation()
+      const conv = jest.spyOn(watcher as any, 'convert').mockImplementation()
+      const del = jest.spyOn(watcher as any, 'delete').mockImplementation()
 
       onChange('change')
       expect(conv).toHaveBeenCalledWith('change')
@@ -251,7 +251,7 @@ describe('WatchNotifier', () => {
 
     afterEach(() => instance.stop())
 
-    const wss = () => (<any>instance).wss
+    const wss = () => (instance as any).wss
 
     it('starts WebSocket server for notify to HTML', async () => {
       expect(wss()).toBeUndefined()


### PR DESCRIPTION
In the platform that allows to save the file into the root by default (Windows), `fs.mkdir` with recursive option to the drive root would fail by the permission error `EPERM`.

I've updated `File` class to prevent calling mkdirp if the output directory is the root.

Fix #442.