### PR TITLE
Allow enabling LayoutNG while PDF conversion via CHROME_LAYOUTNG_PRINTING env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow enabling [LayoutNG](https://www.chromium.org/blink/layoutng/) while PDF conversion via `CHROME_LAYOUTNG_PRINTING` env ([#469](https://github.com/marp-team/marp-cli/pull/469))
+
 ### Changed
 
 - Upgrade Marp Core to [v3.3.1](https://github.com/marp-team/marp-core/releases/v3.3.1) ([#468](https://github.com/marp-team/marp-cli/pull/468))

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -113,8 +113,6 @@ export const generatePuppeteerLaunchArgs = async () => {
     }
   }
 
-  console.log(args)
-
   return {
     executablePath,
     args: [...args],

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -82,6 +82,12 @@ export const generatePuppeteerLaunchArgs = async () => {
   // Enable DocumentTransition API
   if (!process.env.CI) args.add('--enable-blink-features=DocumentTransition')
 
+  // LayoutNG Printing
+  if (process.env.CHROME_LAYOUTNG_PRINTING)
+    args.add(
+      '--enable-blink-features=LayoutNGPrinting,LayoutNGTableFragmentation'
+    )
+
   // Resolve Chrome path to execute
   if (executablePath === false) {
     let findChromeError: Error | undefined
@@ -106,6 +112,8 @@ export const generatePuppeteerLaunchArgs = async () => {
       }
     }
   }
+
+  console.log(args)
 
   return {
     executablePath,

--- a/test/utils/puppeteer.ts
+++ b/test/utils/puppeteer.ts
@@ -178,6 +178,19 @@ describe('#generatePuppeteerLaunchArgs', () => {
     }
   })
 
+  it('enables LayoutNGPrinting and LayoutNGTableFragmentation if defined CHROME_LAYOUTNG_PRINTING environment value', async () => {
+    try {
+      process.env.CHROME_LAYOUTNG_PRINTING = '1'
+
+      const args = await puppeteerUtils().generatePuppeteerLaunchArgs()
+      expect(args.args).toContain(
+        '--enable-blink-features=LayoutNGPrinting,LayoutNGTableFragmentation'
+      )
+    } finally {
+      delete process.env.CHROME_LAYOUTNG_PRINTING
+    }
+  })
+
   describe('with CHROME_PATH env in macOS', () => {
     let originalPlatform: string | undefined
 


### PR DESCRIPTION
By defining `CHROME_LAYOUTNG_PRINTING` env, Marp CLI will enable blink features `LayoutNGPrinting` and `LayoutNGTableFragmentation` to allow using [LayoutNG](https://www.chromium.org/blink/layoutng/) while printing for PDF conversion.
https://bugs.chromium.org/p/chromium/issues/detail?id=1121942

```sh
CHROME_LAYOUTNG_PRINTING=1 marp ./markdown.md --pdf
```

`LayoutNGTableFragmentation` is useful to deal with weird rendering of cropped table. (Reported in marp-team/marp-vscode#330)

It's still in development so we provide as opt-in feature through environment value.