### PR TITLE
Add to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN yarn install --production --frozen-lockfile && yarn cache clean && node marp
 # Setup workspace for user
 USER root
 ENV MARP_USER marp:marp
+ENV PATH $PATH:/home/marp/.cli
 
 WORKDIR /home/marp/app
-ENTRYPOINT ["/home/marp/.cli/docker-entrypoint"]
+ENTRYPOINT ["docker-entrypoint"]
 CMD ["--help"]


### PR DESCRIPTION
This allows you to easily use the container image in CI where you would do some non-MARP operations before you invoke the CLI, without having to use the absolute path to the executable.

An example can be found [here](https://gitlab.com/just-ci/templates/-/merge_requests/68/diffs)