### PR TITLE
Support Puppeteer's new headless mode by `PUPPETEER_HEADLESS_MODE=new` env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support [Puppeteer's new headless mode](https://developer.chrome.com/articles/new-headless/) by `PUPPETEER_HEADLESS_MODE=new` env ([#508](https://github.com/marp-team/marp-cli/pull/508))
+
 ## v2.4.0 - 2023-02-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "cosmiconfig": "^8.0.0",
     "import-from": "^4.0.0",
     "is-wsl": "^2.2.0",
-    "puppeteer-core": "19.7.1",
+    "puppeteer-core": "19.7.2",
     "remove": "^0.1.5",
     "serve-index": "^1.9.1",
     "tmp": "^0.2.1",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -98,7 +98,7 @@ export class ResolvedEngine {
   }
 
   // NOTE: It cannot test because of overriding `require` in Jest context.
-  /* c8 ignore next */
+  /* c8 ignore start */
   private findClassPath(klass) {
     for (const moduleId in require.cache) {
       const expt = require.cache[moduleId]?.exports
@@ -113,4 +113,5 @@ export class ResolvedEngine {
     }
     return undefined
   }
+  /* c8 ignore stop */
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -9,6 +9,7 @@ import { File, FileType } from './file'
 import {
   generatePuppeteerDataDirPath,
   generatePuppeteerLaunchArgs,
+  headlessFlag,
   launchPuppeteer,
 } from './utils/puppeteer'
 import { isChromeInWSLHost } from './utils/wsl'
@@ -149,7 +150,7 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
         `--window-size=${this.options.width},${this.options.height}`,
       ],
       defaultViewport: null as any,
-      headless: process.env.NODE_ENV === 'test' ? 'new' : false,
+      headless: process.env.NODE_ENV === 'test' ? headlessFlag : false,
       ignoreDefaultArgs: ['--enable-automation'],
       userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview', {
         wslHost: isChromeInWSLHost(baseArgs.executablePath),

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -9,7 +9,7 @@ import { File, FileType } from './file'
 import {
   generatePuppeteerDataDirPath,
   generatePuppeteerLaunchArgs,
-  headlessFlag,
+  enableHeadless,
   launchPuppeteer,
 } from './utils/puppeteer'
 import { isChromeInWSLHost } from './utils/wsl'
@@ -152,7 +152,7 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
         `--window-size=${this.options.width},${this.options.height}`,
       ],
       defaultViewport: null as any,
-      headless: process.env.NODE_ENV === 'test' ? headlessFlag : false,
+      headless: process.env.NODE_ENV === 'test' ? enableHeadless() : false,
       ignoreDefaultArgs: ['--enable-automation'],
       userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview', {
         wslHost: isChromeInWSLHost(baseArgs.executablePath),

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -83,11 +83,13 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
       close: async () => {
         try {
           return await page.close()
+
+          /* c8 ignore start */
         } catch (e: any) {
           // Ignore raising error if a target page has already close
-          /* c8 ignore next */
           if (!e.message.includes('Target closed.')) throw e
         }
+        /* c8 ignore stop */
       },
       load: async (uri: string) => {
         await page.goto(uri, { timeout: 0, waitUntil: 'domcontentloaded' })
@@ -171,12 +173,13 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
 
     let windowObject: Preview.Window | undefined
 
-    /* c8 ignore next */
+    /* c8 ignore start */
     if (process.platform === 'darwin') {
       // An initial app window is not using in macOS for correct handling activation from Dock
       windowObject = (await this.createWindow()) || undefined
       await page.close()
     }
+    /* c8 ignore stop */
 
     page.on('close', handlePageOnClose)
     this.emit('launch')

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from 'events'
 import { nanoid } from 'nanoid'
 import type { Page, Browser, Target } from 'puppeteer-core'
 import TypedEmitter from 'typed-emitter'
-import macDockIcon from './assets/mac-dock-icon.png'
 import { ConvertType, mimeTypes } from './converter'
 import { error } from './error'
 import { File, FileType } from './file'
@@ -150,24 +149,12 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
         `--window-size=${this.options.width},${this.options.height}`,
       ],
       defaultViewport: null as any,
-      headless: process.env.NODE_ENV === 'test',
+      headless: process.env.NODE_ENV === 'test' ? 'new' : false,
       ignoreDefaultArgs: ['--enable-automation'],
       userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview', {
         wslHost: isChromeInWSLHost(baseArgs.executablePath),
       }),
     })
-
-    // Set Marp icon asynchrnously (only for macOS)
-    this.puppeteerInternal
-      .target()
-      .createCDPSession()
-      .then((session) => {
-        session
-          .send('Browser.setDockTile', { image: macDockIcon.slice(22) })
-          .catch(() => {
-            // No ops
-          })
-      })
 
     const handlePageOnClose = async () => {
       const pages = (await this.puppeteer?.pages()) || []

--- a/src/templates/bespoke/utils/transition.ts
+++ b/src/templates/bespoke/utils/transition.ts
@@ -37,11 +37,12 @@ export const _testElementAnimation = (
   elm: HTMLElement,
   callback: (ret: MarpTransitionResolvableKeyframeSettings | undefined) => void
 ) => {
-  /* c8 ignore next */
+  /* c8 ignore start */
   requestAnimationFrame(() => {
     elm.style.animationPlayState = 'running'
     requestAnimationFrame(() => callback(undefined))
   })
+  /* c8 ignore stop */
 }
 
 const resolvedMarpTransitionKeyframes = new Map<

--- a/src/utils/chrome-finder.ts
+++ b/src/utils/chrome-finder.ts
@@ -28,12 +28,12 @@ export const findChromeInstallation = async () => {
       case 'win32':
         return win32()
       // CI cannot test against WSL environment
-      /* c8 ignore next */
+      /* c8 ignore start */
       case 'wsl':
         return wsl()
     }
-    /* c8 ignore next */
     return []
+    /* c8 ignore stop */
   })()
 
   return installations[0]

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -13,6 +13,11 @@ import { isWSL, resolveWindowsEnv } from './wsl'
 let executablePath: string | undefined | false = false
 let wslTmp: string | undefined
 
+export const headlessFlag =
+  process.env.NODE_ENV === 'test' && process.platform === 'darwin'
+    ? true
+    : ('new' as const)
+
 const isShebang = (path: string) => {
   let fd: number | null = null
 
@@ -124,7 +129,7 @@ export const generatePuppeteerLaunchArgs = async () => {
     executablePath,
     args: [...args],
     pipe: !(isWSL() || isSnapBrowser(executablePath)),
-    headless: 'new' as const,
+    headless: headlessFlag,
 
     // Workaround to avoid force-extensions policy for Chrome enterprise (SET CHROME_ENABLE_EXTENSIONS=1)
     // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-windows
@@ -144,7 +149,7 @@ export const launchPuppeteer = async (
 
     // Set Marp icon asynchrnously (only for macOS)
     browser
-      .target()
+      ?.target()
       .createCDPSession()
       .then((session) => {
         session

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -13,10 +13,8 @@ import { isWSL, resolveWindowsEnv } from './wsl'
 let executablePath: string | undefined | false = false
 let wslTmp: string | undefined
 
-export const headlessFlag =
-  process.env.NODE_ENV === 'test' && process.platform === 'darwin'
-    ? true
-    : ('new' as const)
+export const enableHeadless = (): true | 'new' =>
+  process.env.PUPPETEER_HEADLESS_MODE?.toLowerCase() === 'new' ? 'new' : true
 
 const isShebang = (path: string) => {
   let fd: number | null = null
@@ -129,7 +127,7 @@ export const generatePuppeteerLaunchArgs = async () => {
     executablePath,
     args: [...args],
     pipe: !(isWSL() || isSnapBrowser(executablePath)),
-    headless: headlessFlag,
+    headless: enableHeadless(),
 
     // Workaround to avoid force-extensions policy for Chrome enterprise (SET CHROME_ENABLE_EXTENSIONS=1)
     // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-windows

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -148,6 +148,7 @@ export const launchPuppeteer = async (
     const browser = await launch(options)
 
     // Set Marp icon asynchrnously (only for macOS)
+    /* c8 ignore start */
     browser
       ?.target()
       .createCDPSession()
@@ -158,6 +159,7 @@ export const launchPuppeteer = async (
             // No ops
           })
       })
+    /* c8 ignore stop */
 
     return browser
   } catch (e: unknown) {

--- a/test/preview.ts
+++ b/test/preview.ts
@@ -63,16 +63,17 @@ describe('Preview', () => {
     })
 
     describe('with constructor option about window size', () => {
-      it('opens window that have specified window size', async () => {
-        const instance = preview({ height: 400, width: 200 })
+      it('opens window that have specified (or smaller) window size', async () => {
+        const instance = preview({ height: 600, width: 400 })
         const win = await instance.open('about:blank')
 
-        expect(
-          await win.page.evaluate(() => ({
-            height: window.innerHeight,
-            width: window.innerWidth,
-          }))
-        ).toMatchObject({ height: 400, width: 200 })
+        const { height, width } = await win.page.evaluate(() => ({
+          height: window.innerHeight,
+          width: window.innerWidth,
+        }))
+
+        expect(height).toBeLessThanOrEqual(600)
+        expect(width).toBeLessThanOrEqual(400)
       })
     })
 

--- a/test/utils/puppeteer.ts
+++ b/test/utils/puppeteer.ts
@@ -168,6 +168,7 @@ describe('#generatePuppeteerLaunchArgs', () => {
 
   it("ignores puppeteer's --disable-extensions option if defined CHROME_ENABLE_EXTENSIONS environment value", async () => {
     const replacedEnv = replaceProperty(process, 'env', {
+      ...process.env,
       CHROME_ENABLE_EXTENSIONS: 'true',
     })
 
@@ -181,6 +182,7 @@ describe('#generatePuppeteerLaunchArgs', () => {
 
   it('enables LayoutNGPrinting and LayoutNGTableFragmentation if defined CHROME_LAYOUTNG_PRINTING environment value', async () => {
     const replacedEnv = replaceProperty(process, 'env', {
+      ...process.env,
       CHROME_LAYOUTNG_PRINTING: '1',
     })
 
@@ -197,6 +199,7 @@ describe('#generatePuppeteerLaunchArgs', () => {
   describe('with PUPPETEER_HEADLESS_MODE env', () => {
     it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was empty', async () => {
       const replacedEnv = replaceProperty(process, 'env', {
+        ...process.env,
         PUPPETEER_HEADLESS_MODE: '',
       })
 
@@ -212,6 +215,7 @@ describe('#generatePuppeteerLaunchArgs', () => {
 
     it('uses new headless mode if PUPPETEER_HEADLESS_MODE was "new"', async () => {
       const replacedEnv = replaceProperty(process, 'env', {
+        ...process.env,
         PUPPETEER_HEADLESS_MODE: 'new',
       })
 
@@ -227,6 +231,7 @@ describe('#generatePuppeteerLaunchArgs', () => {
 
     it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was "legacy"', async () => {
       const replacedEnv = replaceProperty(process, 'env', {
+        ...process.env,
         PUPPETEER_HEADLESS_MODE: 'legacy',
       })
 
@@ -242,6 +247,7 @@ describe('#generatePuppeteerLaunchArgs', () => {
 
     it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was "old"', async () => {
       const replacedEnv = replaceProperty(process, 'env', {
+        ...process.env,
         PUPPETEER_HEADLESS_MODE: 'old',
       })
 

--- a/test/utils/puppeteer.ts
+++ b/test/utils/puppeteer.ts
@@ -1,12 +1,9 @@
 import os from 'os'
 import path from 'path'
-import { jest as jestGlobals } from '@jest/globals'
 
 jest.mock('../../src/utils/chrome-finder')
 jest.mock('../../src/utils/edge-finder')
 jest.mock('../../src/utils/wsl')
-
-const { replaceProperty } = jestGlobals
 
 const CLIError = (): typeof import('../../src/error').CLIError =>
   require('../../src/error').CLIError // eslint-disable-line @typescript-eslint/no-var-requires
@@ -167,97 +164,79 @@ describe('#generatePuppeteerLaunchArgs', () => {
   })
 
   it("ignores puppeteer's --disable-extensions option if defined CHROME_ENABLE_EXTENSIONS environment value", async () => {
-    const replacedEnv = replaceProperty(process, 'env', {
-      ...process.env,
-      CHROME_ENABLE_EXTENSIONS: 'true',
-    })
-
     try {
+      process.env.CHROME_ENABLE_EXTENSIONS = 'true'
+
       const args = await puppeteerUtils().generatePuppeteerLaunchArgs()
       expect(args.ignoreDefaultArgs).toContain('--disable-extensions')
     } finally {
-      replacedEnv.restore()
+      delete process.env.CHROME_ENABLE_EXTENSIONS
     }
   })
 
   it('enables LayoutNGPrinting and LayoutNGTableFragmentation if defined CHROME_LAYOUTNG_PRINTING environment value', async () => {
-    const replacedEnv = replaceProperty(process, 'env', {
-      ...process.env,
-      CHROME_LAYOUTNG_PRINTING: '1',
-    })
-
     try {
+      process.env.CHROME_LAYOUTNG_PRINTING = '1'
+
       const args = await puppeteerUtils().generatePuppeteerLaunchArgs()
       expect(args.args).toContain(
         '--enable-blink-features=LayoutNGPrinting,LayoutNGTableFragmentation'
       )
     } finally {
-      replacedEnv.restore()
+      delete process.env.CHROME_LAYOUTNG_PRINTING
     }
   })
 
   describe('with PUPPETEER_HEADLESS_MODE env', () => {
     it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was empty', async () => {
-      const replacedEnv = replaceProperty(process, 'env', {
-        ...process.env,
-        PUPPETEER_HEADLESS_MODE: '',
-      })
-
       try {
+        process.env.PUPPETEER_HEADLESS_MODE = ''
+
         const { headless } =
           await puppeteerUtils().generatePuppeteerLaunchArgs()
 
         expect(headless).toBe(true)
       } finally {
-        replacedEnv.restore()
+        delete process.env.PUPPETEER_HEADLESS_MODE
       }
     })
 
     it('uses new headless mode if PUPPETEER_HEADLESS_MODE was "new"', async () => {
-      const replacedEnv = replaceProperty(process, 'env', {
-        ...process.env,
-        PUPPETEER_HEADLESS_MODE: 'new',
-      })
-
       try {
+        process.env.PUPPETEER_HEADLESS_MODE = 'new'
+
         const { headless } =
           await puppeteerUtils().generatePuppeteerLaunchArgs()
 
         expect(headless).toBe('new')
       } finally {
-        replacedEnv.restore()
+        delete process.env.PUPPETEER_HEADLESS_MODE
       }
     })
 
     it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was "legacy"', async () => {
-      const replacedEnv = replaceProperty(process, 'env', {
-        ...process.env,
-        PUPPETEER_HEADLESS_MODE: 'legacy',
-      })
-
       try {
+        process.env.PUPPETEER_HEADLESS_MODE = 'legacy'
+
         const { headless } =
           await puppeteerUtils().generatePuppeteerLaunchArgs()
 
         expect(headless).toBe(true)
       } finally {
-        replacedEnv.restore()
+        delete process.env.PUPPETEER_HEADLESS_MODE
       }
     })
 
     it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was "old"', async () => {
-      const replacedEnv = replaceProperty(process, 'env', {
-        ...process.env,
-        PUPPETEER_HEADLESS_MODE: 'old',
-      })
-
       try {
+        process.env.PUPPETEER_HEADLESS_MODE = 'old'
+
         const { headless } =
           await puppeteerUtils().generatePuppeteerLaunchArgs()
 
         expect(headless).toBe(true)
       } finally {
-        replacedEnv.restore()
+        delete process.env.PUPPETEER_HEADLESS_MODE
       }
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,6 +2487,13 @@ chrome-launcher@^0.15.1:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
+chromium-bidi@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.4.tgz#44f25d4fa5d2f3debc3fc3948d0657194cac4407"
+  integrity sha512-4BX5cSaponuvVT1+SbLYTOAgDoVtX/Khoc9UsbFJ/AsPVUeFAM3RiIDFI6XFhLYMi9WmVJqh1ZH+dRpNKkKwiQ==
+  dependencies:
+    mitt "3.0.0"
+
 ci-info@^3.2.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
@@ -5593,6 +5600,11 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+mitt@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
+  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
+
 mj-context-menu@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/mj-context-menu/-/mj-context-menu-0.6.1.tgz#a043c5282bf7e1cf3821de07b13525ca6f85aa69"
@@ -6685,11 +6697,12 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
-puppeteer-core@19.7.1:
-  version "19.7.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.7.1.tgz#6f5326ba0a97a7ba63f8f986c3971e31ef42d871"
-  integrity sha512-4b5Go25IA+0xrUIw0Qtqi4nxc0qwdu/C7VT1+tFPl1W27207YT+7bxfANC3PjXMlS6bcbzinCf5YfGqMl8tfyQ==
+puppeteer-core@19.7.2:
+  version "19.7.2"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.7.2.tgz#deee9ef915829b6a1d1a3a008625c29eeb251161"
+  integrity sha512-PvI+fXqgP0uGJxkyZcX51bnzjFA73MODZOAv0fSD35yR7tvbqwtMV3/Y+hxQ0AMMwzxkEebP6c7po/muqxJvmQ==
   dependencies:
+    chromium-bidi "0.4.4"
     cross-fetch "3.1.5"
     debug "4.3.4"
     devtools-protocol "0.0.1094867"


### PR DESCRIPTION
The latest Puppeteer allows `headless: 'new'` option to use more compatible browser rendering that is same as the headful mode.
https://developer.chrome.com/articles/new-headless/

For the time being at least, Marp CLI can unlock the new headless mode an environment value `PUPPETEER_HEADLESS_MODE=new`.

```bash
PUPPETEER_HEADLESS_MODE=new marp ./new-headless.md --pdf
```

> If it became stable, we will change the default headless mode to `new`. If so, users would need to opt-in for using legacy headless mode via `PUPPETEER_HEADLESS_MODE=old`.
