### PR TITLE
Render HTML via `Page.setContent()` instead of data URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Upgrade development Node.js LTS to v18.18.0 ([#547](https://github.com/marp-team/marp-cli/pull/547))
 - Upgrade dependent packages to the latest versions ([#548](https://github.com/marp-team/marp-cli/pull/548))
 
+### Fixed
+
+- A huge document fails generating PDF/PPTX/images by `net::ERR_ABORTED` ([#545](https://github.com/marp-team/marp-cli/issues/545), [#551](https://github.com/marp-team/marp-cli/pull/551))
+
 ## v3.2.1 - 2023-08-24
 
 ### Added


### PR DESCRIPTION
In a huge Markdown document, the encoded slide HTML may reach to the limit of data URI length.

I updated how to render a HTML for conversion to use [Puppeteer's `Page.setContent()`](https://pptr.dev/api/puppeteer.page.setcontent). Resolves #545.

> `about:`, the scheme of the default page `about:blank` after `browser.newPage()` is Chrome internal scheme, so it may be insecure because `about:` can access to some Chrome-internal resources provided by other `about:` pages. We should keep a secure scheme `data:` by going to the empty HTML page `data:text/html,` before rendering HTML through `Page.setContent()`.