### PR TITLE
Accessibility: Render CLI's kind output in a specific color instead of ANSI color

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     ecmaFeatures: { jsx: true },
   },
   rules: {
-    'import/no-unresolved': ['error', { ignore: ['chalk', 'ts-key-enum'] }],
+    'import/no-unresolved': ['error', { ignore: ['ts-key-enum'] }],
     'import/order': ['error', { alphabetize: { order: 'asc' } }],
   },
   settings: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- Improve stability of in-memory preview for large content  ([#553](https://github.com/marp-team/marp-cli/pull/553))
+- Improve stability of in-memory preview for large content ([#553](https://github.com/marp-team/marp-cli/pull/553))
+- Accessibility: Render CLI's kind output in a specific color instead of ANSI color ([#552](https://github.com/marp-team/marp-cli/issues/552), [#554](https://github.com/marp-team/marp-cli/pull/554))
 
 ## v3.3.0 - 2023-09-23
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,3 +2,5 @@
 jest.mock('wrap-ansi')
 
 require('css.escape') // Polyfill for CSS.escape
+
+process.env.FORCE_COLOR = '0'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,9 @@
-import chalk from 'chalk'
+import chalk, { supportsColorStderr } from 'chalk'
 import stripAnsi from 'strip-ansi'
 import wrapAnsi from 'wrap-ansi'
 import { terminalWidth } from 'yargs'
+
+const { has16m, has256 } = { ...supportsColorStderr } // Workaround for type error
 
 interface CLIOption {
   singleLine?: boolean
@@ -27,16 +29,27 @@ export function silence(value: boolean) {
 }
 
 export function info(message: string, opts: CLIOption = {}): void {
+  if (silent) return
+
+  const highlight =
+    has16m || has256 ? chalk.bgHex('#67b8e3').hex('#000') : chalk.inverse
+
   // Use console.warn to output into stderr
-  if (!silent)
-    console.warn(messageBlock(chalk.bgCyan.black('[  INFO ]'), message, opts))
+  console.warn(messageBlock(highlight`[  INFO ]`, message, opts))
 }
 
 export function warn(message: string, opts: CLIOption = {}): void {
-  if (!silent)
-    console.warn(messageBlock(chalk.bgYellow.black('[  WARN ]'), message, opts))
+  if (silent) return
+
+  const highlight =
+    has16m || has256 ? chalk.bgHex('#fc0').hex('#000') : chalk.inverse
+
+  console.warn(messageBlock(highlight`[  WARN ]`, message, opts))
 }
 
 export function error(message: string, opts: CLIOption = {}): void {
-  console.error(messageBlock(chalk.bgRed.white('[ ERROR ]'), message, opts))
+  const highlight =
+    has16m || has256 ? chalk.bgHex('#c00').hex('#fff') : chalk.inverse
+
+  console.error(messageBlock(highlight`[ ERROR ]`, message, opts))
 }


### PR DESCRIPTION
When used ANSI color to both of the text color and background, the content may be inaccessible color depending on the terminal theme choosed by the user. If the terminal was supported 256 colors and more, Marp CLI tries to use a specific color instead of ANSI colors. If not, fallback to simple color inverse `ESC[48m`.

Fix #552.