### PR TITLE
Wait for next HTML animation frame when rendering

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -668,6 +668,13 @@ export class Converter {
           await page.goto('data:text/html,', waitForOptions)
           await page.setContent(baseFile.buffer!.toString(), waitForOptions)
         }
+
+        // Wait for next frame (In parallel rendering, it may be needed to wait for the first rendering)
+        await page.evaluate(async () => {
+          await new Promise<void>((resolve) =>
+            window.requestAnimationFrame(() => resolve())
+          )
+        })
       }
 
       try {


### PR DESCRIPTION
Follow up #628.

Some interactive elements were not applied into PDF when converting multiple files in parallel. This PR fixes it to wait the first rendering of HTML by using `requestAnimationFrame()`.