### PR TITLE
Allow setting default duration in custom transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [Experimental transition] Allow setting default duration in custom transition through `--marp-transition-duration` ([#459](https://github.com/marp-team/marp-cli/pull/459))
+
 ## v2.0.3 - 2022-06-05
 
 ### Changed

--- a/src/templates/bespoke/transition.ts
+++ b/src/templates/bespoke/transition.ts
@@ -97,7 +97,15 @@ const bespokeTransition = (deck) => {
         })
         .filter((v): v is string => !!v)
     )
-  )
+  ).then(() => {
+    // Workaround for Chrome's animation jank: Disable duration variables in keyframes after prefetch
+    document.querySelectorAll<HTMLStyleElement>('style').forEach((style) => {
+      style.innerHTML = style.innerHTML.replace(
+        /--marp-transition-duration:[^;}]*[;}]/g,
+        (matched) => matched.slice(0, -1) + '!important' + matched.slice(-1)
+      )
+    })
+  })
 
   const transitionCallback =
     (fn: (e: any) => void, { back, cond }: TransitionCallbackOption) =>

--- a/src/templates/bespoke/transition.ts
+++ b/src/templates/bespoke/transition.ts
@@ -35,13 +35,13 @@ const reducedMotionIncomingKeyframes =
 const reducedKeyframes: MarpTransitionKeyframes = {
   forward: {
     both: undefined,
-    incoming: reducedMotionIncomingKeyframes,
-    outgoing: reducedMotionOutgoingKeyframes,
+    incoming: { name: reducedMotionIncomingKeyframes },
+    outgoing: { name: reducedMotionOutgoingKeyframes },
   },
   backward: {
     both: undefined,
-    incoming: reducedMotionIncomingKeyframes,
-    outgoing: reducedMotionOutgoingKeyframes,
+    incoming: { name: reducedMotionIncomingKeyframes },
+    outgoing: { name: reducedMotionOutgoingKeyframes },
   },
 }
 

--- a/src/templates/bespoke/utils/transition.ts
+++ b/src/templates/bespoke/utils/transition.ts
@@ -15,7 +15,7 @@ export type MarpTransitionKeyframeSettings = {
   defaultDuration?: string
 }
 
-type MarpTransitionResolvableKeyframeSettings = Omit<
+export type MarpTransitionResolvableKeyframeSettings = Omit<
   MarpTransitionKeyframeSettings,
   'name'
 >

--- a/test/templates/bespoke.ts
+++ b/test/templates/bespoke.ts
@@ -1503,11 +1503,18 @@ describe("Bespoke template's browser context", () => {
       return deck
     }
 
-    const defineKeyframesMock = (...keyframes: string[]) => {
+    const defineKeyframesMock = (
+      keyframes: string[] = [],
+      opts: transitionUtils.MarpTransitionResolvableKeyframeSettings = {}
+    ) => {
       jest
         .spyOn(transitionUtils, '_testElementAnimation')
         .mockImplementation((elm, resolve) => {
-          resolve(keyframes.includes(elm.style.animationName))
+          resolve(
+            keyframes.includes(elm.style.animationName)
+              ? { ...opts }
+              : undefined
+          )
         })
     }
 
@@ -1576,10 +1583,10 @@ describe("Bespoke template's browser context", () => {
       })
 
       // Set mocked keyframes
-      defineKeyframesMock(
+      defineKeyframesMock([
         'marp-transition-__builtin__built-in',
-        'marp-incoming-transition-custom'
-      )
+        'marp-incoming-transition-custom',
+      ])
 
       // Initialize
       const deck = await initializeBespoke()
@@ -1635,7 +1642,7 @@ describe("Bespoke template's browser context", () => {
       parent.querySelectorAll('section').forEach((section) => {
         section.dataset.transition = JSON.stringify({ name: 'test' })
       })
-      defineKeyframesMock('marp-transition-test')
+      defineKeyframesMock(['marp-transition-test'])
 
       // Initialize
       const deck = await initializeBespoke()


### PR DESCRIPTION
Allowed setting the default duration time of animation for specific custom transition. Declare `--marp-transition-duration` custom property in the first keyframe (`from` or `0%`).

```css
@keyframes marp-incoming-transition-triangle {
  from {
    /* Set the default duration time of "triangle" transition to 1s. */
    --marp-transition-duration: 1s;

    clip-path: polygon(0% 0%, 0% 0%, 0% 0%);
  }
  to {
    clip-path: polygon(0% 0%, 200% 0%, 0% 200%);
  }
}

@keyframes marp-incoming-transition-backward-triangle {
  from {
    /* The duration defined in a forwarding animation will be used in backward animation too. */
    /* A transition author also can set an individual default value to the backward transition. */
    /* --marp-transition-duration: 2.5s; */

    clip-path: polygon(100% 100%, 100% 100%, 100% 100%);
  }
  to {
    clip-path: polygon(-100% 100%, 100% -100%, 100% 100%);
  }
}
```

<details><summary>Memo for cross-browser support...</summary>

Inspecting the custom duration is working only in Chrome. It's OK in the experiment phase, but if API had supported other browsers, we have to consider about abusing an existing animatable property that takes a `<custom-ident>` value, such as `grid-area`.

For getting the state of `--marp-transition-duration` custom property directly in Firefox and Safari, either of `CSS.registerProperty()` or `@property` at-rule is required to mark the property interpolatable and make parsable the specific value within an animation keyframe. There are not supported in neither Firefox nor Safari too.

The `bespoke` template does never try to display the container of transition images as a grid container, so an abused `grid-area` property should not have any harmful effects. I hope no need to do this hack when API was marked as stable, but we may have to consider adding PostCSS plugin to transform the custom property just in case API is coming to Firefox and Safari.

</details>
