### PR TITLE
Add `prepare` hook script to run `patch-package`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,7 @@ commands:
             - v3-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}-
             - v3-dependencies-{{ .Environment.CIRCLE_JOB }}-
 
-      - run: |
-          npm ci
-          npx patch-package
+      - run: npm ci
 
       - steps: << parameters.postinstall >>
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,14 +22,7 @@ We are following [**the contributing guideline of Marp team projects**][team-con
 
 ```bash
 npm install
-npx patch-package
 ```
-
-Running [`npx patch-package`](https://github.com/ds300/patch-package) after `npm install` is required to apply patches for development dependencies. See also [the documentation of patches](../patches/README.md) for details.
-
-> [!NOTE]
->
-> `patch-package` recommends to [add `postinstall` script to `package.json` to run it automatically after `npm install`](https://github.com/ds300/patch-package?tab=readme-ov-file#set-up). However, Marp CLI does not use it because it will run also when installing CLI by users.
 
 ### Build and watch
 

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -38,9 +38,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: |
-          npm ci
-          npx patch-package
+        run: npm ci
 
       - name: Set up LibreOffice
         run: choco install libreoffice-fresh -y

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cosmiconfig": "^9.0.0",
         "puppeteer-core": "^24.14.0",
         "serve-index": "^1.9.1",
-        "tmp": "^0.2.3",
+        "tmp": "^0.2.5",
         "ws": "^8.18.3",
         "yargs": "^17.7.2"
       },
@@ -2210,9 +2210,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2283,13 +2283,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -12793,16 +12793,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -13185,19 +13175,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/patch-package/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/path-exists": {
@@ -17764,9 +17741,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lint:js": "eslint --cache",
     "lint:css": "stylelint \"src/**/*.{css,scss}\"",
     "prepack": "npm-run-all --parallel check:* lint:* test:coverage --parallel build types",
+    "prepare": "patch-package",
     "preversion": "run-p check:* lint:* test:coverage",
     "standalone": "node -e \"fs.rmSync('bin',{recursive:true,force:true})\" && pkg -C gzip --out-path ./bin .",
     "standalone:pack": "node ./scripts/pack.mjs",
@@ -158,9 +159,14 @@
     "cosmiconfig": "^9.0.0",
     "puppeteer-core": "^24.14.0",
     "serve-index": "^1.9.1",
-    "tmp": "^0.2.3",
+    "tmp": "^0.2.5",
     "ws": "^8.18.3",
     "yargs": "^17.7.2"
+  },
+  "overrides": {
+    "patch-package": {
+      "tmp": "^0.2.5"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,11 +1,8 @@
 # Patches
 
-This directory contains patches for Marp CLI (dev) dependencies. For Marp CLI development, you need to run [`npx patch-package`](https://github.com/ds300/patch-package) after `npm install` to apply these patches.
+This directory contains patches for Marp CLI dev dependencies, powered by [patch-package](https://github.com/ds300/patch-package).
 
-```bash
-npm install
-npx patch-package
-```
+Patches in this directory will be applied when `npm install` run, through `prepare` script hook in `package.json`.
 
 > [!WARNING]
 >


### PR DESCRIPTION
For making the process for preparing development simplify, add `prepare` script to run `patch-package` for `npm install` / `npm ci` (without arguments).

[patch-package](https://github.com/ds300/patch-package) recommend to run `patch-package` in `postinstall` hook, but it also triggers unnecessarily when installed Marp CLI by users, such as `npm i @marp-team/marp-cli --save`.

Marp CLI is currently using `patch-package` only for dev dependencies, so we have no need to run it in `postinstall` hook.