### PR TITLE
[Transition experiment] Support custom transition declared in `<style scoped>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- [Experimental transition] Parse custom transitions declared in `<style scoped>` ([#456](https://github.com/marp-team/marp-cli/pull/456))
 - [Experimental transition] A basic support of transition with shared elements (just like PowerPoint Morph and Keynote Magic Move) ([#457](https://github.com/marp-team/marp-cli/pull/457))
 
 ## v2.0.1 - 2022-06-01

--- a/src/templates/bespoke/transition.ts
+++ b/src/templates/bespoke/transition.ts
@@ -170,15 +170,23 @@ const bespokeTransition = (deck) => {
           const rootClassList = document.documentElement.classList
           rootClassList.add(transitionWarmUpClass)
 
+          let navigated = false
+
+          const navigate = () => {
+            if (navigated) return
+
+            fn(e)
+            navigated = true
+
+            rootClassList.remove(transitionWarmUpClass)
+          }
+
           doTransition(transition, async () => {
             try {
-              await transition.start(() => {
-                fn(e)
-                rootClassList.remove(transitionWarmUpClass)
-              })
+              await transition.start(navigate)
             } catch (err) {
               console.error(err)
-              fn(e)
+              navigate()
             } finally {
               style.remove()
               rootClassList.remove(transitionWarmUpClass)

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -412,6 +412,33 @@ describe('Converter', () => {
         expect(data.duration).toBe('1s')
       })
     })
+
+    describe('with scoped style', () => {
+      it('assigns transition data with the scoped name of keyframes', async () => {
+        const converter = instance({
+          template: 'bespoke',
+          templateOption: { transition: true },
+        })
+
+        const { result } = await converter.convert(
+          [
+            '<!-- transition: hello -->',
+            '<style scoped>',
+            '  @keyframes marp-transition-hello { to { opacity: 0; } }',
+            '</style>',
+            '\n---\n',
+          ].join('\n')
+        )
+        const $result = load(result)
+
+        const data = $result('section').first().data('transition')
+        expect(data.name).toMatch(/^hello-\w+$/)
+
+        const bData = $result($result('section').get(1)).data('transitionBack')
+        expect(bData.name).toMatch(/^hello-\w+$/)
+        expect(bData.name).toBe(data.name)
+      })
+    })
   })
 
   describe('#convertFile', () => {


### PR DESCRIPTION
#447

A built-in transition plugin for Marpit will recognize [metadata about keyframe scoping](https://github.com/marp-team/marpit/blob/77bead6f1915e16a773f0c343224d7a2925d949e/src/markdown/style/assign.js#L111) during parse, and rewrite the transition name into the scoped keyframe.

By this change, the Markdown author can declare or override the custom transitions that are available only in the current slide page.