### PR TITLE
Fix: Add ability to reference external themes (closes #183)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -377,7 +377,9 @@ export class MarpCLIConfig {
         return {
           advice: { use: '--theme-set', insteadOf: '--theme' },
           name: this.args.theme,
-          path: path.resolve(this.args.theme),
+          path: this.args.theme.includes(`http`)
+            ? this.args.theme
+            : path.resolve(this.args.theme),
         }
 
       if (this.conf.theme)

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import { Marpit } from '@marp-team/marpit'
 import { isDynamicPattern } from 'globby'
-import { warn } from './cli'
+import { warn, info } from './cli'
 import { isError } from './error'
 import { File } from './file'
 
@@ -33,7 +33,23 @@ export class Theme {
   }
 
   async load() {
-    this.readBuffer = await fs.promises.readFile(this.filename)
+    if (this.isUrl(this.filename)) {
+      // Fetch the content from a remote URL
+      const response = await fetch(this.filename)
+      this.readBuffer = Buffer.from(await response.text())
+    } else {
+      // Read the content from a local file
+      this.readBuffer = await fs.promises.readFile(this.filename)
+    }
+  }
+
+  private isUrl(filename: string): boolean {
+    try {
+      new URL(filename)
+      return true
+    } catch {
+      return false
+    }
   }
 
   private genUniqName() {


### PR DESCRIPTION
## Description

I like Marp, but I don't particularly like using VS Code. As a user of the CLI, I'd like to be able to write my markdown in any editor and then reference a hosted stylesheet to use as a particular theme. This is common — as an example — for my organization, as we want to use a single source of truth for our template(s).

## Implementation

In the `config.ts`, we don't try to resolve the local path if `http` is included within the string passed to the `--theme` argument:

```ts
path: this.args.theme.includes(`http`)
            ? this.args.theme
            : path.resolve(this.args.theme),
        }
```

Further, on the `load()` function, we either use the local file via a buffer, or fetch the remote file:

```ts
async load() {
    if (this.isUrl(this.filename)) {
      // Fetch the content from a remote URL
      const response = await fetch(this.filename)
      this.readBuffer = Buffer.from(await response.text())
    } else {
      // Read the content from a local file
      this.readBuffer = await fs.promises.readFile(this.filename)
    }
  }

  private isUrl(filename: string): boolean {
    try {
      new URL(filename)
      return true
    } catch {
      return false
    }
  }
```

## Testing

Coverage was above the 95% threshold 🎉 

You can use this ref when building the binary:

```bash
<PATH_TO_BINARY> --theme https://raw.githubusercontent.com/hasura/marp-template/main/custom-default.css -- <PATH_TO_DECK>
```