### PR TITLE
Fix circular dependency warning

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -20,9 +20,7 @@ import { CLIError, CLIErrorCode, error, isError } from './error'
 import { File, markdownExtensions } from './file'
 import serverIndex from './server/index.pug'
 import style from './server/index.scss'
-import { notifier } from './watcher'
-
-export const watchNotifierWebSocketEntrypoint = '.__marp-cli-watch-notifier__'
+import { WatchNotifier, notifier } from './watcher'
 
 export class Server extends (EventEmitter as new () => TypedEmitter<Server.Events>) {
   readonly converter: Converter
@@ -74,7 +72,7 @@ export class Server extends (EventEmitter as new () => TypedEmitter<Server.Event
       )
 
       this.httpServer.on('upgrade', (request, socket, head) => {
-        if (request.url?.startsWith(`/${watchNotifierWebSocketEntrypoint}/`)) {
+        if (request.url?.startsWith(`/${WatchNotifier.webSocketEntrypoint}/`)) {
           const ws = notifier.server
 
           if (ws) {
@@ -197,7 +195,7 @@ export class Server extends (EventEmitter as new () => TypedEmitter<Server.Event
 
     this.server = express.default()
     this.server
-      .get(`/${watchNotifierWebSocketEntrypoint}/*all`, (_, res) => {
+      .get(`/${WatchNotifier.webSocketEntrypoint}/*all`, (_, res) => {
         res.status(426).end('Upgrade Required')
       })
       .get('*all', (req, res, next) =>

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -8,7 +8,6 @@ import type { ServerOptions } from 'ws'
 import { Converter, ConvertedCallback } from './converter'
 import { isError } from './error'
 import { File, FileType } from './file'
-import { watchNotifierWebSocketEntrypoint } from './server'
 import { debugWatcher, debugWatcherWS } from './utils/debug'
 
 const chokidarWatch: typeof _watch = (...args) => {
@@ -100,6 +99,8 @@ export class WatchNotifier {
   private wss?: WebSocketServer
   private portNumber?: number
 
+  static readonly webSocketEntrypoint = '.__marp-cli-watch-notifier__'
+
   get server() {
     return this.wss
   }
@@ -128,7 +129,7 @@ export class WatchNotifier {
     entrypointType: WatchNotifierEntrypointType = 'static'
   ) {
     if (entrypointType === 'server') {
-      return `/${watchNotifierWebSocketEntrypoint}/${identifier}`
+      return `/${WatchNotifier.webSocketEntrypoint}/${identifier}`
     }
 
     const port = await this.port()

--- a/test/watcher.ts
+++ b/test/watcher.ts
@@ -1,7 +1,6 @@
 import http from 'node:http'
 import { watch as chokidarWatch } from 'chokidar'
 import { File, FileType } from '../src/file'
-import { watchNotifierWebSocketEntrypoint } from '../src/server'
 import { ThemeSet } from '../src/theme'
 import { Watcher, WatchNotifier, notifier } from '../src/watcher'
 
@@ -224,7 +223,7 @@ describe('WatchNotifier', () => {
     it('generates WebSocket URL with relative path for server entrypoint if specified entrypoint type as "server"', async () => {
       const instance = new WatchNotifier()
       expect(await instance.register('test', 'server')).toBe(
-        `/${watchNotifierWebSocketEntrypoint}/${testIdentifier}`
+        `/${WatchNotifier.webSocketEntrypoint}/${testIdentifier}`
       )
     })
   })


### PR DESCRIPTION
#664 had introduced circular dependency, and `npm run build` was getting warning from rollup.