### PR TITLE
Review Puppeteer launch args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support the project configuration file written in TypeScript `marp.config.ts` ([#548](https://github.com/marp-team/marp-cli/pull/548), [#549](https://github.com/marp-team/marp-cli/pull/549))
 - `defineConfig` helper for writing typed configuration ([#549](https://github.com/marp-team/marp-cli/pull/549))
+- Recognize `CHROME_NO_SANDBOX` env to allow opt-out of the Chrome/Chromium sandbox during conversion explicitly ([#543](https://github.com/marp-team/marp-cli/issues/543), [#550](https://github.com/marp-team/marp-cli/pull/550))
 
 ### Changed
 

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -75,16 +75,11 @@ export const generatePuppeteerDataDirPath = async (
 export const generatePuppeteerLaunchArgs = async () => {
   const args = new Set<string>(['--export-tagged-pdf', '--test-type'])
 
-  // Docker environment and WSL environment need to disable sandbox. :(
-  if (isInsideContainer() || (await isWSL())) args.add('--no-sandbox')
+  // Docker environment and WSL environment always need to disable sandbox
+  if (process.env.CHROME_NO_SANDBOX || isInsideContainer() || (await isWSL()))
+    args.add('--no-sandbox')
 
-  // Workaround for Chrome 73 in docker and unit testing with CircleCI
-  // https://github.com/GoogleChrome/puppeteer/issues/3774
-  if (isInsideContainer() || process.env.CI)
-    args.add('--disable-features=VizDisplayCompositor')
-
-  // Enable View transitions API
-  if (!process.env.CI) args.add('--enable-blink-features=ViewTransition')
+  args.add('--enable-blink-features=ViewTransition')
 
   // LayoutNG Printing
   if (process.env.CHROME_LAYOUTNG_PRINTING)

--- a/test/utils/puppeteer.ts
+++ b/test/utils/puppeteer.ts
@@ -151,7 +151,18 @@ describe('#generatePuppeteerLaunchArgs', () => {
     }
   })
 
-  it('uses specific settings if running within a container image', async () => {
+  it('disables sandbox if defined CHROME_NO_SANDBOX environment value', async () => {
+    try {
+      process.env.CHROME_NO_SANDBOX = '1'
+
+      const args = await puppeteerUtils().generatePuppeteerLaunchArgs()
+      expect(args.args).toContain('--no-sandbox')
+    } finally {
+      delete process.env.CHROME_NO_SANDBOX
+    }
+  })
+
+  it('disables sandbox if running within a container image', async () => {
     jest.spyOn(container(), 'isInsideContainer').mockImplementation(() => true)
     jest
       .spyOn(chromeFinder(), 'findChromeInstallation')
@@ -159,7 +170,6 @@ describe('#generatePuppeteerLaunchArgs', () => {
 
     const args = await puppeteerUtils().generatePuppeteerLaunchArgs()
     expect(args.args).toContain('--no-sandbox')
-    expect(args.args).toContain('--disable-features=VizDisplayCompositor')
   })
 
   it("ignores puppeteer's --disable-extensions option if defined CHROME_ENABLE_EXTENSIONS environment value", async () => {


### PR DESCRIPTION
- Make opt-outable Chrome sandbox by `CHROME_NO_SANDBOX` env
  - It has designed to become a clear workaround for #543.

* Review arguments for obsolete Chromium versions
  - `--disable-features=VizDisplayCompositor` for CI and container may be no longer required.