### PR TITLE
Temporarily disable ESM engine resolution when using the standalone binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Temporarily disable ESM engine resolution when using the standalone binary ([#524](https://github.com/marp-team/marp-cli/issues/524), [#525](https://github.com/marp-team/marp-cli/pull/525))
+
 ## v3.0.0 - 2023-06-10
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ export default async (constructorOptions) => {
 }
 ```
 
+> :information_source: Currently ESM engine can resolve only when using Marp CLI via Node.js. [The standalone binary](#standalone-binary) cannot resolve ESM due to [vercel/pkg#1291](https://github.com/vercel/pkg/issues/1291).
+
 #### `marp` getter property
 
 Marp CLI also exposes `marp` getter property to the parameter. It returns a prepared instance of the built-in Marp Core engine, so you can apply several customizations to Marp engine with simple declarations.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     "marp": "marp-cli.js"
   },
   "pkg": {
-    "scripts": "lib/**/*.js"
+    "scripts": "lib/**/*.js",
+    "assets": [
+      "node_modules/vm2/**/*"
+    ]
   },
   "browserslist": [
     "> 1% and last 3 versions",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "get-stdin": "^9.0.0",
     "globby": "^13.1.4",
     "image-size": "^1.0.2",
+    "import-from": "^4.0.0",
     "import-meta-resolve": "^3.0.0",
     "is-docker": "^3.0.0",
     "jest": "^29.5.0",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -222,6 +222,8 @@ export class ResolvedEngine<T extends Engine = Engine> {
         : process.cwd()
 
       return importFrom(resolvedFrom, moduleId) as T | null
+
+      /* c8 ignore start */
     } catch (e) {
       if (isError(e) && e.code === 'ERR_REQUIRE_ESM') {
         // Show reason why `require()` failed in the current context
@@ -231,8 +233,9 @@ export class ResolvedEngine<T extends Engine = Engine> {
           )
         }
       }
-      return null
+      return null // Jest allows importing ESM via `require()` so this line cannot measure coverage.
     }
+    /* c8 ignore stop */
   }
 
   // NOTE: It cannot test because of overriding `require` in Jest context.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8,48 +8,6 @@ import { resolve as importMetaResolve } from 'import-meta-resolve'
 import { pkgUp } from 'pkg-up'
 import { error, isError } from './error'
 
-/** @internal */
-export const _silentImport = async <T = any>(
-  moduleId: string,
-  from?: string
-): Promise<T | null> => {
-  const basePath = path.join(from || process.cwd(), '_.js')
-  const dirPath = path.dirname(basePath)
-  const moduleFilePath = path.resolve(dirPath, moduleId)
-
-  try {
-    const stat = await fs.promises.stat(moduleFilePath)
-
-    if (stat.isFile()) moduleId = url.pathToFileURL(moduleFilePath).toString()
-  } catch (e: unknown) {
-    // No ops
-  }
-
-  try {
-    const resolved = importMetaResolve(
-      moduleId,
-      url.pathToFileURL(basePath).toString()
-    )
-
-    // Try to import without `file:` protocol first
-    if (resolved.startsWith('file:')) {
-      try {
-        return await import(url.fileURLToPath(resolved))
-
-        // NOTE: Fallback cannot test because of overriding `import` in Jest context.
-        /* c8 ignore start */
-      } catch (e) {
-        /* fallback */
-      }
-    }
-
-    return await import(resolved)
-    /* c8 ignore stop */
-  } catch (e) {
-    return null
-  }
-}
-
 type MarpitInstanceOrClass = Marpit | typeof Marpit
 
 type FunctionEngine = (

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3,9 +3,10 @@ import path from 'path'
 import url from 'url'
 import type { Marp } from '@marp-team/marp-core'
 import { Marpit } from '@marp-team/marpit'
+import importFrom from 'import-from'
 import { resolve as importMetaResolve } from 'import-meta-resolve'
 import { pkgUp } from 'pkg-up'
-import { error } from './error'
+import { error, isError } from './error'
 
 /** @internal */
 export const _silentImport = async <T = any>(
@@ -51,11 +52,11 @@ export const _silentImport = async <T = any>(
 
 type MarpitInstanceOrClass = Marpit | typeof Marpit
 
-export type Engine = MarpitInstanceOrClass | FunctionEngine
-
 type FunctionEngine = (
   opts?: Marpit.Options
 ) => MarpitInstanceOrClass | Promise<MarpitInstanceOrClass>
+
+export type Engine = MarpitInstanceOrClass | FunctionEngine
 
 export type ResolvableEngine = Engine | string
 
@@ -112,8 +113,11 @@ export class ResolvedEngine<T extends Engine = Engine> {
       if (typeof eng === 'string') {
         resolved =
           (from &&
-            (await _silentImport(eng, path.dirname(path.resolve(from))))) ||
-          (await _silentImport(eng))
+            (await this._silentImportOrRequire(
+              eng,
+              path.dirname(path.resolve(from))
+            ))) ||
+          (await this._silentImportOrRequire(eng))
       } else if (typeof eng === 'function' && eng[preResolveAsyncSymbol]) {
         resolved = await (eng as any)()
       } else {
@@ -150,6 +154,85 @@ export class ResolvedEngine<T extends Engine = Engine> {
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require(pkgPath) as Record<string, any>
+  }
+
+  static isESMAvailable() {
+    // Standalone binary that is built by pkg cannot import ESM module.
+    // https://github.com/vercel/pkg/issues/1291
+    return !('pkg' in process)
+  }
+
+  private static async _silentImportOrRequire<T = any>(
+    moduleId: string,
+    from?: string
+  ): Promise<T | null> {
+    if (this.isESMAvailable()) return this._silentImport(moduleId, from)
+
+    return this._silentRequire(moduleId, from)
+  }
+
+  private static async _silentImport<T = any>(
+    moduleId: string,
+    from?: string
+  ): Promise<T | null> {
+    const basePath = path.join(from || process.cwd(), '_.js')
+    const dirPath = path.dirname(basePath)
+    const moduleFilePath = path.resolve(dirPath, moduleId)
+
+    try {
+      const stat = await fs.promises.stat(moduleFilePath)
+
+      if (stat.isFile()) moduleId = url.pathToFileURL(moduleFilePath).toString()
+    } catch (e: unknown) {
+      // No ops
+    }
+
+    try {
+      const resolved = importMetaResolve(
+        moduleId,
+        url.pathToFileURL(basePath).toString()
+      )
+
+      // Try to import without `file:` protocol first
+      if (resolved.startsWith('file:')) {
+        try {
+          return await import(url.fileURLToPath(resolved))
+
+          // NOTE: Fallback cannot test because of overriding `import` in Jest context.
+          /* c8 ignore start */
+        } catch (e) {
+          /* fallback */
+        }
+      }
+
+      return await import(resolved)
+      /* c8 ignore stop */
+    } catch (e) {
+      return null
+    }
+  }
+
+  private static async _silentRequire<T = any>(
+    moduleId: string,
+    from?: string
+  ): Promise<T | null> {
+    try {
+      const resolvedFrom = from
+        ? path.dirname(path.resolve(from))
+        : process.cwd()
+
+      return importFrom(resolvedFrom, moduleId) as T | null
+    } catch (e) {
+      if (isError(e) && e.code === 'ERR_REQUIRE_ESM') {
+        // Show reason why `require()` failed in the current context
+        if ('pkg' in process) {
+          error(
+            'A standalone binary version of Marp CLI is currently not supported resolving ESM engine. Please consider using CommonJS engine, or trying to use Marp CLI via Node.js.'
+          )
+        }
+      }
+      return null
+    }
   }
 
   // NOTE: It cannot test because of overriding `require` in Jest context.

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -1,7 +1,5 @@
 import Marp from '@marp-team/marp-core'
-import * as engine from '../src/engine'
-
-const { ResolvedEngine } = engine
+import { ResolvedEngine } from '../src/engine'
 
 afterEach(() => jest.restoreAllMocks())
 
@@ -24,7 +22,10 @@ describe('ResolvedEngine', () => {
 
   describe('#resolveDefaultEngine', () => {
     it('returns ResolvedEngine class with Marp Core which is resolved from current directory', async () => {
-      const importSpy = jest.spyOn(engine, '_silentImport')
+      const importSpy = jest.spyOn(
+        ResolvedEngine as any,
+        '_silentImportOrRequire'
+      )
       const resolvedEngine = await ResolvedEngine.resolveDefaultEngine()
 
       expect(importSpy).toHaveBeenCalledWith('@marp-team/marp-core')
@@ -37,8 +38,8 @@ describe('ResolvedEngine', () => {
 
     it('returns ResolvedEngine class with a function engine to return natively-bundled Marp Core with Promise if failed to resolve from current directory', async () => {
       jest
-        .spyOn(engine, '_silentImport')
-        .mockImplementationOnce(async () => undefined)
+        .spyOn(ResolvedEngine as any, '_silentImportOrRequire')
+        .mockImplementationOnce(async () => null)
 
       const resolvedEngine = await ResolvedEngine.resolveDefaultEngine()
       expect(resolvedEngine.klass).toBe(Marp)

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -297,6 +297,39 @@ describe('Marp CLI', () => {
         error.mockRestore()
       }
     })
+
+    it('uses require() instead of import() to resolve engine when ESM is not available in this context', async () => {
+      const isESMAvailable = jest
+        .spyOn(ResolvedEngine, 'isESMAvailable')
+        .mockReturnValue(false)
+
+      try {
+        const error = jest.spyOn(console, 'error').mockImplementation()
+
+        try {
+          const silentImportSpy = jest.spyOn(
+            ResolvedEngine as any,
+            '_silentImport'
+          )
+          const silentRequireSpy = jest.spyOn(
+            ResolvedEngine as any,
+            '_silentRequire'
+          )
+
+          await marpCli([
+            '--engine',
+            assetFn('_configs/custom-engine/custom-engine.mjs'),
+          ])
+
+          expect(silentImportSpy).not.toHaveBeenCalled()
+          expect(silentRequireSpy).toHaveBeenCalled()
+        } finally {
+          error.mockRestore()
+        }
+      } finally {
+        isESMAvailable.mockRestore()
+      }
+    })
   })
 
   describe('with --input-dir option', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4553,6 +4553,11 @@ import-from@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
+import-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-4.0.0.tgz#2710b8d66817d232e16f4166e319248d3d5492e2"
+  integrity sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==
+
 import-lazy@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"


### PR DESCRIPTION
Marp CLI is using Vercel's [pkg](https://github.com/vercel/pkg) to build standalone binaries. However, it still cannot use ESM resolution via `import()`. Marp CLI v3.0.0 has supported ESM engine, but the standalone binary has been reported failing execution when trying to resolve an integrated Marp Core via `import()` due to lacked ESM support of pkg.

Not only pkg, alternative ways to make a binary also not supported ESM for now: [nexe](https://github.com/nexe/nexe), [the single executable application (Node.js 20)](https://nodejs.org/api/single-executable-applications.html))

So we currently have to disable ESM resolution in the binary packaged by pkg, and must revert to the same way as v2 (using `import-from`). If tried to resolve ESM in the standalone binary, Marp CLI fails with outputting more clear error message.

Close #524 for now.

### ToDo

- [x] Update tests
- [x] Update README