### PR TITLE
Get rid of sharp dependency in favor of JPEG conversion via the browser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ commands:
           command: npm run test:coverage -- --ci -i --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: tmp/test-results
+            MOZ_LOG: Process:5
 
       - codecov/upload:
           flags: linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,6 @@ commands:
           command: npm run test:coverage -- --ci -i --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: tmp/test-results
-            MOZ_LOG: Process:5
 
       - codecov/upload:
           flags: linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ commands:
           condition: << parameters.browser >>
           steps:
             - browser-tools/install-chrome
+            - browser-tools/install-firefox
 
   lint:
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Get rid of `sharp` dependency in favor of using browser in JPEG image conversion with WebDriver BiDi ([#610](https://github.com/marp-team/marp-cli/pull/610))
+
 ## v4.0.0 - 2024-10-05
 
 > [!IMPORTANT]

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "cosmiconfig": "^9.0.0",
         "puppeteer-core": "23.5.0",
         "serve-index": "^1.9.1",
-        "sharp": "^0.33.5",
         "tmp": "^0.2.3",
         "ws": "^8.18.0",
         "yargs": "^17.7.2"
@@ -2173,16 +2172,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.0.tgz",
-      "integrity": "sha512-XMBySMuNZs3DM96xcJmLW4EfGnf+uGmFNjzpehMjuX5PLB5j87ar2Zc4e3PVeZ3I5g3tYtAqskB28manlF69Zw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2448,367 +2437,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -6611,19 +6239,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6641,16 +6256,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -7499,6 +7104,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -16455,57 +16061,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -16611,21 +16166,6 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,7 @@
     "marp": "marp-cli.js"
   },
   "pkg": {
-    "scripts": "lib/**/*.js",
-    "assets": [
-      "node_modules/sharp/**/*",
-      "node_modules/@img/**/*"
-    ]
+    "scripts": "lib/**/*.js"
   },
   "browserslist": [
     "> 1% and last 3 versions",
@@ -165,7 +161,6 @@
     "cosmiconfig": "^9.0.0",
     "puppeteer-core": "23.5.0",
     "serve-index": "^1.9.1",
-    "sharp": "^0.33.5",
     "tmp": "^0.2.3",
     "ws": "^8.18.0",
     "yargs": "^17.7.2"

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -11,7 +11,12 @@ import type {
 } from 'puppeteer-core'
 import type TypedEventEmitter from 'typed-emitter'
 import { debugBrowser } from '../utils/debug'
-import { getWindowsEnv, isWSL, translateWindowsPathToWSL } from '../utils/wsl'
+import {
+  getWindowsEnv,
+  isWSL,
+  translateWSLPathToWindows,
+  translateWindowsPathToWSL,
+} from '../utils/wsl'
 
 export type BrowserKind = 'chrome' | 'firefox'
 export type BrowserProtocol = ProtocolType
@@ -120,6 +125,12 @@ export abstract class Browser
       !!(await isWSL()) &&
       wslHostMatcher.test(this.puppeteer?.process()?.spawnfile ?? this.path)
     )
+  }
+
+  async resolveToFileURI(filePath: string) {
+    return (await this.browserInWSLHost())
+      ? `file:${await translateWSLPathToWindows(filePath, true)}`
+      : `file://${filePath}`
   }
 
   /** @internal Overload launch behavior in subclass */

--- a/src/browser/browsers/firefox.ts
+++ b/src/browser/browsers/firefox.ts
@@ -17,6 +17,8 @@ export class FirefoxBrowser extends Browser {
       await this.generateLaunchOptions({
         ...opts,
 
+        dumpio: process.env.NODE_ENV === 'test',
+
         // NOTE: Currently Windows path is incompatible with Puppeteer's preparing
         userDataDir: (await this.browserInWSLHost())
           ? undefined

--- a/src/browser/browsers/firefox.ts
+++ b/src/browser/browsers/firefox.ts
@@ -17,12 +17,12 @@ export class FirefoxBrowser extends Browser {
       await this.generateLaunchOptions({
         ...opts,
 
-        dumpio: process.env.NODE_ENV === 'test',
-
         // NOTE: Currently Windows path is incompatible with Puppeteer's preparing
-        userDataDir: (await this.browserInWSLHost())
-          ? undefined
-          : await this.puppeteerDataDir(),
+        // FIXME: CircleCI does not work custom user data directory
+        userDataDir:
+          !!process.env.CIRCLECI || (await this.browserInWSLHost())
+            ? undefined
+            : await this.puppeteerDataDir(),
       })
     )
   }

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,15 +1,11 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import * as url from 'node:url'
-import { promisify } from 'node:util'
 import getStdin from 'get-stdin'
 import { globby, Options as GlobbyOptions } from 'globby'
-import { tmpName } from 'tmp'
 import { debug } from './utils/debug'
-
-const tmpNamePromise = promisify(tmpName)
+import { generateTmpName } from './utils/tmp'
 
 export const markdownExtensions = ['md', 'mdown', 'markdown', 'markdn']
 
@@ -94,11 +90,10 @@ export class File {
     }
   }
 
-  async saveTmpFile(
-    opts: { extension?: string; home?: boolean } = {}
-  ): Promise<File.TmpFileInterface> {
-    let tmp: string = await tmpNamePromise({ postfix: opts.extension })
-    if (opts.home) tmp = path.join(os.homedir(), path.basename(tmp))
+  async saveTmpFile({
+    extension,
+  }: { extension?: `.${string}` } = {}): Promise<File.TmpFileInterface> {
+    const tmp = await generateTmpName(extension)
 
     debug('Saving temporary file: %s', tmp)
     await this.saveToFile(tmp)

--- a/src/utils/jpeg.ts
+++ b/src/utils/jpeg.ts
@@ -1,0 +1,55 @@
+import { Browser } from '../browser/browser'
+import { debug } from './debug'
+
+export const png2jpegViaPuppeteer = async (
+  browser: Browser,
+  pngBuffer: Uint8Array,
+  quality?: number
+) =>
+  await browser.withPage(async (page) => {
+    debug('Converting PNG to JPEG via Puppeteer')
+
+    await page.goto('data:text/html,', {
+      waitUntil: ['domcontentloaded', 'networkidle0'],
+    })
+
+    const jpegDataURL = await page.evaluate(
+      async (pngUri, q, timeout) => {
+        const canvas = document.createElement('canvas')
+        const ctx = canvas.getContext('2d')
+        if (!ctx)
+          throw new Error(
+            'Failed to prepare canvas context for converting to JPEG'
+          )
+
+        const img = new Image()
+
+        await Promise.race([
+          new Promise<void>((resolve) => {
+            img.addEventListener('load', () => {
+              canvas.width = img.width
+              canvas.height = img.height
+              ctx.drawImage(img, 0, 0)
+              resolve()
+            })
+            img.src = pngUri
+          }),
+          new Promise<void>((_, reject) => {
+            setTimeout(() => {
+              reject(new Error('Failed to convert PNG to JPEG due to timeout'))
+            }, timeout)
+          }),
+        ])
+
+        return canvas.toDataURL('image/jpeg', q)
+      },
+      `data:image/png;base64,${Buffer.from(pngBuffer).toString('base64')}`,
+      quality,
+      browser.timeout
+    )
+
+    if (!jpegDataURL.startsWith('data:image/jpeg;base64,'))
+      throw new Error('Failed to convert PNG to JPEG')
+
+    return Buffer.from(jpegDataURL.slice(23), 'base64')
+  })

--- a/src/utils/jpeg.ts
+++ b/src/utils/jpeg.ts
@@ -15,6 +15,9 @@ export const png2jpegViaPuppeteer = async (
 
     const jpegDataURL = await page.evaluate(
       async (pngUri, q, timeout) => {
+        // This function is executed outside of Jest's scope so we have to ignore coverage.
+        // https://jestjs.io/docs/puppeteer
+        /* c8 ignore start */
         const canvas = document.createElement('canvas')
         const ctx = canvas.getContext('2d')
         if (!ctx)
@@ -42,6 +45,7 @@ export const png2jpegViaPuppeteer = async (
         ])
 
         return canvas.toDataURL('image/jpeg', q)
+        /* c8 ignore end */
       },
       `data:image/png;base64,${Buffer.from(pngBuffer).toString('base64')}`,
       quality,

--- a/src/utils/jpeg.ts
+++ b/src/utils/jpeg.ts
@@ -15,9 +15,9 @@ export const png2jpegViaPuppeteer = async (
 
     const jpegDataURL = await page.evaluate(
       async (pngUri, q, timeout) => {
+        /* c8 ignore start */
         // This function is executed outside of Jest's scope so we have to ignore coverage.
         // https://jestjs.io/docs/puppeteer
-        /* c8 ignore start */
         const canvas = document.createElement('canvas')
         const ctx = canvas.getContext('2d')
         if (!ctx)

--- a/src/utils/tmp.ts
+++ b/src/utils/tmp.ts
@@ -1,0 +1,20 @@
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { tmpName } from 'tmp'
+import { isOfficialDockerImage } from './container'
+
+const tmpNamePromise = promisify(tmpName)
+
+// Snapd Chromium cannot access from sandbox container to user-land `/tmp`
+// directory so always create tmp file to home directory if in Linux.
+// (Except an official docker image)
+const shouldPutTmpFileToHome =
+  process.platform === 'linux' && !isOfficialDockerImage()
+
+export const generateTmpName = async (extension?: `.${string}`) => {
+  let tmp: string = await tmpNamePromise({ postfix: extension })
+  if (shouldPutTmpFileToHome) tmp = path.join(os.homedir(), path.basename(tmp))
+
+  return tmp
+}

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -916,29 +916,34 @@ describe('Converter', () => {
       })
 
       describe('with Firefox browser', () => {
-        it('outputs warning about incompatibility', async () => {
-          const warn = jest.spyOn(console, 'warn').mockImplementation()
+        it(
+          'outputs warning about incompatibility',
+          async () => {
+            const warn = jest.spyOn(console, 'warn').mockImplementation()
 
-          await using browserManager = new BrowserManager({
-            finders: ['firefox'],
-          })
+            await using browserManager = new BrowserManager({
+              finders: ['firefox'],
+              timeout,
+            })
 
-          await pdfInstance({
-            browserManager,
-            output: 'test.pdf',
-          }).convertFile(new File(onePath))
+            await pdfInstance({
+              browserManager,
+              output: 'test.pdf',
+            }).convertFile(new File(onePath))
 
-          expect(warn).toHaveBeenCalledWith(
-            expect.stringContaining(
-              'The output may include some incompatible renderings'
+            expect(warn).toHaveBeenCalledWith(
+              expect.stringContaining(
+                'The output may include some incompatible renderings'
+              )
             )
-          )
-          expect(fs.promises.writeFile).toHaveBeenCalled()
+            expect(fs.promises.writeFile).toHaveBeenCalled()
 
-          const [lastCall] = writeFileSpy.mock.calls.slice(-1)
-          expect(lastCall[0]).toBe('test.pdf')
-          expect(lastCall[1]).toBeInstanceOf(Buffer)
-        })
+            const [lastCall] = writeFileSpy.mock.calls.slice(-1)
+            expect(lastCall[0]).toBe('test.pdf')
+            expect(lastCall[1]).toBeInstanceOf(Buffer)
+          },
+          timeout
+        )
       })
     })
 
@@ -1125,6 +1130,7 @@ describe('Converter', () => {
             async () => {
               await using browserManager = new BrowserManager({
                 finders: ['firefox'],
+                timeout,
               })
 
               await instance({
@@ -1225,6 +1231,7 @@ describe('Converter', () => {
             await using browserManager = new BrowserManager({
               finders: ['chrome', 'edge'],
               protocol: 'webDriverBiDi',
+              timeout,
             })
 
             await instance({
@@ -1268,6 +1275,7 @@ describe('Converter', () => {
           async () => {
             await using browserManager = new BrowserManager({
               finders: ['firefox'],
+              timeout,
             })
 
             await instance({


### PR DESCRIPTION
Currently, WebDriver BiDi does not support image rendering except PNG. Since Marp CLI v4, `--image(s) jpeg` option may use `sharp` image processor when converting image to JPEG if used WebDriver BiDi.

However, sharp is too huge library just for usage of converting PNG to JPEG.

To diet the dependency, I've improved PNG to JPEG conversion to use the browser `<canvas>` through Puppeteer. By this change, the filesize of standalone binary will be reduced about 8MB.