### PR TITLE
Fix an edge case about failure of global directive injection by CLI with `--html` option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,15 +41,15 @@ commands:
 
       - restore_cache:
           keys:
-            - v2.3-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
-            - v2.3-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
-            - v2.3-dependencies-{{ .Environment.CIRCLE_JOB }}-
+            - v2.4-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+            - v2.4-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
+            - v2.4-dependencies-{{ .Environment.CIRCLE_JOB }}-
 
       - run: yarn install --frozen-lockfile
       - steps: << parameters.postinstall >>
 
       - save_cache:
-          key: v2.3-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+          key: v2.4-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
           paths:
             - ~/.cache/yarn
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Upgrade dependent packages to the latest version ([#517](https://github.com/marp-team/marp-cli/pull/517))
 - Change `id` attribute for the whole of `bespoke` template's HTML document, to avoid conflicting with slugs generated from Markdown headings ([#516](https://github.com/marp-team/marp-cli/pull/516))
 
+### Fixed
+
+- Fix an edge case about failure of global directive injection by CLI with `--html` option ([#511](https://github.com/marp-team/marp-cli/issues/511), [#519](https://github.com/marp-team/marp-cli/pull/519))
+
 ## v2.4.0 - 2023-02-19
 
 ### Changed

--- a/src/engine/directive-plugin.ts
+++ b/src/engine/directive-plugin.ts
@@ -1,0 +1,30 @@
+export const generateOverrideGlobalDirectivesPlugin = (
+  directives: Record<string, any>
+) => {
+  return function overrideGlobalDirectivesPlugin(md: any) {
+    md.core.ruler.after(
+      'inline',
+      'marp_cli_override_global_directives',
+      (state) => {
+        if (state.inlineMode) return
+
+        for (const [key, value] of Object.entries(directives)) {
+          if (value !== undefined) {
+            const kv = `${key}: ${value}`
+            const marpitCommentToken = new state.Token('marpit_comment', '', 0)
+
+            marpitCommentToken.hidden = true
+            marpitCommentToken.content = kv
+            marpitCommentToken.markup = `<!-- ${kv} -->`
+            marpitCommentToken.meta = {
+              marpitParsedDirectives: { [key]: value },
+              marpitCommentParsed: 'marp-cli-overridden-global-directives',
+            }
+
+            state.tokens.push(marpitCommentToken)
+          }
+        }
+      }
+    )
+  }
+}

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -143,6 +143,15 @@ describe('Converter', () => {
       expect(disabled.html).toContain('&lt;i&gt;Hello!&lt;/i&gt;')
     })
 
+    it('correctly applies overridden global directives even if enabled HTML option', async () => {
+      const { rendered } = await instance({
+        html: true,
+        globalDirectives: { title: 'Hello' },
+      }).convert('<p>test</p>')
+
+      expect(rendered.title).toBe('Hello')
+    })
+
     it('strips UTF-8 BOM', async () => {
       const noBOM = await instance().convert('---\ntitle: test\n---')
       const BOM = await instance().convert('\ufeff---\ntitle: test\n---')


### PR DESCRIPTION
Fixed #511.

The converter is now using Marpit plugin instead of a simple string injection to override CLI specific global directives.

This change will fix a failure about overriding global directives when `--html` option was enabled and there was a HTML block at the end of Markdown file.