### PR TITLE
Follow up for auto-detection of the slide title

### DIFF
--- a/src/engine/info-plugin.ts
+++ b/src/engine/info-plugin.ts
@@ -15,6 +15,8 @@ export const engineInfo = Symbol()
 
 /**
  * Extracts the title from the higher hierarchy heading in the Markdown tokens.
+ *
+ * @todo Move from info plugin to meta plugin.
  * @param tokens - The list of Markdown tokens.
  * @returns The extracted title or undefined if no heading is found.
  */

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -326,6 +326,7 @@ describe('Marp CLI', () => {
 
     beforeEach(() => {
       writeFile = jest.spyOn(fs.promises, 'writeFile').mockImplementation()
+      jest.spyOn(fs.promises, 'mkdir').mockImplementation()
     })
 
     it('converts files in specified dir', async () => {


### PR DESCRIPTION
This is a follow up PR for #655.

- [ ] Update unit test to use actual Marp/Marpit instances instead of mocks (in progress)
- [ ] Update the rule injection point to allow reading the result of automatically detected title by 3rd party Marp/markdown-it plugins