### PR TITLE
Improve in-memory preview for a large content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve stability of in-memory preview for large content  ([#553](https://github.com/marp-team/marp-cli/pull/553))
+
 ## v3.3.0 - 2023-09-23
 
 ### Added

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -189,13 +189,13 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
     })
 
     const [page] = await this.puppeteerInternal.pages()
+    await page.goto(emptyPageURI, { waitUntil: 'domcontentloaded' })
 
     let windowObject: Preview.Window | undefined
 
     /* c8 ignore start */
     if (process.platform === 'darwin') {
       // An initial app window is not using in macOS for correct handling activation from Dock
-      await page.goto(emptyPageURI, { waitUntil: 'domcontentloaded' })
       windowObject = (await this.createWindow()) || undefined
       await page.close()
     }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -14,6 +14,8 @@ import {
 } from './utils/puppeteer'
 import { isChromeInWSLHost } from './utils/wsl'
 
+const emptyPageURI = `data:text/html;base64,PHRpdGxlPk1hcnAgQ0xJPC90aXRsZT4` // <title>Marp CLI</title>
+
 export namespace Preview {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- TypedEmitter requires type definition instead of interface
   export type Events = {
@@ -165,10 +167,10 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
       ...baseArgs,
       args: [
         ...baseArgs.args,
-        `--app=data:text/html,<title>${encodeURIComponent('Marp CLI')}</title>`,
+        `--app=${emptyPageURI}`,
         `--window-size=${this.options.width},${this.options.height}`,
       ],
-      defaultViewport: null as any,
+      defaultViewport: null,
       headless: process.env.NODE_ENV === 'test' ? enableHeadless() : false,
       ignoreDefaultArgs: ['--enable-automation'],
       userDataDir: await generatePuppeteerDataDirPath('marp-cli-preview', {
@@ -193,6 +195,7 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
     /* c8 ignore start */
     if (process.platform === 'darwin') {
       // An initial app window is not using in macOS for correct handling activation from Dock
+      await page.goto(emptyPageURI, { waitUntil: 'domcontentloaded' })
       windowObject = (await this.createWindow()) || undefined
       await page.close()
     }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -4,7 +4,7 @@ import { nanoid } from 'nanoid'
 import type { Page, Browser, Target } from 'puppeteer-core'
 import TypedEmitter from 'typed-emitter'
 import { ConvertType, mimeTypes } from './converter'
-import { CLIError, error } from './error'
+import { error } from './error'
 import { File, FileType } from './file'
 import {
   generatePuppeteerDataDirPath,


### PR DESCRIPTION
By the same reason as #545, the preview for the result in memory fails in a large output. Changed to use `blob://` URL generated from the buffer for previewing.