### PR TITLE
Don't install the latest harfbuzz to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk update && apk upgrade && \
       chromium@edge \
       freetype@edge \
       libstdc++@edge \
-      harfbuzz@edge \
       ttf-liberation@edge \
       font-noto-cjk@edge \
       font-noto-devanagari@edge \


### PR DESCRIPTION
Now `harfbuzz` has a major update v8. I discovered installing it into docker image breaks PDF generation.

I don't know why installed harfbuzz into Docker image, but currently seems to be not required.

This may resolve #538.