### PR TITLE
Make the preview option stable against occasional invalid URL errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Make the preview option stable against occasional invalid URL errors ([#627](https://github.com/marp-team/marp-cli/pull/627))
+
 ## v4.0.4 - 2024-12-25
 
 ### Added

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -165,15 +165,17 @@ export class Preview extends (EventEmitter as new () => TypedEmitter<Preview.Eve
           const idMatcher = (target: Target) => {
             debugPreview('Activated the window finder for %s.', id)
 
-            const url = new URL(target.url())
+            if (target.type() === 'page') {
+              const url = new URL(target.url())
 
-            if (url.searchParams.get('__marp_cli_id') === id) {
-              debugPreview('Found a target window with id: %s', id)
-              pptr.off('targetcreated', idMatcher)
+              if (url.searchParams.get('__marp_cli_id') === id) {
+                debugPreview('Found a target window with id: %s', id)
+                pptr.off('targetcreated', idMatcher)
 
-              void (async () => {
-                res((await target.page()) ?? (await target.asPage()))
-              })()
+                void (async () => {
+                  res((await target.page()) ?? (await target.asPage()))
+                })()
+              }
             }
           }
 


### PR DESCRIPTION
When opening multiple previews with `--preview` option, the preview window detector will sometimes fail with the parse error of empty URL for `other` type page.

```
node:internal/url:818
      href = bindingUrl.parse(input, base, true);
                        ^

TypeError: Invalid URL
    at new URL (node:internal/url:818:25)
    at idMatcher (/Users/yhatt/Programs/marp/marp-cli/lib/marp-cli-DSmb16j_.js:25490:33)
    at /Users/yhatt/Programs/marp/marp-cli/node_modules/puppeteer-core/lib/cjs/third_party/mitt/mitt.js:62:7
    at Array.map (<anonymous>)
    at Object.emit (/Users/yhatt/Programs/marp/marp-cli/node_modules/puppeteer-core/lib/cjs/third_party/mitt/mitt.js:61:20)
    at CdpBrowser.emit (/Users/yhatt/Programs/marp/marp-cli/node_modules/puppeteer-core/lib/cjs/puppeteer/common/EventEmitter.js:83:23)
    at #onAttachedToTarget (/Users/yhatt/Programs/marp/marp-cli/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/Browser.js:158:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  code: 'ERR_INVALID_URL',
  input: ''
}
```

This PR fixes that to narrow check only for the target that is having `page` type.