### PR TITLE
Change to pass the location of Chrome data dir through args directly

### DIFF
--- a/src/browser/browsers/chrome.ts
+++ b/src/browser/browsers/chrome.ts
@@ -25,16 +25,18 @@ export class ChromeBrowser extends Browser {
   static readonly kind: BrowserKind = 'chrome'
   static readonly protocol: BrowserProtocol = 'webDriverBiDi'
 
-  private _dataDirName: string
+  private _puppeteerDataDir?: string
+
+  #dataDirName: string
 
   constructor(opts: BrowserOptions) {
     super(opts)
 
-    this._dataDirName = `marp-cli-${nanoid(10)}`
+    this.#dataDirName = `marp-cli-${nanoid(10)}`
   }
 
   protected async launchPuppeteer(
-    opts: PuppeteerLaunchOptions
+    opts: Omit<PuppeteerLaunchOptions, 'userDataDir'> // userDataDir cannot overload in current implementation
   ): Promise<PuppeteerBrowser> {
     const ignoreDefaultArgsSet = new Set(
       typeof opts.ignoreDefaultArgs === 'object' ? opts.ignoreDefaultArgs : []
@@ -50,8 +52,9 @@ export class ChromeBrowser extends Browser {
     const baseOpts = this.generateLaunchOptions({
       headless: this.puppeteerHeadless(),
       pipe: await this.puppeteerPipe(),
-      // userDataDir: await this.createPuppeteerDataDir(), // user data dir will set in args option due to wrong path normalization in WSL
+      // userDataDir: await this.puppeteerDataDir(), // userDataDir will set in args option due to wrong path normalization in WSL
       ...opts,
+      userDataDir: undefined,
       args: await this.puppeteerArgs(opts.args ?? []),
       ignoreDefaultArgs: opts.ignoreDefaultArgs === true || [
         ...ignoreDefaultArgsSet,
@@ -93,7 +96,7 @@ export class ChromeBrowser extends Browser {
 
   private async puppeteerArgs(extraArgs: string[] = []) {
     const args = new Set([
-      `--user-data-dir=${await this.createPuppeteerDataDir()}`,
+      `--user-data-dir=${await this.puppeteerDataDir()}`,
       '--test-type',
       ...extraArgs,
     ])
@@ -123,32 +126,33 @@ export class ChromeBrowser extends Browser {
     return ['old', 'legacy', 'shell'].includes(modeEnv) ? 'shell' : true
   }
 
-  private async createPuppeteerDataDir() {
-    let requiredResolveWSLPath = false
+  private async puppeteerDataDir() {
+    if (this._puppeteerDataDir === undefined) {
+      let requiredResolveWSLPath = false
 
-    const dataDir = await (async () => {
-      // In WSL environment, Marp CLI may use Chrome on Windows. If Chrome has
-      // located in host OS (Windows), we have to specify Windows path.
-      if (await this.browserInWSLHost()) {
-        if (wslTmp === undefined) wslTmp = await resolveWindowsEnv('TMP')
-        if (wslTmp !== undefined) {
-          requiredResolveWSLPath = true
-          return path.win32.resolve(wslTmp, this._dataDirName)
+      this._puppeteerDataDir = await (async () => {
+        // In WSL environment, Marp CLI may use Chrome on Windows. If Chrome has
+        // located in host OS (Windows), we have to specify Windows path.
+        if (await this.browserInWSLHost()) {
+          if (wslTmp === undefined) wslTmp = await resolveWindowsEnv('TMP')
+          if (wslTmp !== undefined) {
+            requiredResolveWSLPath = true
+            return path.win32.resolve(wslTmp, this.#dataDirName)
+          }
         }
-      }
-      return path.resolve(os.tmpdir(), this._dataDirName)
-    })()
+        return path.resolve(os.tmpdir(), this.#dataDirName)
+      })()
 
-    debugBrowser(`Chrome data directory: %s`, dataDir)
+      debugBrowser(`Chrome data directory: %s`, this._puppeteerDataDir)
 
-    // Ensure the data directory is created
-    const mkdirPath = requiredResolveWSLPath
-      ? resolveWSLPathToGuestSync(dataDir)
-      : dataDir
+      // Ensure the data directory is created
+      const mkdirPath = requiredResolveWSLPath
+        ? resolveWSLPathToGuestSync(this._puppeteerDataDir)
+        : this._puppeteerDataDir
 
-    await fs.promises.mkdir(mkdirPath, { recursive: true })
-    debugBrowser(`Created data directory: %s`, mkdirPath)
-
-    return dataDir
+      await fs.promises.mkdir(mkdirPath, { recursive: true })
+      debugBrowser(`Created data directory: %s`, mkdirPath)
+    }
+    return this._puppeteerDataDir
   }
 }

--- a/test/browser/browsers/chrome.ts
+++ b/test/browser/browsers/chrome.ts
@@ -67,7 +67,7 @@ describe('ChromeBrowser', () => {
 
         expect(puppeteer.launch).toHaveBeenCalledWith(
           expect.objectContaining({
-            args: ['--test-type'],
+            args: [expect.stringMatching(/^--user-data-dir=/), '--test-type'],
             ignoreDefaultArgs: [],
           })
         )
@@ -82,7 +82,12 @@ describe('ChromeBrowser', () => {
         // Duplicate arguments should be removed
         expect(puppeteer.launch).toHaveBeenCalledWith(
           expect.objectContaining({
-            args: ['--test-type', '--foo', '--bar'],
+            args: [
+              expect.stringMatching(/^--user-data-dir=/),
+              '--test-type',
+              '--foo',
+              '--bar',
+            ],
             ignoreDefaultArgs: ['--ignore'],
           })
         )
@@ -369,7 +374,9 @@ describe('ChromeBrowser', () => {
 
         const userDataDir = mockedMkdir.mock.calls[0][0]
         expect(puppeteer.launch).toHaveBeenCalledWith(
-          expect.objectContaining({ userDataDir })
+          expect.objectContaining({
+            args: expect.arrayContaining([`--user-data-dir=${userDataDir}`]),
+          })
         )
 
         // Check uniqueness
@@ -407,10 +414,12 @@ describe('ChromeBrowser', () => {
 
         expect(puppeteer.launch).toHaveBeenCalledWith(
           expect.objectContaining({
-            userDataDir: expect.stringContaining(
-              // Chrome is a Windows application, so the path should be Windows style
-              String.raw`C:\Users\user\AppData\Local\Temp\marp-cli-`
-            ),
+            args: expect.arrayContaining([
+              expect.stringContaining(
+                // Chrome is a Windows application, so the path should be Windows style
+                String.raw`--user-data-dir=C:\Users\user\AppData\Local\Temp\marp-cli-`
+              ),
+            ]),
           })
         )
       })


### PR DESCRIPTION
When the specified browser path is located in WSL host OS, `ChromeBrowser.createPuppeteerDataDir()` returns the Windows path even if Marp CLI is working on Linux. However, Puppeteer's `userDataDir` will always normalize the path by a manner of Linux.

So we stopped to use `userDataDir` option and pass the location of Chrome data dir through `args` option directly.