### PR TITLE
Update GitHub Actions for testing on Windows

### DIFF
--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -38,7 +38,7 @@ jobs:
         id: yarn
         run: |
           cd $HOME && yarn policies set-version $YARN_VERSION
-          echo "cache_dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          echo "cache_dir=$(yarn cache dir)" >> $env:$GITHUB_OUTPUT
 
       - name: Cache yarn
         uses: actions/cache@v3

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -38,7 +38,7 @@ jobs:
         id: yarn
         run: |
           cd $HOME && yarn policies set-version $YARN_VERSION
-          echo "::set-output name=cache_dir::$(yarn cache dir)"
+          echo "cache_dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn
         uses: actions/cache@v3
@@ -67,8 +67,7 @@ jobs:
           name: coverage
           path: coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: windows
-          version: v0.1.15

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -36,9 +36,10 @@ jobs:
 
       - name: Install yarn
         id: yarn
+        shell: bash
         run: |
           cd $HOME && yarn policies set-version $YARN_VERSION
-          echo "cache_dir=$(yarn cache dir)" >> $env:$GITHUB_OUTPUT
+          echo "cache_dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn
         uses: actions/cache@v3


### PR DESCRIPTION
- Replaced a deprecated `set-output` syntax.
- Update Codecov action to use v3.