### PR TITLE
Allow to disable GPU use of Chrome through `CHROME_DISABLE_GPU` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow to disable GPU use of Chrome through `CHROME_DISABLE_GPU` environment variable ([#592](https://github.com/marp-team/marp-cli/issues/592), [#617](https://github.com/marp-team/marp-cli/issues/617), [#618](https://github.com/marp-team/marp-cli/pull/618))
+
 ## v4.0.2 - 2024-10-31
 
 ### Fixed

--- a/src/browser/browsers/chrome.ts
+++ b/src/browser/browsers/chrome.ts
@@ -82,6 +82,7 @@ export class ChromeBrowser extends Browser {
     ])
 
     if (!(await this.puppeteerArgsEnableSandbox())) args.add('--no-sandbox')
+    if (!this.puppeteerArgsEnableGPU()) args.add('--disable-gpu')
 
     return [...args]
   }
@@ -91,6 +92,12 @@ export class ChromeBrowser extends Browser {
     if (process.getuid?.() === 0) return false // Running as root without --no-sandbox is not supported.
     if (isInsideContainer()) return false
     if (await isWSL()) return false
+
+    return true
+  }
+
+  private puppeteerArgsEnableGPU() {
+    if (process.env.CHROME_DISABLE_GPU) return false
 
     return true
   }

--- a/test/browser/browsers/chrome.ts
+++ b/test/browser/browsers/chrome.ts
@@ -131,7 +131,20 @@ describe('ChromeBrowser', () => {
         })
       })
 
-      describe('Disable extensions', () => {
+      describe('Disabling GPU', () => {
+        it('adds --disable-gpu argument if CHROME_DISABLE_GPU environment variable is defined', async () => {
+          process.env.CHROME_DISABLE_GPU = '1'
+          await new ChromeBrowser({ path: '/path/to/chrome' }).launch()
+
+          expect(puppeteer.launch).toHaveBeenCalledWith(
+            expect.objectContaining({
+              args: expect.arrayContaining(['--disable-gpu']),
+            })
+          )
+        })
+      })
+
+      describe('Disabling extensions', () => {
         it('ignores --disable-extensions argument if CHROME_ENABLE_EXTENSIONS environment variable is defined', async () => {
           process.env.CHROME_ENABLE_EXTENSIONS = '1'
           await new ChromeBrowser({ path: '/path/to/chrome' }).launch()


### PR DESCRIPTION
It has mainly designed to become the workaround of timeout error for Alpine 3.20: #592, #617

```bash
CHROME_DISABLE_GPU=1 marp --pdf markdown.md
```

However, I'm doubtful that `--disable-gpu` for Chrome will actually solve the problem.