### PR TITLE
Remove unnecessary spaces in package.json in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Marp CLI can be configured options with file, such as `marp.config.js`, `marp.co
 {
   "marp": {
     "inputDir": "./slides",
-    "output":" ./public",
+    "output": "./public",
     "themeSet": "./themes"
   }
 }


### PR DESCRIPTION
If you copy and paste this as is and run marp, the output directory will be strange.