### PR TITLE
Follow up for experimental `--pptx-editable` in Windows environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve LibreOffice handling in experimental `--pptx-editable` option ([#632](https://github.com/marp-team/marp-cli/pull/632))
+  - Detect LibreOffice automatically that was installed in Windows by Scoop ([#631](https://github.com/marp-team/marp-cli/issues/631), [#632](https://github.com/marp-team/marp-cli/pull/632))
+
 ## v4.1.0 - 2025-01-15
 
 ### Added

--- a/src/browser/manager.ts
+++ b/src/browser/manager.ts
@@ -50,7 +50,7 @@ export class BrowserManager implements AsyncDisposable {
       this._finderResult.value = undefined // Reset finder result cache
     }
     if (config.protocol) {
-      if (this._conversionBrowser)
+      if (this._conversionBrowser.value)
         debugBrowser(
           'WARNING: Changing protocol after created browser for conversion is not supported'
         )


### PR DESCRIPTION
Follow up for experimental `--pptx-editable` option (#626), especially Windows environment.

- Removed Windows LibreOffice app transparency from WSL. WSL-specific finder is no longer used.
  - Tmpfile saved into WSL environment cannot read from Windows LibreOffice.
- Detect LibreOffice installed via Scoop in Windows. (#631)
- Update error level of soffice stderr from ERROR to WARN.
  - Windows may throw an error about libpng as ERROR, but the conversion would be successful. Showing ERROR level may lead confusion.