### PR TITLE
Allow async engine.render in converter

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -171,7 +171,7 @@ export class Converter {
 
         tplOpts.modifier?.(engine)
 
-        const ret = engine.render(stripBOM(markdown))
+        const ret = await engine.render(stripBOM(markdown))
 
         const info = engine[engineInfo]
         const outline = engine[pdfOutlineInfo]


### PR DESCRIPTION
Related to discussion https://github.com/orgs/marp-team/discussions/466

The whole context is async already, but the `engine.render` method is not treated as possibly async.
Using `await` here allows to use either non-async and async render method, which is helpful for custom engines.

I have checked that all tests pass using `yarn test`.