### PR TITLE
Adopt new headless mode by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Upgrade Marp Core to [v4.0.0](https://github.com/marp-team/marp-core/releases/v4.0.0) ([#591](https://github.com/marp-team/marp-cli/pull/591))
   - The slide container of built-in themes became the block element and adopted safe centering
   - Relax HTML allowlist: Allowed a lot of HTML elements and attributes by default
+- Use [the new headless mode of Chrome](https://developer.chrome.com/docs/chromium/headless) while converting by default ([#593](https://github.com/marp-team/marp-cli/pull/593))
+  - You can get back to the old headless mode by setting `PUPPETEER_HEADLESS_MODE=old` env.
 
 ### Added
 

--- a/src/utils/puppeteer.ts
+++ b/src/utils/puppeteer.ts
@@ -15,7 +15,11 @@ let executablePath: string | undefined | false = false
 let wslTmp: string | undefined
 
 export const enableHeadless = (): 'shell' | true =>
-  process.env.PUPPETEER_HEADLESS_MODE?.toLowerCase() === 'new' ? true : 'shell'
+  ['old', 'legacy', 'shell'].includes(
+    process.env.PUPPETEER_HEADLESS_MODE?.toLowerCase() ?? ''
+  )
+    ? 'shell'
+    : true
 
 const isShebang = (path: string) => {
   let fd: number | null = null

--- a/test/utils/puppeteer.ts
+++ b/test/utils/puppeteer.ts
@@ -201,14 +201,14 @@ describe('#generatePuppeteerLaunchArgs', () => {
   })
 
   describe('with PUPPETEER_HEADLESS_MODE env', () => {
-    it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was empty', async () => {
+    it('uses headless mode if PUPPETEER_HEADLESS_MODE was empty', async () => {
       try {
         process.env.PUPPETEER_HEADLESS_MODE = ''
 
         const { headless } =
           await puppeteerUtils().generatePuppeteerLaunchArgs()
 
-        expect(headless).toBe('shell')
+        expect(headless).toBe(true)
       } finally {
         delete process.env.PUPPETEER_HEADLESS_MODE
       }
@@ -243,6 +243,19 @@ describe('#generatePuppeteerLaunchArgs', () => {
     it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was "old"', async () => {
       try {
         process.env.PUPPETEER_HEADLESS_MODE = 'old'
+
+        const { headless } =
+          await puppeteerUtils().generatePuppeteerLaunchArgs()
+
+        expect(headless).toBe('shell')
+      } finally {
+        delete process.env.PUPPETEER_HEADLESS_MODE
+      }
+    })
+
+    it('uses legacy headless mode if PUPPETEER_HEADLESS_MODE was "shell"', async () => {
+      try {
+        process.env.PUPPETEER_HEADLESS_MODE = 'shell'
 
         const { headless } =
           await puppeteerUtils().generatePuppeteerLaunchArgs()


### PR DESCRIPTION
Marp CLI is using the classic headless known as `shell` mode in current Puppeteer.
https://developer.chrome.com/blog/chrome-headless-shell

The headless shell will become to remove from the browser binary in the last of 2024, so we have to update the headless mode into the current. Marp CLI had been able to choose the new headless mode via `PUPPETEER_HEADLESS_MODE=new` env (#508), and now it will be used to revert into the classic headless `shell` via `PUPPETEER_HEADLESS_MODE=old`,`legacy`, or `shell`.