### PR TITLE
fix: use cdn instead of specific mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM node:16.16.0-alpine
 LABEL maintainer "Marp team"
 
 RUN apk update && apk upgrade && \
-    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
-    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
-    echo @edge http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
     apk add --no-cache \
       grep \
       chromium@edge \


### PR DESCRIPTION
This mirror appears to be down, causing the image to fail installing extra packages. Building the image will also fail now.

This changes it to use the cdn, selecting the best mirror (in theory ;-) ) for anyone building the image or adding packages.