### PR TITLE
Make `--pdf` work on FreeBSD

### DIFF
--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -106,7 +106,8 @@ export const generatePuppeteerLaunchArgs = async () => {
 
         // https://github.com/marp-team/marp-cli/issues/475
         // https://github.com/GoogleChrome/chrome-launcher/issues/278
-        const chromiumResolvable = process.platform === 'linux'
+        const chromiumResolvable =
+          process.platform === 'linux' || process.platform === 'freebsd'
 
         error(
           `You have to install Google Chrome${


### PR DESCRIPTION
chrome-launcher doesn't support FreeBSD, and just calling `linux()` on FreeBSD would only work when the user sets `CHROME_PATH` because the Chromium port on FreeBSD calls the binary "chrome" and not "google-chrome[-stable]" or "chromium[-stable]" like on Linux.

So this PR adds a really simple function which looks for `CHROME_PATH` and also does `which chrome` when on FreeBSD.