### PR TITLE
Generate V8 compile cache when building container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Make the preview option stable against occasional invalid URL errors ([#627](https://github.com/marp-team/marp-cli/pull/627))
+- Generate V8 compile cache when building container image ([#630](https://github.com/marp-team/marp-cli/pull/630))
 
 ## v4.0.4 - 2024-12-25
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,6 @@ WORKDIR /home/marp/app
 ENTRYPOINT ["docker-entrypoint"]
 CMD ["--help"]
 LABEL maintainer="Marp team"
+
+# Generate V8 compile cache
+RUN node marp-cli.js --version


### PR DESCRIPTION
This is effectively the retry of #148. Execute Marp CLI once while building container image, and create v8 precompiled cache.