### PR TITLE
Add `--test-type` flag to the default Puppeteer launch arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preview mode has unexpected message in the information bar "You are using an unsupported command-line flag" ([#453](https://github.com/marp-team/marp-cli/issues/453), [#454](https://github.com/marp-team/marp-cli/pull/454))
+
 ## v2.0.0 - 2022-05-24
 
 ### ⚡️ Breaking

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -69,7 +69,7 @@ export const generatePuppeteerDataDirPath = async (
 }
 
 export const generatePuppeteerLaunchArgs = () => {
-  const args = new Set<string>(['--export-tagged-pdf'])
+  const args = new Set<string>(['--export-tagged-pdf', '--test-type'])
 
   // Docker environment and WSL environment need to disable sandbox. :(
   if (isDocker() || isWSL()) args.add('--no-sandbox')


### PR DESCRIPTION
Added `--test-type` flag as the default flag for Chromium launched by Puppeteer.

- Windows: Hide a information bar "You are using an unsupported command-line flag". Fix #453.
- macOS: Improve focus handling on the first interaction to the opened preview window.
- CI test: `--test-type` may bring reducing flaky tests in Windows environment.

See also: https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#test--debugging-flags:~:text=extension%20background%20pages.-,%2D%2Dtest%2Dtype,-%3A%20Basically%20the%202014