### PR TITLE
Route help messages to stdout instead of stderr

### DIFF
--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -287,7 +287,7 @@ export const marpCli = async (
     }
 
     if (args.help) {
-      program.showHelp()
+      program.showHelp('log')
       return 0
     }
 
@@ -325,11 +325,14 @@ export const marpCli = async (
     const { length } = foundFiles
 
     if (length === 0) {
-      if (config.files.length > 0)
+      if (config.files.length > 0) {
         cli.warn('Not found processable Markdown file(s).\n')
-
-      program.showHelp()
-      return config.files.length > 0 ? 1 : 0
+        program.showHelp('error')
+        return 1
+      } else {
+        program.showHelp('log')
+        return 0
+      }
     }
 
     // Convert markdown into HTML

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -199,27 +199,25 @@ describe('Marp CLI', () => {
     describe(`with ${cmd || 'empty'} option`, () => {
       const run = (...args) => marpCli([...(cmd ? [cmd] : []), ...args])
 
-      let error: jest.SpyInstance<ReturnType<Console['error']>, any>
+      let log: jest.SpyInstance<void, any>
 
       beforeEach(() => {
-        error = jest.spyOn(console, 'error').mockImplementation()
+        log = jest.spyOn(console, 'log').mockImplementation()
       })
 
       afterEach(() => {
-        error?.mockRestore()
+        log?.mockRestore()
       })
 
-      it('outputs help to stderr', async () => {
+      it('outputs help to stdout', async () => {
         expect(await run()).toBe(0)
-        expect(error).toHaveBeenCalledWith(expect.stringContaining('Usage'))
+        expect(log).toHaveBeenCalledWith(expect.stringContaining('Usage'))
       })
 
       describe('Preview option', () => {
         it('outputs help about --preview option', async () => {
           expect(await run()).toBe(0)
-          expect(error).toHaveBeenCalledWith(
-            expect.stringContaining('--preview')
-          )
+          expect(log).toHaveBeenCalledWith(expect.stringContaining('--preview'))
         })
 
         describe('when CLI is running in an official Docker image', () => {
@@ -230,7 +228,7 @@ describe('Marp CLI', () => {
 
             try {
               expect(await run()).toBe(0)
-              expect(error).toHaveBeenCalledWith(
+              expect(log).toHaveBeenCalledWith(
                 expect.not.stringContaining('--preview')
               )
             } finally {
@@ -304,7 +302,7 @@ describe('Marp CLI', () => {
         .mockReturnValue(false)
 
       try {
-        const error = jest.spyOn(console, 'error').mockImplementation()
+        const log = jest.spyOn(console, 'log').mockImplementation()
 
         try {
           const silentImportSpy = jest.spyOn(
@@ -324,7 +322,7 @@ describe('Marp CLI', () => {
           expect(silentImportSpy).not.toHaveBeenCalled()
           expect(silentRequireSpy).toHaveBeenCalled()
         } finally {
-          error.mockRestore()
+          log.mockRestore()
         }
       } finally {
         isESMAvailable.mockRestore()


### PR DESCRIPTION
Hi marp team,

I'd like to suggest to route `--help` messages to stdout instead of stderr so that `marp --help | less` works. This is recommended by the [Gnu Coding Standards on --help](http://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html).

I appreciate you to develop and maintain such a great tool.:smile:
Thanks