### PR TITLE
Reflect `lang` global directive to HTML templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Changed
 
 - Upgrade Marpit to [v2.6.1](https://github.com/marp-team/marpit/releases/tag/v2.6.1) ([#557](https://github.com/marp-team/marp-cli/pull/557))
+  - Added `lang` global directive
 - Upgrade Marp Core to [v3.9.0](https://github.com/marp-team/marp-core/releases/v3.9.0) ([#557](https://github.com/marp-team/marp-cli/pull/557))
+  - Enabled [CSS container query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_container_queries) support for child elements of `section` element by default
 - Upgrade dependent packages to the latest versions ([#557](https://github.com/marp-team/marp-cli/pull/557))
+- Reflect the language defined in `lang` global directive to `<html>` element ([#542](https://github.com/marp-team/marp-cli/issues/542), [#558](https://github.com/marp-team/marp-cli/pull/558))
 
 ### Fixed
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -135,7 +135,7 @@ export class Converter {
       fallbackToPrintableTemplate = false,
     }: { fallbackToPrintableTemplate?: boolean } = {}
   ): Promise<TemplateResult> {
-    const { lang, globalDirectives, type } = this.options
+    const { globalDirectives, type } = this.options
 
     const isFile = (f: File | undefined): f is File =>
       !!f && f.type === FileType.File
@@ -159,7 +159,6 @@ export class Converter {
 
     return await template({
       ...(this.options.templateOption || {}),
-      lang,
       base: await resolveBase(file),
       notifyWS:
         isFile(file) && this.options.watch && type === ConvertType.html
@@ -478,8 +477,8 @@ export class Converter {
   private async generateEngine(
     mergeOptions: MarpitOptions
   ): Promise<Marpit & { [engineInfo]?: EngineInfo }> {
-    const { html, options } = this.options
-    const opts = { ...options, ...mergeOptions, html }
+    const { html, lang, options } = this.options
+    const opts = { ...options, lang, ...mergeOptions, html }
 
     let engine = this.options.engine
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -478,7 +478,7 @@ export class Converter {
     mergeOptions: MarpitOptions
   ): Promise<Marpit & { [engineInfo]?: EngineInfo }> {
     const { html, lang, options } = this.options
-    const opts = { ...options, lang, ...mergeOptions, html }
+    const opts = { lang, ...options, ...mergeOptions, html }
 
     let engine = this.options.engine
 

--- a/src/engine/info-plugin.ts
+++ b/src/engine/info-plugin.ts
@@ -3,6 +3,7 @@ export interface EngineInfo {
   description: string | undefined
   image: string | undefined
   keywords: string[] | undefined
+  lang: string | undefined
   length: number
   size: { height: number; width: number }
   theme: string | undefined
@@ -28,6 +29,7 @@ export default function infoPlugin(md: any) {
       description: globalDirectives.marpCLIDescription,
       image: globalDirectives.marpCLIImage,
       keywords: globalDirectives.marpCLIKeywords,
+      lang: globalDirectives.lang || marpit.options.lang,
       title: globalDirectives.marpCLITitle,
       url: globalDirectives.marpCLIURL,
       size: {

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -22,7 +22,6 @@ interface TemplateRendererOptions extends Options {
 
 interface TemplateCoreOption {
   base?: string
-  lang: string
   notifyWS?: string
   renderer: (
     tplOpts: TemplateRendererOptions
@@ -36,6 +35,7 @@ export interface TemplateMeta {
   keywords: string[] | undefined
   title: string | undefined
   url: string | undefined
+  lang: string | undefined
 }
 
 interface RenderedSize {

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -132,6 +132,11 @@ describe('Converter', () => {
       expect(result).toContain('<html lang="zh">')
     })
 
+    it('prefers lang specified in Markdown than lang option', async () => {
+      const { result } = await instance().convert('<!-- lang: fr -->')
+      expect(result).toContain('<html lang="fr">')
+    })
+
     it("overrides html option by converter's html option", async () => {
       const defaultHtml = (await instance().convert('<i><br></i>')).rendered
       expect(defaultHtml.html).toContain('&lt;i&gt;<br />&lt;/i&gt;')


### PR DESCRIPTION
`lang` directive has added since [Marpit framework v2.6.0](https://github.com/marp-team/marpit/releases/tag/v2.6.0). (https://github.com/marp-team/marpit/pull/376)

By this change, `lang` attribute in `<html>` element of templates will determine with the priority in order of below:

- If `lang` global directive was defined in Markdown, it would be set as `lang` attribute of `<html>`.
- If not, `lang` prefers the engine constructor option passed by `options` in configuration file.
- If `options.lang` is not defined, `lang` field of configuration file will be used. (Already implemented)
- If not defined `lang` field, Marp CLI will fallback to OS locale. This is the most general case for now. (Already implemented)

Closes #542.