### PR TITLE
Avoid using dynamic `import()` in the bundled output as much as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Standalone binary: Fix `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` error when exporting to pptx ([#676](https://github.com/marp-team/marp-cli/issues/676), [#677](https://github.com/marp-team/marp-cli/pull/677))
+
 ## v4.2.1 - 2025-07-19
 
 ### Changed

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -27,7 +27,10 @@ const compact = !process.env.ROLLUP_WATCH
 const plugins = (opts = {}) => [
   json({ preferConst: true }),
   alias({
-    entries: [{ find: 'jszip', replacement: 'jszip/dist/jszip.min.js' }],
+    entries: [
+      { find: 'jszip', replacement: 'jszip/dist/jszip.min.js' },
+      { find: 'pdf-lib', replacement: 'pdf-lib/dist/pdf-lib.esm.js' },
+    ],
   }),
   nodeResolve({
     browser: !!opts.browser,
@@ -59,6 +62,13 @@ const plugins = (opts = {}) => [
         output: path.join(__dirname, opts.license),
       },
     }),
+  !opts.browser && {
+    name: 'marp-cli-dynamic-import',
+    renderDynamicImport: ({ targetModuleId }) => {
+      // We should keep `import()` syntax when the target module has not been determined.
+      if (!targetModuleId) return { left: `import(`, right: `)` }
+    },
+  },
 ]
 
 const browser = (opts = {}) => ({

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -97,6 +97,12 @@ export default [
       'src/patch.ts', // CLI patch
       'src/prepare.ts', // CLI preparation
     ],
-    output: { compact, dir: 'lib', exports: 'named', format: 'cjs' },
+    output: {
+      compact,
+      dir: 'lib',
+      exports: 'named',
+      format: 'cjs',
+      dynamicImportInCjs: false, // Required to avoid using `import()` that is incompatible with standalone binary
+    },
   },
 ]

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -39,7 +39,7 @@ import { ThemeSet } from './theme'
 import { debug } from './utils/debug'
 import { isReadable } from './utils/finder'
 import { png2jpegViaPuppeteer } from './utils/jpeg'
-import { pdfLib, setOutline } from './utils/pdf'
+import { setOutline } from './utils/pdf'
 import { translateWSLPathToWindows } from './utils/wsl'
 import { notifier, type WatchNotifierEntrypointType } from './watcher'
 
@@ -382,7 +382,7 @@ export class Converter {
     if (postprocess) {
       // Apply PDF metadata and annotations
       const creationDate = new Date()
-      const { PDFDocument, PDFHexString, PDFString } = await pdfLib()
+      const { PDFDocument, PDFHexString, PDFString } = await import('pdf-lib')
       const pdfDoc = await PDFDocument.load(ret.buffer)
 
       pdfDoc.setCreator(CREATED_BY_MARP)

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -14,7 +14,3 @@ declare module '*.scss' {
   const scss: string
   export default scss
 }
-
-declare module 'pdf-lib/dist/pdf-lib.min.js' {
-  export * from 'pdf-lib'
-}

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -1,10 +1,5 @@
 import type { PDFDocument, PDFRef } from 'pdf-lib'
 
-// Use pre-bundled pdf-lib to avoid circular dependency warning. pdf-lib as an
-// external dependency will make failure in the standalone binary.
-// @see https://github.com/marp-team/marp-cli/issues/373
-export const pdfLib = async () => await import('pdf-lib/dist/pdf-lib.min.js')
-
 // --- Outline ---
 
 type PDFOutlineTo =
@@ -58,7 +53,7 @@ export const setOutline = async (
   doc: PDFDocument,
   outlines: readonly PDFOutline[]
 ) => {
-  const { PDFHexString } = await pdfLib()
+  const { PDFHexString } = await import('pdf-lib')
 
   // Refs
   const rootRef = doc.context.nextRef()


### PR DESCRIPTION
Fix #676.

The latest pptxgenjs has improved support for hybrid environments, such as Web, Node.js, and other bundlers. If pptxgenjs detected running on Node.js, pptxgenjs will try to import `node:fs` and `node:https` dynamically with `import` statement.

> ```typescript
> // STEP 2: Lazy-load Node built-ins if needed
> const loadNodeDeps = isNode
>   ? async () => {
>     ; ({ default: fs } = await import('node:fs')); ({ default: https } = await import('node:https'))
>   }
>   : async () => { }
> ```
>
> _&mdash; https://github.com/gitbrent/PptxGenJS/blob/3c9ec1b687c174952166f6a34b5e87ebf69fa469/src/gen-media.ts#L23_

However, a dyanamic `import` statement is known that it does not work as expected in the binary build packaged by `pkg` (`@yao-pkg/pkg`).

So I've updated the configuration of [rollup `output.dynamicImportInCjs`](https://rollupjs.org/configuration-options/#output-dynamicimportincjs) to `false`, to apply downlevel transpiling for dynamic `import()` to use `require()`.

This transpilation will break already ESM compatible import for the engine so I also have added the rollup plugin for keeping dynamic `import()` for the engine.
