### PR TITLE
Use arm64 hosted runner to build container image for ARM

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,8 +22,7 @@ jobs:
           - runner: ubuntu-latest
             platform: linux/amd64
 
-          # TODO: Change to ARM64 runner for open-sourced project if available (M1 Mac cannot run Docker due to lack of nested virtualization)
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04-arm
             platform: linux/arm64
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Use arm64 hosted runner to build container image for ARM64 ([#635](https://github.com/marp-team/marp-cli/issues/635), [#637](https://github.com/marp-team/marp-cli/pull/637))
+
 ## v4.1.1 - 2025-01-19
 
 ### Fixed


### PR DESCRIPTION
Close #635.