### PR TITLE
Add browser options `--browser` and several sub options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,18 @@
 - Upgrade Marp Core to [v4.0.0](https://github.com/marp-team/marp-core/releases/v4.0.0) ([#591](https://github.com/marp-team/marp-cli/pull/591))
   - The slide container of built-in themes became the block element and adopted safe centering
   - Relax HTML allowlist: Allowed a lot of HTML elements and attributes by default
-- Use [the new headless mode of Chrome](https://developer.chrome.com/docs/chromium/headless) while converting by default ([#593](https://github.com/marp-team/marp-cli/pull/593))
-  - You can get back to the old headless mode by setting `PUPPETEER_HEADLESS_MODE=old` env.
 
 ### Added
 
-<!-- Allow using Firefox / WebDriver BiDi protocol during conversion ([#597](https://github.com/marp-team/marp-cli/pull/597)) -->
-
+- Initial support for Firefox / WebDriver BiDi protocol during conversion ([#565](https://github.com/marp-team/marp-cli/issues/565), [#597](https://github.com/marp-team/marp-cli/pull/597))
+- `--browser` and some related options to control the browser for conversion ([#603](https://github.com/marp-team/marp-cli/pull/603))
 - `--debug` (`-d`) option to CLI interface ([#599](https://github.com/marp-team/marp-cli/pull/599))
 - CI testing against Node.js v22 ([#591](https://github.com/marp-team/marp-cli/pull/591))
 
 ### Changed
 
+- Use [the new headless mode of Chrome](https://developer.chrome.com/docs/chromium/headless) while converting by default ([#593](https://github.com/marp-team/marp-cli/pull/593))
+  - You can get back to the old headless mode by setting `PUPPETEER_HEADLESS_MODE=old` env.
 - Upgrade Marpit to [v3.1.1](https://github.com/marp-team/marpit/releases/tag/v3.1.1) ([#591](https://github.com/marp-team/marp-cli/pull/591))
   - Support for CSS nesting
 - Upgrade development Node.js LTS to v20.17.0 ([#591](https://github.com/marp-team/marp-cli/pull/591))

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ npx @marp-team/marp-cli@latest -w slide-deck.md
 npx @marp-team/marp-cli@latest -s ./slides
 ```
 
-> :information_source: You have to install [Google Chrome]<!--, [Chromium], --> or [Microsoft Edge] to convert slide deck into PDF, PPTX, and image(s).
+> [!IMPORTANT]
+> You have to install any one of [Google Chrome], [Microsoft Edge], or [Mozilla Firefox] to convert slide deck into PDF, PPTX, and image(s). Check out [browser options](#browser-options) for more details.
 
 [google chrome]: https://www.google.com/chrome/
-[chromium]: https://www.chromium.org/
 [microsoft edge]: https://www.microsoft.com/edge
+[mozilla firefox]: https://www.mozilla.org/firefox/new/
 
 ### Docker
 
@@ -65,7 +66,7 @@ You can use the package manager to install and update Marp CLI easily.
 
 _Disclaimer: Package manifests are maintained by the community, not Marp team._
 
-<!-- For contributors: For contributors: This section describes only package managers that Marp manifest has been actively maintained. Each tools are following update within a few days of the latest CLI update. -->
+<!-- For contributors: This section describes only package managers that Marp manifest has been actively maintained. Each tools are following update within a few days of the latest CLI update. -->
 
 #### macOS: **[Homebrew](https://brew.sh/)**
 
@@ -73,7 +74,7 @@ _Disclaimer: Package manifests are maintained by the community, not Marp team._
 brew install marp-cli
 ```
 
-<!-- https://github.com/Homebrew/homebrew-core/blob/master/Formula/marp-cli.rb -->
+<!-- https://github.com/Homebrew/homebrew-core/blob/master/Formula/m/marp-cli.rb -->
 
 #### Windows: **[Scoop](https://scoop.sh/)**
 
@@ -87,13 +88,14 @@ scoop install marp
 
 We recommend to install Marp CLI into your Node.js project. You may control the CLI version (and engine if you want) exactly.
 
-> :information_source: Marp CLI is working only with [actively supported Node.js versions](https://endoflife.date/nodejs), so Node.js v18 and later is required when installing into your Node.js project.
-
 ```bash
 npm install --save-dev @marp-team/marp-cli
 ```
 
 The installed `marp` command is available in [npm-scripts](https://docs.npmjs.com/misc/scripts) or `npx marp`.
+
+> [!NOTE]
+> Marp CLI is working only with [actively supported Node.js versions](https://endoflife.date/nodejs), so Node.js v18 and later is required when installing into your Node.js project.
 
 #### Global installation
 
@@ -113,6 +115,9 @@ We also provide standalone binaries for Linux, macOS, and Windows. These have bu
 
 ## Basic usage
 
+> [!IMPORTANT]
+> Several kind of conversions with 🌐 icon require to install any of compatible browsers, [Google Chrome], [Microsoft Edge], or [Mozilla Firefox]. When an unexpected problem has occurred while converting, please update your browser to the latest version. Check out [browser options](#browser-options) for more details.
+
 ### Convert to HTML
 
 The passed markdown will be converted to HTML file by default. In the below example, a converted `slide-deck.html` will output to the same directory.
@@ -131,7 +136,7 @@ Marp CLI supports converting multiple files by passing multiple paths, directori
 
 When you want to output the converted result to another directory with keeping the origin directory structure, you can use `--input-dir` (`-I`) option. `--output` option would be available for specify the output directory.
 
-### Convert to PDF (`--pdf`)
+### Convert to PDF (`--pdf`) 🌐
 
 If you passed `--pdf` option or the output filename specified by `--output` (`-o`) option ends with `.pdf`, Marp CLI will try to convert Markdown into PDF file through the browser.
 
@@ -139,12 +144,6 @@ If you passed `--pdf` option or the output filename specified by `--output` (`-o
 marp --pdf slide-deck.md
 marp slide-deck.md -o converted.pdf
 ```
-
-All kind of conversions except HTML _require to install [Google Chrome]<!--, [Chromium]-->, [Microsoft Edge], or [Chromium] (flavored) browser._ When an unexpected problem has occurred while converting, please update your browser to the latest version or try installing [Google Chrome Canary].
-
-[google chrome canary]: https://www.google.com/chrome/canary/
-
-> :information_source: If you want to use Chromium or flavored browsers to convert, you have to specify the path to the browser binary through `CHROME_PATH` environment variable. For example: `CHROME_PATH=$(which brave) marp --pdf slide-deck.md`
 
 #### PDF output options
 
@@ -159,7 +158,7 @@ All kind of conversions except HTML _require to install [Google Chrome]<!--, [Ch
 
 [marpit presenter notes]: https://marpit.marp.app/usage?id=presenter-notes
 
-### Convert to PowerPoint document (`--pptx`)
+### Convert to PowerPoint document (`--pptx`) 🌐
 
 Do you want more familiar way to present and share your deck? PPTX conversion to create PowerPoint document is available by passing `--pptx` option or specify the output path with PPTX extension.
 
@@ -176,7 +175,7 @@ A created PPTX includes rendered Marp slide pages and the support of [Marpit pre
 
 > :information_source: A converted PPTX consists of pre-rendered images. Please note that contents would not be able to modify or re-use in PowerPoint.
 
-### Convert to PNG/JPEG image(s)
+### Convert to PNG/JPEG image(s) 🌐
 
 #### Multiple images (`--images`)
 
@@ -213,9 +212,11 @@ You can set the scale factor for rendered image(s) through `--image-scale` optio
 marp slide-deck.md -o title-slide@2x.png --image-scale 2
 ```
 
-> :information_source: `--image-scale` is not affect to the actual size of presentation.
+> [!TIP]
 >
-> It is also available for PPTX conversion. By default, Marp CLI will use `2` as the default scale factor in PPTX to suppress deterioration of slide rendering in full-screen presentation.
+> `--image-scale` is not affect to the actual size of presentation.
+>
+> The scale factor is also available for PPTX conversion. By default, Marp CLI will use `2` as the default scale factor in PPTX, to suppress deterioration of slide rendering in full-screen presentation.
 
 ### Export presenter notes (`--notes`)
 
@@ -229,9 +230,9 @@ marp slide-deck.md -o output.txt
 
 ### Security about local files
 
-Because of [the security reason](https://github.com/marp-team/marp-cli/pull/10#user-content-security), **PDF, PPTX and image(s) conversion cannot use local files by default.**
+Because of [the security reason](https://github.com/marp-team/marp-cli/pull/10#user-content-security), **conversion that is using the browser cannot use local files by default.**
 
-Marp CLI would output incompleted result with warning if the blocked local file accessing is detected. We recommend uploading your assets to online.
+Marp CLI would output incomplete result with warning if the blocked local file accessing is detected. We recommend uploading your assets to online.
 
 If you really need to use local files in these conversion, `--allow-local-files` option helps to find your local files. _Please use only to the trusted Markdown because there is a potential security risk._
 
@@ -255,9 +256,13 @@ Server mode supports on-demand conversion by HTTP request. We require to pass `-
   <img src="https://raw.githubusercontent.com/marp-team/marp-cli/main/docs/images/server-mode.gif" />
 </p>
 
-In this mode, the converted file outputs as the result of accessing to server, and not to disk. You can set the server port by setting the environment variable `PORT`, for example `PORT=5000 marp -s ./slides` would listen on port number 5000.
+In this mode, the converted file outputs as the result of accessing to server, and not to disk.
 
-You would get the converted PDF, PPTX, PNG, and JPEG by adding corresponded query string when requesting. e.g. `http://localhost:8080/deck-a.md?pdf` returns converted PDF.
+You would get the converted PDF, PPTX, PNG, JPEG, and TXT by adding corresponded query string when requesting. e.g. `http://localhost:8080/deck-a.md?pdf` returns converted PDF.
+
+> [!TIP]
+>
+> You can set the server port by setting the environment variable `PORT`. For example, `PORT=5000 marp -s ./slides` would listen on port number 5000.
 
 #### `index.md` / `PITCHME.md`
 
@@ -272,7 +277,51 @@ When conversions were executed together with `--preview` (`-p`) option, Marp CLI
 Unlike opening with browser, you may present deck with the immersive window.
 [Watch mode](#watch-mode) is automatically enabled while using preview window.
 
-> :information_source: `--preview` option cannot use when you are using Marp CLI through official docker image.
+> [!NOTE]
+>
+> `--preview` option cannot use when you are using Marp CLI through official Docker image.
+
+## Browser options
+
+### Choose browser (`--browser`)
+
+You can specify the kind of browser for conversion by `--browser` option. Available browsers are `chrome`, `edge`, and `firefox`. If set comma-separated browsers, Marp CLI will try to use the first available browser among them.
+
+```bash
+# Use Firefox for image conversion
+marp --browser firefox ./slide.md -o slide.png
+
+# Prefer to use Firefox first, then Chrome
+marp --browser firefox,chrome ./slide.md -o slide.png
+```
+
+The default is a special value `auto`, which means to use the first available browser from `chrome,edge,firefox`.
+
+> [!WARNING]
+>
+> _Firefox support is still early stage._ The PDF output generated by Firefox may include some incompatible renderings compared to the PDF generated by Chrome.
+
+### Browser path (`--browser-path`)
+
+If you have a browser binary that cannot find out by Marp CLI automatically, you can explicitly set the path to the browser executable through `--browser-path` option.
+
+```bash
+# Use Chromium-flavored browser (Chromium, Brave, Vivaldi, etc...)
+marp --browser-path /path/to/chromium-flavored-browser ./slide.md -o slide.pdf
+
+# Use Firefox with explicitly set path
+marp --browser firefox --browser-path /path/to/firefox ./slide.md -o slide.png
+```
+
+### Other browser options
+
+- **`--browser-protocol`**: Set the preferred protocol for connecting to the browser.
+  - `cdp`: [Chrome DevTools Protocol][cdp] (default)
+  - `webdriver-bidi`: [WebDriver BiDi]
+- **`--browser-timeout`**: Set the timeout for each browser operation in seconds. (default: `30` seconds)
+
+[cdp]: https://chromedevtools.github.io/devtools-protocol/
+[webdriver bidi]: https://w3c.github.io/webdriver-bidi/
 
 ## Template
 
@@ -292,14 +341,12 @@ The `bespoke` template is using [Bespoke.js](https://github.com/bespokejs/bespok
 - **Fullscreen**: Toggle fullscreen by hitting <kbd>f</kbd> / <kbd>F11</kbd> key.
 - **On-screen controller**: There is a touch-friendly OSC. You may also disable by `--bespoke.osc=false` if unneccesary.
 - **Fragmented list**: Recognize [Marpit's fragmented list](https://github.com/marp-team/marpit/issues/145) and appear list one-by-one if used `*` and `1)` as the bullet marker.
-- **Presenter view**: Open presenter view in external window by hitting <kbd>p</kbd> key.
+- **Presenter view**: Open presenter view in external window by hitting <kbd>p</kbd> key. (It may become disabled when not fulfilled requirements for working)
 - **Progress bar** (optional): By setting `--bespoke.progress` option, you can add a progress bar on the top of the deck.
 - [**Slide transitions**][transitions]: Support transitions (`transition` local directive) powered by [View Transitions API].
 
 [transitions]: ./docs/bespoke-transitions/README.md
 [view transitions api]: https://www.w3.org/TR/css-view-transitions-1/
-
-> ℹ️ Presenter view may be disabled if [the browser restricted using localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage) (e.g. Open HTML in the old Safari with private browsing, or open the _local_ HTML file with Chrome that has blocked 3rd party cookies in `chrome://settings/content/cookies`).
 
 #### Docs
 
@@ -334,10 +381,8 @@ Through [global directives] or CLI options, you can set metadata for a converted
 |    `description`    | `--description` | Define description of the slide | HTML, PDF, PPTX |
 |      `author`       |   `--author`    | Define author of the slide deck | HTML, PDF, PPTX |
 |     `keywords`      |  `--keywords`   | Define comma-separated keywords | HTML, PDF       |
-|        `url`        |     `--url`     | Define [canonical URL] \*       | HTML            |
+|        `url`        |     `--url`     | Define [canonical URL]          | HTML            |
 |       `image`       |  `--og-image`   | Define [Open Graph] image URL   | HTML            |
-
-> \*: If could not parse a specified value as valid, the URL will be ignored.
 
 [canonical url]: https://en.wikipedia.org/wiki/Canonical_link_element
 [open graph]: http://ogp.me/
@@ -383,7 +428,9 @@ A custom theme created by user also can use easily by passing the path of CSS fi
 marp --theme custom-theme.css
 ```
 
-> :information_source: Normally [Marpit theme CSS requires `@theme` meta comment](https://marpit.marp.app/theme-css?id=metadata), but it's not required in this usage.
+> [!TIP]
+>
+> [Marpit theme CSS requires `@theme` meta comment](https://marpit.marp.app/theme-css?id=metadata) in regular use, but it's not required in this usage.
 
 ### Theme set
 
@@ -417,6 +464,8 @@ marp --engine @marp-team/marpit marpit-deck.md
 
 Notice that Marpit has not provided theme. It would be good to include inline style in Markdown, or pass CSS file by `--theme` option.
 
+> [!TIP]
+>
 > If you want to use the Marpit-based custom engine by the module name, the specified module must be exporting a class inherited from Marpit as the default export.
 
 ### Functional engine
@@ -455,7 +504,9 @@ export default async (constructorOptions) => {
 }
 ```
 
-> :information_source: Currently ES Modules can resolve only when using Marp CLI via Node.js. [The standalone binary](#standalone-binary) cannot resolve ESM due to [vercel/pkg#1291](https://github.com/vercel/pkg/issues/1291).
+> [!WARNING]
+>
+> Currently ES Modules can resolve only when using Marp CLI via Node.js. [The standalone binary](#standalone-binary) cannot resolve ESM. ([vercel/pkg#1291](https://github.com/vercel/pkg/issues/1291))
 
 #### `marp` getter property
 
@@ -551,7 +602,9 @@ By default we use configuration file that is placed on current directory, but yo
 
 If you want to prevent looking up a configuration file, you can pass `--no-config-file` (`--no-config`) option.
 
-> :information_source: Currently ES Modules can resolve only when using Marp CLI via Node.js. [The standalone binary](#standalone-binary) cannot resolve ESM due to [vercel/pkg#1291](https://github.com/vercel/pkg/issues/1291).
+> [!WARNING]
+>
+> Currently ES Modules can resolve only when using Marp CLI via Node.js. [The standalone binary](#standalone-binary) cannot resolve ESM. ([vercel/pkg#1291](https://github.com/vercel/pkg/issues/1291))
 
 ### Options
 
@@ -563,6 +616,10 @@ If you want to prevent looking up a configuration file, you can pass `--no-confi
 | ┗ `osc`           |           boolean           |      `--bespoke.osc`      | \[Bespoke\] Use on-screen controller (`true` by default)                                                    |
 | ┗ `progress`      |           boolean           |   `--bespoke.progress`    | \[Bespoke\] Use progress bar (`false` by default)                                                           |
 | ┗ `transition`    |           boolean           |  `--bespoke.transition`   | \[Bespoke\] Use [transitions] (Only in browsers supported [View Transitions API]: `true` by default)        |
+| `browser`         |     string \| string[]      |        `--browser`        | The kind of browser for conversion (`auto` by default)                                                      |
+| `browserPath`     |           string            |     `--browser-path`      | Path to the browser executable                                                                              |
+| `browserProtocol` |  `cdp` \| `webdriver-bidi`  |   `--browser-protocol`    | Set the preferred protocol for connecting to the browser (`cdp` by default)                                 |
+| `browserTimeout`  |           number            |    `--browser-timeout`    | Set the timeout for each browser operation in seconds (`30` by default)                                     |
 | `description`     |           string            |      `--description`      | Define description of the slide deck                                                                        |
 | `engine`          | string \| Class \| Function |        `--engine`         | Specify Marpit based engine                                                                                 |
 | `html`            |      boolean \| object      |         `--html`          | Enable or disable HTML tags (Configuration file can pass [the whitelist object] if you are using Marp Core) |
@@ -594,12 +651,12 @@ If you want to prevent looking up a configuration file, you can pass `--no-confi
 
 [the whitelist object]: https://github.com/marp-team/marp-core#html-boolean--object
 
-Some of options that cannot specify through CLI options can be configured by file.
-
-For example, `options` field can set the base options for the constructor of the used engine. You can fine-tune constructor options for the engine, [Marp Core](https://github.com/marp-team/marp-core#constructor-options) / [Marpit](https://marpit-api.marp.app/marpit).
+Some of options that cannot specify through CLI options can be configured by file. (e.g. `options` field for the constructor option of used engine)
 
 <details>
 <summary>Example: Customize engine's constructor option</summary>
+
+You can fine-tune constructor options for the engine, [Marp Core](https://github.com/marp-team/marp-core#constructor-options) / [Marpit](https://marpit-api.marp.app/marpit).
 
 ```json
 {
@@ -617,7 +674,9 @@ This configuration will set the constructor option for Marp Core as specified:
 - Disables [Marp Core's line breaks conversion](https://github.com/marp-team/marp-core#marp-markdown) (`\n` to `<br />`) to match for CommonMark, by passing [markdown-it's `breaks` option](https://markdown-it.github.io/markdown-it/#MarkdownIt.new) as `false`.
 - Disable minification for rendered theme CSS to make debug your style easily, by passing [`minifyCSS`](https://github.com/marp-team/marp-core#minifycss-boolean) as `false`.
 
-> :warning: Some options may be overridden by used template.
+> [!WARNING]
+>
+> Some options may be overridden by used template.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npx @marp-team/marp-cli@latest -s ./slides
 ```
 
 > [!IMPORTANT]
-> You have to install any one of [Google Chrome], [Microsoft Edge], or [Mozilla Firefox] to convert slide deck into PDF, PPTX, and image(s). Check out [browser options](#browser-options) for more details.
+> You have to install any one of [Google Chrome], [Microsoft Edge], or [Mozilla Firefox] to convert slide deck into PDF, PPTX, and image(s).
 
 [google chrome]: https://www.google.com/chrome/
 [microsoft edge]: https://www.microsoft.com/edge
@@ -116,7 +116,7 @@ We also provide standalone binaries for Linux, macOS, and Windows. These have bu
 ## Basic usage
 
 > [!IMPORTANT]
-> Several kind of conversions with 🌐 icon require to install any of compatible browsers, [Google Chrome], [Microsoft Edge], or [Mozilla Firefox]. When an unexpected problem has occurred while converting, please update your browser to the latest version. Check out [browser options](#browser-options) for more details.
+> Several kind of conversions with 🌐 icon require to install any of compatible browsers, [Google Chrome], [Microsoft Edge], or [Mozilla Firefox]. When an unexpected problem has occurred while converting, please update your browser to the latest version. Check out [browser options](#browser-options) too.
 
 ### Convert to HTML
 
@@ -173,7 +173,9 @@ A created PPTX includes rendered Marp slide pages and the support of [Marpit pre
   <img src="https://raw.githubusercontent.com/marp-team/marp-cli/main/docs/images/pptx.png" height="300" />
 </p>
 
-> :information_source: A converted PPTX consists of pre-rendered images. Please note that contents would not be able to modify or re-use in PowerPoint.
+> [!WARNING]
+>
+> A converted PPTX consists of pre-rendered images. Please note that **contents would not be able to modify** or re-use in PowerPoint.
 
 ### Convert to PNG/JPEG image(s) 🌐
 

--- a/src/browser/finder.ts
+++ b/src/browser/finder.ts
@@ -19,11 +19,19 @@ export type BrowserFinder = (
   opts: BrowserFinderOptions
 ) => Promise<BrowserFinderResult>
 
-const finderMap = { chrome, edge, firefox } as const
+export type FinderName = keyof typeof availableFindersMap
 
-export type FinderName = keyof typeof finderMap
+const availableFindersMap = { chrome, edge, firefox } as const
 
-export const defaultFinders = ['chrome', 'edge', 'firefox'] as const
+export const availableFinders = Object.keys(
+  availableFindersMap
+) as readonly FinderName[]
+
+export const defaultFinders = [
+  'chrome',
+  'edge',
+  'firefox',
+] as const satisfies readonly FinderName[]
 
 export const findBrowser = async (
   finders: readonly FinderName[] = defaultFinders,
@@ -68,7 +76,7 @@ export const findBrowser = async (
     const resolved = Array<boolean | undefined>(finderCount)
 
     finders.forEach((finderName, index) => {
-      const finder = finderMap[finderName]
+      const finder = availableFindersMap[finderName]
 
       finder(normalizedOpts)
         .then((ret) => {

--- a/src/browser/finders/edge.ts
+++ b/src/browser/finders/edge.ts
@@ -1,9 +1,6 @@
 import path from 'node:path'
 import { error, CLIErrorCode } from '../../error'
-import {
-  resolveWSLPathToGuestSync,
-  resolveWindowsEnvSync,
-} from '../../utils/wsl'
+import { translateWindowsPathToWSL, getWindowsEnv } from '../../utils/wsl'
 import { ChromeBrowser } from '../browsers/chrome'
 import { ChromeCdpBrowser } from '../browsers/chrome-cdp'
 import type { BrowserFinder, BrowserFinderResult } from '../finder'
@@ -83,12 +80,14 @@ const edgeFinderWin32 = async ({
 }
 
 const edgeFinderWSL1 = async () => {
-  const localAppData = resolveWindowsEnvSync('LOCALAPPDATA')
+  const localAppData = await getWindowsEnv('LOCALAPPDATA')
 
   return await edgeFinderWin32({
     programFiles: '/mnt/c/Program Files',
     programFilesX86: '/mnt/c/Program Files (x86)',
-    localAppData: localAppData ? resolveWSLPathToGuestSync(localAppData) : '',
+    localAppData: localAppData
+      ? await translateWindowsPathToWSL(localAppData)
+      : '',
     join: path.posix.join,
   })
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ import path from 'node:path'
 import chalk from 'chalk'
 import { cosmiconfig, cosmiconfigSync } from 'cosmiconfig'
 import { osLocale } from 'os-locale'
+import { availableFinders } from './browser/finder'
+import type { FinderName } from './browser/finder'
 import type { BrowserManagerConfig } from './browser/manager'
 import { info, warn, error as cliError } from './cli'
 import { ConvertType, type ConverterOption } from './converter'
@@ -13,8 +15,6 @@ import { TemplateOption } from './templates'
 import { Theme, ThemeSet } from './theme'
 import { isStandaloneBinary } from './utils/binary'
 import { isOfficialDockerImage } from './utils/container'
-import { availableFinders } from './browser/finder'
-import type { FinderName } from './browser/finder'
 
 type Overwrite<T, U> = Omit<T, Extract<keyof T, keyof U>> & U
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -37,7 +37,7 @@ import { ThemeSet } from './theme'
 import { isOfficialDockerImage } from './utils/container'
 import { debug } from './utils/debug'
 import { pdfLib, setOutline } from './utils/pdf'
-import { resolveWSLPathToHost } from './utils/wsl'
+import { translateWSLPathToWindows } from './utils/wsl'
 import { notifier } from './watcher'
 
 const CREATED_BY_MARP = 'Created by Marp'
@@ -161,7 +161,7 @@ export class Converter {
         const browser = await this.browser
 
         return (await browser.browserInWSLHost())
-          ? `file:${await resolveWSLPathToHost(f.absolutePath)}`
+          ? `file:${await translateWSLPathToWindows(f.absolutePath)}`
           : f.absoluteFileScheme
       }
 
@@ -643,7 +643,7 @@ export class Converter {
 
     if (tmpFile) {
       if (await browser.browserInWSLHost()) {
-        uri = `file:${await resolveWSLPathToHost(tmpFile.path)}`
+        uri = `file:${await translateWSLPathToWindows(tmpFile.path)}`
       } else {
         uri = `file://${tmpFile.path}`
       }

--- a/src/error.ts
+++ b/src/error.ts
@@ -17,6 +17,7 @@ export class CLIError extends Error {
 }
 
 export const CLIErrorCode = {
+  INVALID_OPTIONS: -1,
   GENERAL_ERROR: 1,
   NOT_FOUND_BROWSER: 2,
   LISTEN_PORT_IS_ALREADY_USED: 3,

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -12,15 +12,17 @@ import { isOfficialDockerImage } from './utils/container'
 import { createYargs } from './utils/yargs'
 import version from './version'
 import watcher, { Watcher, notifier } from './watcher'
+import { availableFinders } from './browser/finder'
 
-enum OptionGroup {
-  Basic = 'Basic Options:',
-  Converter = 'Converter Options:',
-  Template = 'Template Options:',
-  PDF = 'PDF Options:',
-  Meta = 'Metadata Options:',
-  Marp = 'Marp / Marpit Options:',
-}
+const OptionGroup = {
+  Basic: 'Basic Options:',
+  Converter: 'Converter Options:',
+  Template: 'Template Options:',
+  Browser: 'Browser Options:',
+  PDF: 'PDF Options:',
+  Meta: 'Metadata Options:',
+  Marp: 'Marp / Marpit Options:',
+} as const
 
 export interface MarpCLIOptions {
   baseUrl?: string
@@ -44,7 +46,70 @@ const usage = `
 Usage:
   marp [options] <files...>
   marp [options] -I <dir>
-`.trim()
+`
+  .trim()
+  .replaceAll(' ', '\u2009') // https://github.com/yargs/yargs/issues/2120#issuecomment-1065802242
+
+const coerceImage = (image: string) => {
+  if (image === '') return 'png'
+
+  const normalized = image.toLowerCase().trim()
+  if (normalized === 'jpg' || normalized === 'jpeg') return 'jpeg'
+  if (normalized === 'png') return 'png'
+
+  return image // Expect to be handled error by yargs
+}
+
+const coerceBrowser = (browser: string | false) => {
+  if (browser === false) return []
+
+  const normalize = (str: string) => str.toLowerCase().trim()
+  const isAvailable = (finder: string) =>
+    (availableFinders as string[]).includes(normalize(finder))
+
+  const normalized = normalize(browser)
+  if (normalized === '' || normalized === 'auto') return 'auto'
+  if (isAvailable(normalized)) return normalized
+
+  // Try parsing as comma-separated list
+  const browsers = normalized
+    .split(',')
+    .flatMap((b) => (isAvailable(normalize(b)) ? normalize(b) : []))
+
+  if (browsers.length > 1) return browsers
+  if (browsers.length === 1) return browsers[0]
+
+  return browser // Expect to be handled error by yargs
+}
+
+const coerceBrowserProtocol = (protocol: string | false) => {
+  if (protocol === false) return undefined
+
+  const normalized = protocol.toLowerCase().trim()
+
+  if (normalized === 'cdp' || normalized === 'webdriver-bidi') return normalized
+  if (normalized === 'webdriver') return 'webdriver-bidi'
+  if (normalized === 'bidi') return 'webdriver-bidi'
+
+  return protocol // Expect to be handled error by yargs
+}
+
+const coerceBrowserTimeout = (timeout: string | number | boolean) => {
+  const t = timeout.toString()
+  if (timeout === false || t.toLowerCase() === 'false') return 0
+  if (timeout === true || t.toLowerCase() === 'true') return undefined
+
+  const [num, base] = (() => {
+    if (t.endsWith('ms')) return [t.slice(0, -2), 0.001]
+    if (t.endsWith('s')) return [t.slice(0, -1), 1]
+    return [t, 1]
+  })()
+
+  const parsed = Number.parseFloat(num)
+  if (Number.isNaN(parsed)) throw new Error(`Invalid number for timeout: ${t}`)
+
+  return parsed * base
+}
 
 export const marpCli = async (
   argv: string[],
@@ -154,11 +219,7 @@ export const marpCli = async (
           describe: 'Convert the first slide page into an image file',
           group: OptionGroup.Converter,
           choices: ['png', 'jpeg'],
-          coerce: (type: string) => {
-            if (type === '') return 'png'
-            if (type === 'jpg') return 'jpeg'
-            return type
-          },
+          coerce: coerceImage,
           type: 'string',
         },
         images: {
@@ -166,15 +227,11 @@ export const marpCli = async (
           describe: 'Convert slide deck into multiple image files',
           group: OptionGroup.Converter,
           choices: ['png', 'jpeg'],
-          coerce: (type: string) => {
-            if (type === '') return 'png'
-            if (type === 'jpg') return 'jpeg'
-            return type
-          },
+          coerce: coerceImage,
           type: 'string',
         },
         'image-scale': {
-          defaultDescription: '1 (or 2 for PPTX conversion)',
+          defaultDescription: '1 (or 2 for PPTX)',
           describe: 'The scale factor for rendered images',
           group: OptionGroup.Converter,
           type: 'number',
@@ -216,6 +273,36 @@ export const marpCli = async (
           defaultDescription: 'true',
           group: OptionGroup.Template,
           type: 'boolean',
+        },
+        browser: {
+          describe:
+            'The kind of browser to use for PDF, PPTX, and image conversion',
+          choices: ['auto', ...availableFinders],
+          defaultDescription: '"auto"',
+          group: OptionGroup.Browser,
+          coerce: coerceBrowser,
+          type: 'string',
+        },
+        'browser-path': {
+          describe:
+            'Path to the browser executable (Find automatically if not set)',
+          group: OptionGroup.Browser,
+          type: 'string',
+        },
+        'browser-protocol': {
+          describe: 'Preferred protocol to use for browser connection',
+          choices: ['cdp', 'webdriver-bidi'],
+          defaultDescription: '"cdp"',
+          group: OptionGroup.Browser,
+          coerce: coerceBrowserProtocol,
+          type: 'string',
+        },
+        'browser-timeout': {
+          describe:
+            'Timeout for each browser operation in seconds (0 to disable)',
+          defaultDescription: '30',
+          group: OptionGroup.Browser,
+          coerce: coerceBrowserTimeout,
         },
         'pdf-notes': {
           describe: 'Add presenter notes to PDF as annotations',

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { availableFinders } from './browser/finder'
 import { BrowserManager } from './browser/manager'
 import * as cli from './cli'
 import { fromArguments } from './config'
@@ -12,7 +13,6 @@ import { isOfficialDockerImage } from './utils/container'
 import { createYargs } from './utils/yargs'
 import version from './version'
 import watcher, { Watcher, notifier } from './watcher'
-import { availableFinders } from './browser/finder'
 
 const OptionGroup = {
   Basic: 'Basic Options:',

--- a/src/utils/__mocks__/yargs.ts
+++ b/src/utils/__mocks__/yargs.ts
@@ -1,0 +1,6 @@
+const watcher = jest.requireActual('../yargs')
+const { createYargs } = watcher
+
+watcher.createYargs = (...opts) => createYargs(...opts).locale('en')
+
+export = watcher

--- a/src/utils/wsl.ts
+++ b/src/utils/wsl.ts
@@ -1,6 +1,6 @@
 import { execFile as cpExecFile } from 'node:child_process'
-import { promisify } from 'node:util'
 import fs from 'node:fs'
+import { promisify } from 'node:util'
 import { debug } from './debug'
 
 const execFile = promisify(cpExecFile)

--- a/src/utils/wsl.ts
+++ b/src/utils/wsl.ts
@@ -1,36 +1,26 @@
-import { execFile, spawnSync } from 'node:child_process'
+import { execFile as cpExecFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import fs from 'node:fs'
 import { debug } from './debug'
 
+const execFile = promisify(cpExecFile)
+const resolveStdout = ({ stdout }: { stdout: string }) => stdout.trim()
+
+export const translateWSLPathToWindows = async (wslPath: string) =>
+  await execFile('wslpath', ['-m', wslPath]).then(resolveStdout)
+
+export const translateWindowsPathToWSL = async (winPath: string) =>
+  await execFile('wslpath', ['-u', winPath]).then(resolveStdout)
+
+export const getWindowsEnv = async (envName: string) => {
+  const ret = await execFile('cmd.exe', ['/c', 'SET', envName]).then(
+    resolveStdout
+  )
+  if (ret.startsWith(`${envName}=`)) return ret.slice(envName.length + 1)
+  return undefined
+}
+
 let isWsl: number | Promise<number> | undefined
-
-export const resolveWSLPathToHost = async (path: string): Promise<string> =>
-  await new Promise<string>((res, rej) => {
-    execFile('wslpath', ['-m', path], (err, stdout) =>
-      err ? rej(err) : res(stdout.trim())
-    )
-  })
-
-export const resolveWSLPathToGuestSync = (path: string): string =>
-  spawnSync('wslpath', ['-u', path]).stdout.toString().trim()
-
-export const resolveWindowsEnv = async (
-  key: string
-): Promise<string | undefined> => {
-  const ret = await new Promise<string>((res, rej) => {
-    execFile('cmd.exe', ['/c', 'SET', key], (err, stdout) =>
-      err ? rej(err) : res(stdout.trim())
-    )
-  })
-
-  return ret.startsWith(`${key}=`) ? ret.slice(key.length + 1) : undefined
-}
-
-export const resolveWindowsEnvSync = (key: string): string | undefined => {
-  const ret = spawnSync('cmd.exe', ['/c', 'SET', key]).stdout.toString().trim()
-  return ret.startsWith(`${key}=`) ? ret.slice(key.length + 1) : undefined
-}
-
 const wsl2VerMatcher = /microsoft-standard-wsl2/i
 
 export const isWSL = async (): Promise<number> => {
@@ -66,6 +56,5 @@ export const isWSL = async (): Promise<number> => {
       }
     })().then((correctedIsWsl) => (isWsl = correctedIsWsl))
   }
-
   return await isWsl
 }

--- a/test/__mocks__/cosmiconfig.ts
+++ b/test/__mocks__/cosmiconfig.ts
@@ -9,7 +9,7 @@ const {
 
 // Because of v8's bug, Jest fails with SIGSEGV if used dynamic import.
 // When using ESM in tests, you have to set up Jest to transpile config files into CommonJS with Babel.
-cosmiconfig.cosmiconfig = jest.fn((moduleName, options) => {
+cosmiconfig.cosmiconfig = (moduleName, options) => {
   return originalCosmiconfig(moduleName, {
     loaders: {
       // cosmiconfig sync loader is using `require()` to load JS
@@ -21,6 +21,6 @@ cosmiconfig.cosmiconfig = jest.fn((moduleName, options) => {
     },
     ...(options ?? {}),
   })
-})
+}
 
 module.exports = cosmiconfig

--- a/test/__mocks__/express.ts
+++ b/test/__mocks__/express.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events'
 const express = jest.requireActual('express')
 
 express.__errorOnListening = undefined
-express.application.listen = jest.fn(() => {
+express.application.listen = () => {
   const serverMock = Object.assign(new EventEmitter(), {
     close: (callback) => callback(),
   })
@@ -17,6 +17,6 @@ express.application.listen = jest.fn(() => {
   }, 0)
 
   return serverMock
-})
+}
 
 module.exports = express

--- a/test/__mocks__/get-stdin.ts
+++ b/test/__mocks__/get-stdin.ts
@@ -1,3 +1,5 @@
-module.exports = {
-  buffer: jest.fn().mockResolvedValue(''),
-}
+const getStdin = Object.assign(async () => '', {
+  buffer: async () => Buffer.from(''),
+})
+
+export default getStdin

--- a/test/__mocks__/wrap-ansi.ts
+++ b/test/__mocks__/wrap-ansi.ts
@@ -1,1 +1,1 @@
-module.exports = jest.fn().mockImplementation((m) => m) // No ops
+module.exports = (m: string) => m // No ops

--- a/test/browser/browsers/chrome.ts
+++ b/test/browser/browsers/chrome.ts
@@ -20,6 +20,7 @@ describe('ChromeBrowser', () => {
         .spyOn(puppeteer as any, 'launch')
         .mockResolvedValue({ once: jest.fn() })
 
+      jest.spyOn(wsl, 'isWSL').mockResolvedValue(0)
       jest.spyOn(fs.promises, 'mkdir').mockImplementation()
     })
 
@@ -388,11 +389,11 @@ describe('ChromeBrowser', () => {
       it('makes data directory to Windows if trying to spawn Chrome in the host Windows from WSL', async () => {
         jest.spyOn(wsl, 'isWSL').mockResolvedValue(1)
         jest
-          .spyOn(wsl, 'resolveWindowsEnv')
+          .spyOn(wsl, 'getWindowsEnv')
           .mockResolvedValue(String.raw`C:\Users\user\AppData\Local\Temp`)
         jest
-          .spyOn(wsl, 'resolveWSLPathToGuestSync')
-          .mockImplementation((path) =>
+          .spyOn(wsl, 'translateWindowsPathToWSL')
+          .mockImplementation(async (path) =>
             path
               .replace(/\\/g, '/')
               .replace(

--- a/test/browser/finders/edge.ts
+++ b/test/browser/finders/edge.ts
@@ -218,11 +218,11 @@ describe('Edge finder', () => {
         .spyOn(utils, 'isExecutable')
         .mockImplementation(async (p) => p === wsl1EdgePath)
       jest
-        .spyOn(wsl, 'resolveWindowsEnvSync')
-        .mockReturnValue('C:\\Mock\\AppData\\Local')
+        .spyOn(wsl, 'getWindowsEnv')
+        .mockResolvedValue('C:\\Mock\\AppData\\Local')
       jest
-        .spyOn(wsl, 'resolveWSLPathToGuestSync')
-        .mockReturnValue('/mnt/c/mock/AppData/Local')
+        .spyOn(wsl, 'translateWindowsPathToWSL')
+        .mockResolvedValue('/mnt/c/mock/AppData/Local')
     })
 
     it('finds possible executable path and returns the matched path', async () => {
@@ -250,7 +250,7 @@ describe('Edge finder', () => {
     })
 
     it('skips inaccessible directories to find', async () => {
-      jest.spyOn(wsl, 'resolveWindowsEnvSync').mockReturnValue(undefined)
+      jest.spyOn(wsl, 'getWindowsEnv').mockResolvedValue(undefined)
 
       const findExecutableSpy = jest.spyOn(utils, 'findExecutable')
       await edgeFinder({})

--- a/test/index.ts
+++ b/test/index.ts
@@ -3,55 +3,46 @@ import getStdin from 'get-stdin'
 import api, { CLIError } from '../src/index'
 import * as marpCli from '../src/marp-cli'
 
-const stdinBuffer = getStdin.buffer
-
-afterEach(() => jest.clearAllMocks())
+afterEach(() => {
+  jest.clearAllMocks()
+  jest.restoreAllMocks()
+})
 
 describe('Marp CLI API interface', () => {
   it('runs Marp CLI with specific options', async () => {
     const marpCliSpy = jest.spyOn(marpCli, 'marpCli').mockResolvedValue(0)
 
-    try {
-      const ret = await api([], { baseUrl: 'https://example.com/' })
+    const ret = await api([], { baseUrl: 'https://example.com/' })
 
-      expect(ret).toBe(0)
-      expect(marpCliSpy).toHaveBeenCalled()
+    expect(ret).toBe(0)
+    expect(marpCliSpy).toHaveBeenCalled()
 
-      const opts: marpCli.MarpCLIOptions = marpCliSpy.mock.calls[0][1]
+    const opts: marpCli.MarpCLIOptions = marpCliSpy.mock.calls[0][1]
 
-      expect(opts.baseUrl).toBe('https://example.com/')
-      expect(opts.stdin).toBe(false)
-      expect(opts.throwErrorAlways).toBe(true)
-    } finally {
-      marpCliSpy.mockRestore()
-    }
+    expect(opts.baseUrl).toBe('https://example.com/')
+    expect(opts.stdin).toBe(false)
+    expect(opts.throwErrorAlways).toBe(true)
   })
 
   it('does not read input from stdin if called API', async () => {
-    const cliStdout = jest.spyOn(console, 'log').mockImplementation()
+    jest.spyOn(console, 'log').mockImplementation()
 
-    try {
-      await marpCli.cliInterface([])
-      expect(stdinBuffer).toHaveBeenCalled()
-      ;(stdinBuffer as jest.Mock).mockClear()
+    const stdinBuffer = jest.spyOn(getStdin, 'buffer')
 
-      await api([])
-      expect(stdinBuffer).not.toHaveBeenCalled()
-    } finally {
-      cliStdout.mockRestore()
-    }
+    await marpCli.cliInterface([])
+    expect(stdinBuffer).toHaveBeenCalled()
+
+    stdinBuffer.mockClear()
+    await api([])
+    expect(stdinBuffer).not.toHaveBeenCalled()
   })
 
   it('always throws error if CLI met an error to suspend', async () => {
-    const cliError = jest.spyOn(console, 'error').mockImplementation()
+    jest.spyOn(console, 'error').mockImplementation()
 
-    try {
-      const fakePath = path.resolve(__dirname, '__fake')
+    const fakePath = path.resolve(__dirname, '__fake')
 
-      expect(await marpCli.cliInterface(['-c', fakePath])).toBeGreaterThan(0)
-      await expect(api(['-c', fakePath])).rejects.toBeInstanceOf(CLIError)
-    } finally {
-      cliError.mockRestore()
-    }
+    expect(await marpCli.cliInterface(['-c', fakePath])).toBeGreaterThan(0)
+    await expect(api(['-c', fakePath])).rejects.toBeInstanceOf(CLIError)
   })
 })

--- a/test/index.ts
+++ b/test/index.ts
@@ -45,4 +45,13 @@ describe('Marp CLI API interface', () => {
     expect(await marpCli.cliInterface(['-c', fakePath])).toBeGreaterThan(0)
     await expect(api(['-c', fakePath])).rejects.toBeInstanceOf(CLIError)
   })
+
+  it('always throws error if CLI has failed to parse options', async () => {
+    jest.spyOn(console, 'error').mockImplementation()
+
+    expect(await marpCli.cliInterface(['--image', 'unknown'])).toBeGreaterThan(
+      0
+    )
+    await expect(api(['--image', 'unknown'])).rejects.toBeInstanceOf(CLIError)
+  })
 })

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -736,9 +736,14 @@ describe('Marp CLI', () => {
       describe('with --browser-path option', () => {
         it('uses the path as the preferred path of finder', async () => {
           expect(
-            (await conversion(onePath, '--browser-path', '/path/to/browser'))
-              .options.browserManager['_finderPreferredPath']
-          ).toBe('/path/to/browser')
+            (
+              await conversion(
+                onePath,
+                '--browser-path',
+                path.join('path', 'to', 'browser')
+              )
+            ).options.browserManager['_finderPreferredPath']
+          ).toBe(path.join('path', 'to', 'browser'))
 
           // Relative path
           const resolved = (

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -683,13 +683,42 @@ describe('Marp CLI', () => {
           ).toStrictEqual(['firefox'])
         })
 
-        it('prints error when --browser is unknown browser', async () => {
+        it('prints yargs error when --browser is unknown browser', async () => {
           const error = jest.spyOn(console, 'error').mockImplementation()
 
           expect(await marpCli([onePath, '--browser', 'unknown'])).toBe(1)
 
           expect(error).toHaveBeenCalledWith(
             expect.stringContaining('Invalid values')
+          )
+        })
+
+        it('uses a specific browser finder when browser option in configuration file is a kind of browser', async () => {
+          const conf = assetFn('_configs/marpit/config.js')
+
+          jest.spyOn(Explorer.prototype, 'load').mockResolvedValue({
+            filepath: conf,
+            config: { browser: 'firefox' },
+          })
+
+          expect(
+            (await conversion(onePath, '--config', conf)).options
+              .browserManager['_finders']
+          ).toStrictEqual(['firefox'])
+        })
+
+        it('prints error when browser option in configuration file is unknown browser', async () => {
+          const conf = assetFn('_configs/marpit/config.js')
+          const error = jest.spyOn(console, 'error').mockImplementation()
+
+          jest.spyOn(Explorer.prototype, 'load').mockResolvedValue({
+            filepath: conf,
+            config: { browser: 'UNKNOWN' },
+          })
+
+          expect(await marpCli([onePath, '--config', 'conf'])).toBe(1)
+          expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('Unknown browser: UNKNOWN')
           )
         })
 
@@ -712,6 +741,20 @@ describe('Marp CLI', () => {
           ).toStrictEqual(['firefox'])
         })
 
+        it('uses a specific order of browser finders when browser option in configuration file is an array of browsers', async () => {
+          const conf = assetFn('_configs/marpit/config.js')
+
+          jest.spyOn(Explorer.prototype, 'load').mockResolvedValue({
+            filepath: conf,
+            config: { browser: ['edge', 'firefox', 'chrome'] },
+          })
+
+          expect(
+            (await conversion(onePath, '--config', conf)).options
+              .browserManager['_finders']
+          ).toStrictEqual(['edge', 'firefox', 'chrome'])
+        })
+
         it('prints error when --browser has comma-separated unknown browsers', async () => {
           const error = jest.spyOn(console, 'error').mockImplementation()
 
@@ -721,6 +764,21 @@ describe('Marp CLI', () => {
 
           expect(error).toHaveBeenCalledWith(
             expect.stringContaining('Invalid values')
+          )
+        })
+
+        it('prints error when browser option in configuration file is an array of unknown browsers', async () => {
+          const conf = assetFn('_configs/marpit/config.js')
+          const error = jest.spyOn(console, 'error').mockImplementation()
+
+          jest.spyOn(Explorer.prototype, 'load').mockResolvedValue({
+            filepath: conf,
+            config: { browser: ['unknown', 'browsers'] },
+          })
+
+          expect(await marpCli([onePath, '--config', 'conf'])).toBe(1)
+          expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('No available browsers: unknown, browsers')
           )
         })
 
@@ -746,6 +804,20 @@ describe('Marp CLI', () => {
           ).options.browserManager['_finderPreferredPath']
 
           expect(resolved).toBe(path.join(process.cwd(), 'browser-executable'))
+        })
+
+        it('uses a path from the configuration file as the preferred path of finder when browserPath option in configuration file is specified', async () => {
+          const conf = assetFn('_configs/marpit/config.js')
+
+          jest.spyOn(Explorer.prototype, 'load').mockResolvedValue({
+            filepath: conf,
+            config: { browserPath: '../test/browser/path' },
+          })
+
+          expect(
+            (await conversion(onePath, '--config', conf)).options
+              .browserManager['_finderPreferredPath']
+          ).toBe(assetFn('_configs/test/browser/path'))
         })
       })
 
@@ -804,7 +876,7 @@ describe('Marp CLI', () => {
           ).toBe('webDriverBiDi')
         })
 
-        it('prints error when --browser-protocol is unknown protocol', async () => {
+        it('prints yargs error when --browser-protocol is unknown protocol', async () => {
           const error = jest.spyOn(console, 'error').mockImplementation()
 
           expect(
@@ -813,6 +885,21 @@ describe('Marp CLI', () => {
 
           expect(error).toHaveBeenCalledWith(
             expect.stringContaining('Invalid values')
+          )
+        })
+
+        it('prints error when browserProtocol option in configuration file is unknown protocol', async () => {
+          const conf = assetFn('_configs/marpit/config.js')
+          const error = jest.spyOn(console, 'error').mockImplementation()
+
+          jest.spyOn(Explorer.prototype, 'load').mockResolvedValue({
+            filepath: conf,
+            config: { browserProtocol: 'UNKNOWN' },
+          })
+
+          expect(await marpCli([onePath, '--config', 'conf'])).toBe(1)
+          expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('Unknown browser protocol: UNKNOWN')
           )
         })
       })
@@ -904,6 +991,20 @@ describe('Marp CLI', () => {
           expect(error).toHaveBeenCalledWith(
             expect.stringContaining('Invalid number for timeout: -5')
           )
+        })
+
+        it('sets timeout as second when browserTimeout option in configuration file is specified', async () => {
+          const conf = assetFn('_configs/marpit/config.js')
+
+          jest.spyOn(Explorer.prototype, 'load').mockResolvedValue({
+            filepath: conf,
+            config: { browserTimeout: 42 },
+          })
+
+          expect(
+            (await conversion(onePath, '--config', conf)).options.browserManager
+              .timeout
+          ).toBe(42000)
         })
       })
     })

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -7,6 +7,7 @@ import * as cosmiconfigExplorer from 'cosmiconfig/dist/Explorer' // eslint-disab
 import getStdin from 'get-stdin'
 import stripAnsi from 'strip-ansi'
 import { version as cliVersion } from '../package.json'
+import { defaultFinders } from '../src/browser/finder'
 import * as cli from '../src/cli'
 import { Converter, ConvertType } from '../src/converter'
 import { ResolvedEngine } from '../src/engine'
@@ -23,7 +24,6 @@ import { ThemeSet } from '../src/theme'
 import * as container from '../src/utils/container'
 import * as version from '../src/version'
 import { Watcher } from '../src/watcher'
-import { defaultFinders } from '../src/browser/finder'
 
 jest.mock('cosmiconfig')
 jest.mock('../src/preview')

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -96,12 +96,8 @@ describe('Marp CLI', () => {
         const pkgJson = { name: '@marp-team/marp-core', version: '0.0.0' }
         const pkgPath = '../node_modules/@marp-team/marp-core/package.json'
 
-        let isMarpCoreSpy: jest.SpyInstance
-
         beforeEach(() => {
-          isMarpCoreSpy = jest
-            .spyOn(version, 'isMarpCore')
-            .mockResolvedValue(true)
+          jest.spyOn(version, 'isMarpCore').mockResolvedValue(true)
 
           mockEnginePath(
             assetFn('../node_modules/@marp-team/marp-core/lib/marp.js')
@@ -399,14 +395,9 @@ describe('Marp CLI', () => {
         const run = () =>
           runForObservation(['--input-dir', files, '--server', '--preview'])
 
-        let infoSpy: jest.SpyInstance
-        let serverStartSpy: jest.SpyInstance
-
         beforeEach(() => {
-          infoSpy = jest.spyOn(cli, 'info').mockImplementation()
-          serverStartSpy = jest
-            .spyOn<any, any>(Server.prototype, 'start')
-            .mockResolvedValue(0)
+          jest.spyOn(cli, 'info').mockImplementation()
+          jest.spyOn<any, any>(Server.prototype, 'start').mockResolvedValue(0)
         })
 
         it('opens preview window through Preview.open()', async () => {
@@ -449,12 +440,12 @@ describe('Marp CLI', () => {
   describe('with --theme option', () => {
     let convert: jest.SpyInstance
     let info: jest.SpyInstance
-    let writeFile: jest.SpyInstance
 
     beforeEach(() => {
       convert = jest.spyOn(Converter.prototype, 'convert')
       info = jest.spyOn(cli, 'info').mockImplementation()
-      writeFile = jest.spyOn(fs.promises, 'writeFile').mockImplementation()
+
+      jest.spyOn(fs.promises, 'writeFile').mockImplementation()
     })
 
     describe('when passed value is theme name', () => {
@@ -518,14 +509,13 @@ describe('Marp CLI', () => {
 
     let convert: jest.MockInstance<ReturnType<Converter['convert']>, any>
     let observeSpy: jest.MockInstance<ReturnType<ThemeSet['observe']>, any>
-    let infoSpy: jest.SpyInstance
-    let writeFile: jest.SpyInstance
 
     beforeEach(() => {
       convert = jest.spyOn(Converter.prototype, 'convert')
       observeSpy = jest.spyOn(ThemeSet.prototype, 'observe')
-      infoSpy = jest.spyOn(cli, 'info').mockImplementation()
-      writeFile = jest.spyOn(fs.promises, 'writeFile').mockImplementation()
+
+      jest.spyOn(fs.promises, 'writeFile').mockImplementation()
+      jest.spyOn(cli, 'info').mockImplementation()
     })
 
     describe('with specified single file', () => {
@@ -622,8 +612,9 @@ describe('Marp CLI', () => {
 
     it('prints error and return error code when CLIError is raised', async () => {
       const cliError = jest.spyOn(cli, 'error').mockImplementation()
-      const cliInfo = jest.spyOn(cli, 'info').mockImplementation()
-      const cvtFiles = jest
+
+      jest.spyOn(cli, 'info').mockImplementation()
+      jest
         .spyOn(Converter.prototype, 'convertFiles')
         .mockImplementation(() => Promise.reject(new CLIError('FAIL', 123)))
 
@@ -1246,12 +1237,12 @@ describe('Marp CLI', () => {
   describe('with passing from stdin', () => {
     let cliInfo: jest.SpyInstance
     let stdout: jest.SpyInstance
-    let stdinBuffer: jest.SpyInstance
 
     beforeEach(() => {
       cliInfo = jest.spyOn(cli, 'info').mockImplementation()
       stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
-      stdinBuffer = jest
+
+      jest
         .spyOn(getStdin, 'buffer')
         .mockResolvedValue(Buffer.from('# markdown'))
 

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -736,14 +736,9 @@ describe('Marp CLI', () => {
       describe('with --browser-path option', () => {
         it('uses the path as the preferred path of finder', async () => {
           expect(
-            (
-              await conversion(
-                onePath,
-                '--browser-path',
-                path.join('path', 'to', 'browser')
-              )
-            ).options.browserManager['_finderPreferredPath']
-          ).toBe(path.join('path', 'to', 'browser'))
+            (await conversion(onePath, '--browser-path', '/path/to/browser'))
+              .options.browserManager['_finderPreferredPath']
+          ).toBe(path.resolve('/path/to/browser'))
 
           // Relative path
           const resolved = (
@@ -1463,7 +1458,7 @@ describe('Marp CLI', () => {
               '/preferred/path/to/browser'
             )
           ).options.browserManager['_finderPreferredPath']
-        ).toBe('/preferred/path/to/browser')
+        ).toBe(path.resolve('/preferred/path/to/browser'))
       })
     })
   })

--- a/test/server.ts
+++ b/test/server.ts
@@ -2,7 +2,8 @@ import { ClientRequest } from 'node:http'
 import path from 'node:path'
 import { Marp } from '@marp-team/marp-core'
 import { load } from 'cheerio'
-import express, { type Express } from 'express'
+import express, { application } from 'express'
+import type { Express } from 'express'
 import request from 'supertest'
 import { BrowserManager } from '../src/browser/manager'
 import {
@@ -104,7 +105,7 @@ describe('Server', () => {
 
   describe('#start', () => {
     it('triggers setup of express server and starts listening', async () => {
-      const listen = jest.spyOn(express.application, 'listen')
+      const listen = jest.spyOn(application, 'listen')
 
       const server = new Server(converter())
       await server.start()

--- a/test/server.ts
+++ b/test/server.ts
@@ -104,10 +104,13 @@ describe('Server', () => {
 
   describe('#start', () => {
     it('triggers setup of express server and starts listening', async () => {
+      const listen = jest.spyOn(express.application, 'listen')
+
       const server = new Server(converter())
       await server.start()
 
-      expect(server.server?.listen).toHaveBeenCalledWith(8080)
+      expect(listen).toHaveBeenCalledWith(8080)
+      expect(listen.mock.instances[0]).toBe(server.server)
     })
   })
 


### PR DESCRIPTION
Resolves #565.

This PR introduces new options about browser: `--browser`, `--browser-path`, `--browser-protocol`, and `--browser-timeout`.

```
Browser Options:
      --browser           The kind of browser to use for PDF, PPTX, and image
                          conversion
       [string] [choices: "auto", "chrome", "edge", "firefox"] [default: "auto"]
      --browser-path      Path to the browser executable (Find automatically if
                          not set)                                      [string]
      --browser-protocol  Preferred protocol to use for browser connection
                    [string] [choices: "cdp", "webdriver-bidi"] [default: "cdp"]
      --browser-timeout   Timeout for each browser operation in seconds (0 to
                          disable)                                 [default: 30]
```

### `--browser`

The `--browser` option specifies the kind of browser for conversion. If set comma-separated browsers, CLI will try to use the first available browser among them.

```bash
# Use Firefox for conversion
marp --browser firefox ./slide.md

# Prefer to use Firefox first, then Chrome
marp --browser firefox,chrome ./slide.md
```

The default value is `auto`, which means `chrome,edge,firefox`.

### `--browser-path`

The `--browser-path` option allows you to explicitly set the path to the browser executable.

```bash
# Use the specific Chrome executable
marp --browser-path /usr/bin/google-chrome-stable ./slide.md

# Use the specific Firefox executable
marp --browser firefox --browser-path /usr/bin/firefox ./slide.md
```

This is similar to setting the `CHROME_PATH` environment variable in v3 and earlier, but it can be used across all browsers. For backward compatibility, `CHROME_PATH` is still supported when using `chrome` as the browser.

### `--browser-protocol`

The `--browser-protocol` option specifies the preferred protocol to use for browser connection.

```bash
# Use WebDriver BiDi protocol in Chrome
marp --browser chrome --browser-protocol webdriver-bidi ./slide.md
```

The preferred protocol may be ignored if the browser does not support it (e.g. Firefox is only supporting WebDriver BiDi). The default value is `cdp` (Chrome DevTools Protocol), that is same as up until now.

### `--browser-timeout`

The `--browser-timeout` option specifies the timeout for each browser operation in seconds. The default timeout is 30 seconds. If set `--no-browser-timeout` or `--browser-timeout=0`, the timeout will be disabled.

```bash
# Disable timeout
marp --browser-timeout 0 ./slide.md
marp --no-browser-timeout ./slide.md # Equivalent to the above

# Set timeout to 60 seconds
marp --browser-timeout 60 ./slide.md

# Decimal seconds are also supported
marp --browser-timeout 12.34 ./slide.md

# Set timeout in milliseconds
marp --browser-timeout 45000ms ./slide.md
```

Please note that this timeout is for each browser operation by specified protocol, not for the entire conversion process. For example, opening Marp HTML in browser internally and generating PDF from HTML are separate operations. So if you set `--browser-timeout 10`, the timeout of 10 seconds are applied to each operation.