### PR TITLE
Support stable anchor links in `bespoke` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Stable anchor link support in `bespoke` template ([#518](https://github.com/marp-team/marp-cli/pull/518))
 - Support [Puppeteer's new headless mode](https://developer.chrome.com/articles/new-headless/) by `PUPPETEER_HEADLESS_MODE=new` env ([#508](https://github.com/marp-team/marp-cli/pull/508))
 
 ### Changed

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,4 @@
 /* eslint-env jest */
 jest.mock('wrap-ansi')
+
+require('css.escape') // Polyfill for CSS.escape

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "chalk": "^5.2.0",
     "cheerio": "^1.0.0-rc.12",
     "chrome-launcher": "^0.15.1",
+    "css.escape": "^1.5.1",
     "cssnano": "^6.0.0",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",

--- a/src/templates/bespoke/state.ts
+++ b/src/templates/bespoke/state.ts
@@ -66,7 +66,6 @@ const bespokeState = (opts: BespokeStateOption = {}) => {
 
                 if (pageFragments && fragmentElement) {
                   const fragmentIndex = pageFragments.indexOf(fragmentElement)
-                  console.log(fragmentIndex)
                   if (fragmentIndex >= 0) fragment = fragmentIndex
                 }
 

--- a/src/templates/bespoke/state.ts
+++ b/src/templates/bespoke/state.ts
@@ -37,8 +37,46 @@ const bespokeState = (opts: BespokeStateOption = {}) => {
     }
 
     const parseState = (opts: any = { fragment: true }) => {
-      const page = (coerceInt(location.hash.slice(1)) || 1) - 1
-      const fragment = opts.fragment ? coerceInt(readQuery('f') || '') : null
+      let fragment = opts.fragment ? coerceInt(readQuery('f') || '') : null
+
+      const page = (() => {
+        if (location.hash) {
+          // Support text fragments: https://web.dev/text-fragments/
+          const [hashWithoutDelimiter] = location.hash.slice(1).split(':~:')
+
+          const numMatcher = /^\d+$/.test(hashWithoutDelimiter)
+          if (numMatcher) return (coerceInt(hashWithoutDelimiter) ?? 1) - 1
+
+          const anchorTarget =
+            document.getElementById(hashWithoutDelimiter) ||
+            document.querySelector(
+              `a[name="${CSS.escape(hashWithoutDelimiter)}"]`
+            )
+
+          if (anchorTarget) {
+            const { length } = deck.slides
+
+            for (let i = 0; i < length; i += 1) {
+              if (deck.slides[i].contains(anchorTarget)) {
+                // Detect the fragmented list in the parent element
+                const pageFragments = deck.fragments?.[i]
+                const fragmentElement = anchorTarget.closest(
+                  '[data-marpit-fragment]'
+                )
+
+                if (pageFragments && fragmentElement) {
+                  const fragmentIndex = pageFragments.indexOf(fragmentElement)
+                  console.log(fragmentIndex)
+                  if (fragmentIndex >= 0) fragment = fragmentIndex
+                }
+
+                return i
+              }
+            }
+          }
+        }
+        return 0
+      })()
 
       activateSlide(page, fragment)
     }

--- a/test/_browser/viewTransition.ts
+++ b/test/_browser/viewTransition.ts
@@ -26,6 +26,12 @@ beforeEach(() => {
   })
 })
 
+afterEach(() => {
+  if ('startViewTransition' in document) {
+    delete document.startViewTransition
+  }
+})
+
 export const skipTransition = jest.fn()
 
 export const ViewTransition = Object.seal({ skipTransition })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,6 +2816,11 @@ css-what@^6.0.1, css-what@^6.1.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"


### PR DESCRIPTION
`bespoke` template has become to support links for the stable anchor that has assigned to the element in the slide content. (e.g. Slugified Markdown headings, supported by Marp Core v3.6.0)

By this PR, users can jump to the slide page based on contents even if not used a link to the page number such as `[](#3)`.

### Slugs

```markdown
# Title

[Jump to Hello](#hello)

---

## Contents

- ...
- ...

---

## Hello

Example
```

In general Markdown document, a link of "Jump to Hello" can actually jump to "Hello" heading. By the change in this PR, the HTML with `bespoke` template also can jump to the slide page 3.

### Named anchor (with `--html` option)

```markdown
[Jump to closing slide](#closing-slide)

---

...

---

<a name="closing-slide"></a>

Thanks!
```

`bespoke` template also supports the anchor defined through `<a name="..."></a>`. It's useful when there is not any Markdown headings in the slide.

### Stable anchor in fragmented lists

```markdown
[Show up to "Item 2"](#item-2)

* ### Item 1
* ### Item 2
* ### Item 3
```

It may be a rare case, but `bespoke` template can handle the stable anchor within the fragmented list too.

## Related

- marp-team/marp#161