### PR TITLE
Find Chrome and Edge from the host Windows as fallback when WSL 2 is mirrored network mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Initial support for Firefox / WebDriver BiDi protocol during conversion ([#565](https://github.com/marp-team/marp-cli/issues/565), [#597](https://github.com/marp-team/marp-cli/pull/597))
 - `--browser` and some related options to control the browser for conversion ([#603](https://github.com/marp-team/marp-cli/pull/603))
+- Find Chrome and Edge from the host Windows as a fallback when [WSL 2 networking is mirrored mode](https://learn.microsoft.com/windows/wsl/networking#mirrored-mode-networking) ([#604](https://github.com/marp-team/marp-cli/pull/604))
 - `--debug` (`-d`) option to CLI interface ([#599](https://github.com/marp-team/marp-cli/pull/599))
 - CI testing against Node.js v22 ([#591](https://github.com/marp-team/marp-cli/pull/591))
 

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -1,9 +1,9 @@
+import { EventEmitter } from 'node:events'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { EventEmitter } from 'node:events'
-import { launch } from 'puppeteer-core'
 import { nanoid } from 'nanoid'
+import { launch } from 'puppeteer-core'
 import type {
   Browser as PuppeteerBrowser,
   ProtocolType,
@@ -11,8 +11,8 @@ import type {
   Page,
 } from 'puppeteer-core'
 import type TypedEventEmitter from 'typed-emitter'
-import { getWindowsEnv, isWSL, translateWindowsPathToWSL } from '../utils/wsl'
 import { debugBrowser } from '../utils/debug'
+import { getWindowsEnv, isWSL, translateWindowsPathToWSL } from '../utils/wsl'
 
 export type BrowserKind = 'chrome' | 'firefox'
 export type BrowserProtocol = ProtocolType
@@ -134,7 +134,7 @@ export abstract class Browser
   protected async generateLaunchOptions(
     mergeOptions: PuppeteerLaunchOptions = {}
   ): Promise<PuppeteerLaunchOptions> {
-    return {
+    const opts = {
       browser: this.kind,
       executablePath: this.path,
       headless: true,
@@ -143,10 +143,14 @@ export abstract class Browser
       timeout: this.timeout,
       ...mergeOptions,
     }
+
+    // Don't pass Linux environment variables to Windows process
+    if (await this.browserInWSLHost()) opts.env = {}
+
+    return opts
   }
 
   /** @internal */
-
   protected async puppeteerDataDir() {
     if (this._puppeteerDataDir === undefined) {
       let needToTranslateWindowsPathToWSL = false

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -1,5 +1,9 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { EventEmitter } from 'node:events'
 import { launch } from 'puppeteer-core'
+import { nanoid } from 'nanoid'
 import type {
   Browser as PuppeteerBrowser,
   ProtocolType,
@@ -7,7 +11,7 @@ import type {
   Page,
 } from 'puppeteer-core'
 import type TypedEventEmitter from 'typed-emitter'
-import { isWSL } from '../utils/wsl'
+import { getWindowsEnv, isWSL, translateWindowsPathToWSL } from '../utils/wsl'
 import { debugBrowser } from '../utils/debug'
 
 export type BrowserKind = 'chrome' | 'firefox'
@@ -25,6 +29,8 @@ type BrowserEvents = {
   launch: (browser: PuppeteerBrowser) => void
 }
 
+let wslTmp: string | undefined
+
 const wslHostMatcher = /^\/mnt\/[a-z]\//
 
 export abstract class Browser
@@ -38,10 +44,14 @@ export abstract class Browser
   protocolTimeout: number
   puppeteer: PuppeteerBrowser | undefined
   timeout: number
+  #dataDirName: string
+
+  private _puppeteerDataDir?: string
 
   constructor(opts: BrowserOptions) {
     super()
 
+    this.#dataDirName = `marp-cli-${nanoid(10)}`
     this.path = opts.path
     this.timeout = opts.timeout ?? 30000
     this.protocolTimeout =
@@ -133,5 +143,37 @@ export abstract class Browser
       timeout: this.timeout,
       ...mergeOptions,
     }
+  }
+
+  /** @internal */
+
+  protected async puppeteerDataDir() {
+    if (this._puppeteerDataDir === undefined) {
+      let needToTranslateWindowsPathToWSL = false
+
+      this._puppeteerDataDir = await (async () => {
+        // In WSL environment, Marp CLI may use Chrome on Windows. If Chrome has
+        // located in host OS (Windows), we have to specify Windows path.
+        if (await this.browserInWSLHost()) {
+          if (wslTmp === undefined) wslTmp = await getWindowsEnv('TMP')
+          if (wslTmp !== undefined) {
+            needToTranslateWindowsPathToWSL = true
+            return path.win32.resolve(wslTmp, this.#dataDirName)
+          }
+        }
+        return path.resolve(os.tmpdir(), this.#dataDirName)
+      })()
+
+      debugBrowser(`Chrome data directory: %s`, this._puppeteerDataDir)
+
+      // Ensure the data directory is created
+      const mkdirPath = needToTranslateWindowsPathToWSL
+        ? await translateWindowsPathToWSL(this._puppeteerDataDir)
+        : this._puppeteerDataDir
+
+      await fs.promises.mkdir(mkdirPath, { recursive: true })
+      debugBrowser(`Created data directory: %s`, mkdirPath)
+    }
+    return this._puppeteerDataDir
   }
 }

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -7,7 +7,7 @@ import type {
   Page,
 } from 'puppeteer-core'
 import type TypedEventEmitter from 'typed-emitter'
-import { isWSL, translateWSLPathToWindows } from '../utils/wsl'
+import { isWSL } from '../utils/wsl'
 import { debugBrowser } from '../utils/debug'
 
 export type BrowserKind = 'chrome' | 'firefox'

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -3,7 +3,6 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { nanoid } from 'nanoid'
-import { launch } from 'puppeteer-core'
 import type {
   Browser as PuppeteerBrowser,
   ProtocolType,
@@ -123,12 +122,10 @@ export abstract class Browser
     )
   }
 
-  /** @internal Overload in subclass to customize launch behavior */
-  protected async launchPuppeteer(
+  /** @internal Overload launch behavior in subclass */
+  protected abstract launchPuppeteer(
     opts: PuppeteerLaunchOptions
-  ): Promise<PuppeteerBrowser> {
-    return await launch(await this.generateLaunchOptions(opts))
-  }
+  ): Promise<PuppeteerBrowser>
 
   /** @internal */
   protected async generateLaunchOptions(

--- a/src/browser/browsers/chrome.ts
+++ b/src/browser/browsers/chrome.ts
@@ -49,7 +49,7 @@ export class ChromeBrowser extends Browser {
       ignoreDefaultArgsSet.add('--disable-extensions')
     }
 
-    const baseOpts = this.generateLaunchOptions({
+    const baseOpts = await this.generateLaunchOptions({
       headless: this.puppeteerHeadless(),
       pipe: await this.puppeteerPipe(),
       // userDataDir: await this.puppeteerDataDir(), // userDataDir will set in args option due to wrong path normalization in WSL

--- a/src/browser/browsers/chrome.ts
+++ b/src/browser/browsers/chrome.ts
@@ -1,7 +1,3 @@
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
-import { nanoid } from 'nanoid'
 import { launch } from 'puppeteer-core'
 import type {
   Browser as PuppeteerBrowser,
@@ -9,31 +5,14 @@ import type {
 } from 'puppeteer-core'
 import { CLIErrorCode, error, isError } from '../../error'
 import { isInsideContainer } from '../../utils/container'
-import { debugBrowser } from '../../utils/debug'
-import {
-  isWSL,
-  getWindowsEnv,
-  translateWindowsPathToWSL,
-} from '../../utils/wsl'
+import { isWSL } from '../../utils/wsl'
 import { Browser } from '../browser'
-import type { BrowserKind, BrowserProtocol, BrowserOptions } from '../browser'
+import type { BrowserKind, BrowserProtocol } from '../browser'
 import { isSnapBrowser } from '../finders/utils'
-
-let wslTmp: string | undefined
 
 export class ChromeBrowser extends Browser {
   static readonly kind: BrowserKind = 'chrome'
   static readonly protocol: BrowserProtocol = 'webDriverBiDi'
-
-  private _puppeteerDataDir?: string
-
-  #dataDirName: string
-
-  constructor(opts: BrowserOptions) {
-    super(opts)
-
-    this.#dataDirName = `marp-cli-${nanoid(10)}`
-  }
 
   protected async launchPuppeteer(
     opts: Omit<PuppeteerLaunchOptions, 'userDataDir'> // userDataDir cannot overload in current implementation
@@ -124,35 +103,5 @@ export class ChromeBrowser extends Browser {
   private puppeteerHeadless() {
     const modeEnv = process.env.PUPPETEER_HEADLESS_MODE?.toLowerCase() ?? ''
     return ['old', 'legacy', 'shell'].includes(modeEnv) ? 'shell' : true
-  }
-
-  private async puppeteerDataDir() {
-    if (this._puppeteerDataDir === undefined) {
-      let needToTranslateWindowsPathToWSL = false
-
-      this._puppeteerDataDir = await (async () => {
-        // In WSL environment, Marp CLI may use Chrome on Windows. If Chrome has
-        // located in host OS (Windows), we have to specify Windows path.
-        if (await this.browserInWSLHost()) {
-          if (wslTmp === undefined) wslTmp = await getWindowsEnv('TMP')
-          if (wslTmp !== undefined) {
-            needToTranslateWindowsPathToWSL = true
-            return path.win32.resolve(wslTmp, this.#dataDirName)
-          }
-        }
-        return path.resolve(os.tmpdir(), this.#dataDirName)
-      })()
-
-      debugBrowser(`Chrome data directory: %s`, this._puppeteerDataDir)
-
-      // Ensure the data directory is created
-      const mkdirPath = needToTranslateWindowsPathToWSL
-        ? await translateWindowsPathToWSL(this._puppeteerDataDir)
-        : this._puppeteerDataDir
-
-      await fs.promises.mkdir(mkdirPath, { recursive: true })
-      debugBrowser(`Created data directory: %s`, mkdirPath)
-    }
-    return this._puppeteerDataDir
   }
 }

--- a/src/browser/browsers/firefox.ts
+++ b/src/browser/browsers/firefox.ts
@@ -1,7 +1,27 @@
+import { launch } from 'puppeteer-core'
+import type {
+  Browser as PuppeteerBrowser,
+  PuppeteerLaunchOptions,
+} from 'puppeteer-core'
 import { Browser } from '../browser'
 import type { BrowserKind, BrowserProtocol } from '../browser'
 
 export class FirefoxBrowser extends Browser {
   static readonly kind: BrowserKind = 'firefox'
   static readonly protocol: BrowserProtocol = 'webDriverBiDi'
+
+  protected async launchPuppeteer(
+    opts: PuppeteerLaunchOptions
+  ): Promise<PuppeteerBrowser> {
+    const userDataDir = await this.puppeteerDataDir()
+
+    return await launch(
+      await this.generateLaunchOptions({
+        ...opts,
+
+        // NOTE: Currently Windows path is incompatible with Puppeteer's preparing
+        userDataDir: (await this.browserInWSLHost()) ? undefined : userDataDir,
+      })
+    )
+  }
 }

--- a/src/browser/browsers/firefox.ts
+++ b/src/browser/browsers/firefox.ts
@@ -13,14 +13,14 @@ export class FirefoxBrowser extends Browser {
   protected async launchPuppeteer(
     opts: PuppeteerLaunchOptions
   ): Promise<PuppeteerBrowser> {
-    const userDataDir = await this.puppeteerDataDir()
-
     return await launch(
       await this.generateLaunchOptions({
         ...opts,
 
         // NOTE: Currently Windows path is incompatible with Puppeteer's preparing
-        userDataDir: (await this.browserInWSLHost()) ? undefined : userDataDir,
+        userDataDir: (await this.browserInWSLHost())
+          ? undefined
+          : await this.puppeteerDataDir(),
       })
     )
   }

--- a/src/browser/finders/chrome.ts
+++ b/src/browser/finders/chrome.ts
@@ -5,6 +5,7 @@ import {
   wsl,
 } from 'chrome-launcher/dist/chrome-finder'
 import { error, CLIErrorCode } from '../../error'
+import { getWSL2NetworkingMode } from '../../utils/wsl'
 import { ChromeBrowser } from '../browsers/chrome'
 import { ChromeCdpBrowser } from '../browsers/chrome-cdp'
 import type { BrowserFinder, BrowserFinderResult } from '../finder'
@@ -14,7 +15,6 @@ import {
   isExecutable,
   normalizeDarwinAppPath,
 } from './utils'
-import { getWSL2NetworkingMode } from '../../utils/wsl'
 
 const chrome = (path: string): BrowserFinderResult => ({
   path,
@@ -33,15 +33,15 @@ export const chromeFinder: BrowserFinder = async ({ preferredPath } = {}) => {
   const installation = await (async () => {
     switch (platform) {
       case 'darwin':
-        return darwinFast()
+        return chromeFinderDarwin()
       case 'linux':
         return await chromeFinderLinux()
       case 'win32':
-        return win32()[0]
+        return chromeFinderWin32()
       case 'wsl1':
-        return wsl()[0]
+        return chromeFinderWSL()
     }
-    return await fallback()
+    return await chromeFinderFallack()
   })()
 
   if (installation) return chrome(installation)
@@ -49,17 +49,24 @@ export const chromeFinder: BrowserFinder = async ({ preferredPath } = {}) => {
   error('Chrome browser could not be found.', CLIErrorCode.NOT_FOUND_BROWSER)
 }
 
+const chromeFinderDarwin = () => darwinFast()
 const chromeFinderLinux = async () => {
   try {
     const linuxPath = linux()[0]
     if (linuxPath) return linuxPath
-  } catch (error) {
+  } catch {
     // no ops
   }
-  if ((await getWSL2NetworkingMode()) === 'mirrored') return wsl()[0] // WSL2 Fallback
-}
 
-const fallback = async () =>
+  // WSL2 Fallback
+  if ((await getWSL2NetworkingMode()) === 'mirrored') return chromeFinderWSL()
+
+  return undefined
+}
+const chromeFinderWin32 = (): string | undefined => win32()[0]
+const chromeFinderWSL = (): string | undefined => wsl()[0]
+
+const chromeFinderFallack = async () =>
   await findExecutableBinary([
     'google-chrome-stable',
     'google-chrome',

--- a/src/browser/finders/chrome.ts
+++ b/src/browser/finders/chrome.ts
@@ -14,6 +14,8 @@ import {
   isExecutable,
   normalizeDarwinAppPath,
 } from './utils'
+import { debugBrowserFinder } from '../../utils/debug'
+import { getWSL2NetworkingMode } from '../../utils/wsl'
 
 const chrome = (path: string): BrowserFinderResult => ({
   path,
@@ -34,7 +36,17 @@ export const chromeFinder: BrowserFinder = async ({ preferredPath } = {}) => {
       case 'darwin':
         return darwinFast()
       case 'linux':
-        return linux()[0]
+        return (
+          linux()[0] ||
+          (await (async () => {
+            if ((await getWSL2NetworkingMode()) === 'mirrored') {
+              debugBrowserFinder(
+                'WSL2: Detected "mirrored" networking mode. Try to find Chrome in Windows.'
+              )
+              return wsl()[0]
+            }
+          })())
+        )
       case 'win32':
         return win32()[0]
       case 'wsl1':

--- a/src/browser/finders/edge.ts
+++ b/src/browser/finders/edge.ts
@@ -9,7 +9,6 @@ import { ChromeBrowser } from '../browsers/chrome'
 import { ChromeCdpBrowser } from '../browsers/chrome-cdp'
 import type { BrowserFinder, BrowserFinderResult } from '../finder'
 import { findExecutable, getPlatform } from './utils'
-import { debugBrowserFinder } from '../../utils/debug'
 
 const edge = (path: string): BrowserFinderResult => ({
   path,
@@ -27,14 +26,9 @@ export const edgeFinder: BrowserFinder = async ({ preferredPath } = {}) => {
       case 'linux':
         return (
           (await edgeFinderLinux()) ||
-          (await (async () => {
-            if ((await getWSL2NetworkingMode()) === 'mirrored') {
-              debugBrowserFinder(
-                'WSL2: Detected "mirrored" networking mode. Try to find Chrome in Windows.'
-              )
-              return await edgeFinderWSL()
-            }
-          })())
+          ((await getWSL2NetworkingMode()) === 'mirrored'
+            ? await edgeFinderWSL() // WSL2 Fallback
+            : undefined)
         )
       case 'win32':
         return await edgeFinderWin32()

--- a/src/browser/finders/firefox.ts
+++ b/src/browser/finders/firefox.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { error, CLIErrorCode } from '../../error'
+// import { getWSL2NetworkingMode } from '../../utils/wsl'
 import { FirefoxBrowser } from '../browsers/firefox'
 import type { BrowserFinder, BrowserFinderResult } from '../finder'
 import {
@@ -38,7 +39,13 @@ export const firefoxFinder: BrowserFinder = async ({ preferredPath } = {}) => {
       case 'wsl1':
         return await firefoxFinderWSL()
     }
+
     return await firefoxFinderLinuxOrFallback()
+    /*
+    || ((await getWSL2NetworkingMode()) === 'mirrored'
+      ? await firefoxFinderWSL() // WSL2 Fallback
+      : undefined)
+    */
   })()
 
   if (installation) return firefox(installation)

--- a/src/browser/finders/firefox.ts
+++ b/src/browser/finders/firefox.ts
@@ -9,8 +9,6 @@ import {
   isExecutable,
   normalizeDarwinAppPath,
 } from './utils'
-import { debugBrowserFinder } from '../../utils/debug'
-import { getWSL2NetworkingMode } from '../../utils/wsl'
 
 const firefox = (path: string): BrowserFinderResult => ({
   path,
@@ -40,17 +38,7 @@ export const firefoxFinder: BrowserFinder = async ({ preferredPath } = {}) => {
       case 'wsl1':
         return await firefoxFinderWSL()
     }
-    return (
-      (await firefoxFinderLinuxOrFallback()) ||
-      (await (async () => {
-        if ((await getWSL2NetworkingMode()) === 'mirrored') {
-          debugBrowserFinder(
-            'WSL2: Detected "mirrored" networking mode. Try to find Chrome in Windows.'
-          )
-          return await firefoxFinderWSL()
-        }
-      })())
-    )
+    return await firefoxFinderLinuxOrFallback()
   })()
 
   if (installation) return firefox(installation)

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -161,7 +161,7 @@ export class Converter {
         const browser = await this.browser
 
         return (await browser.browserInWSLHost())
-          ? `file:${await translateWSLPathToWindows(f.absolutePath)}`
+          ? `file:${await translateWSLPathToWindows(f.absolutePath, true)}`
           : f.absoluteFileScheme
       }
 
@@ -643,7 +643,7 @@ export class Converter {
 
     if (tmpFile) {
       if (await browser.browserInWSLHost()) {
-        uri = `file:${await translateWSLPathToWindows(tmpFile.path)}`
+        uri = `file:${await translateWSLPathToWindows(tmpFile.path, true)}`
       } else {
         uri = `file://${tmpFile.path}`
       }


### PR DESCRIPTION
Marp CLI has been already supported out of the box conversion in WSL 1, but WSL 2 is not yet supported. (marp-team/marp#113) This PR introduces the out of the box conversion in WSL 2 with "mirrored network mode".

WSL 1 shares the network with Windows. Puppeteer can communicate with browser's remote debug that is binding to the localhost port. On the other hand, WSL 2 has a separated NAT network from Windows by default, so it is difficult to communicate WSL 2 with Windows.

If configured WSL 2 to enable "mirroed network mode", WSL 2 will become to share the network interface with Windows as same as WSL 1. In this mode, we have confirmed that Puppeteer for Chrome can communicate with the process on the Windows host.

```
# %USERPROFILE%\.wslconfig
[wsl2]
networkingMode=mirrored
```

Marp CLI's browser finder will become to resolve the Chrome/Edge from the host if the mirrored networking mode was enabled and the suitable browser was not found in WSL Linux.