### PR TITLE
Fix ambiguous CLI arguments parsing for `--output`

### DIFF
--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -153,6 +153,7 @@ export const marpCli = async (
           describe: 'Output file path (or directory when input-dir is passed)',
           group: OptionGroup.Basic,
           type: 'string',
+          nargs: 1, // Required to work `--output -` (stdout)
         },
         'input-dir': {
           alias: 'I',

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -1204,12 +1204,30 @@ describe('Marp CLI', () => {
       })
     })
 
+    describe('with --output option', () => {
+      it('converts file and output to stdout when --output is "-"', async () => {
+        const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
+        jest.spyOn(cli, 'info').mockImplementation()
+
+        expect(await marpCli([onePath, '--output', '-'])).toBe(0)
+        expect(stdout).toHaveBeenCalledTimes(1)
+
+        stdout.mockClear()
+        expect(await marpCli([onePath, '--output=-'])).toBe(0)
+        expect(stdout).toHaveBeenCalledTimes(1)
+      })
+    })
+
     describe('with -o option', () => {
       it('converts file and output to stdout when -o is "-"', async () => {
         const stdout = jest.spyOn(process.stdout, 'write').mockImplementation()
         jest.spyOn(cli, 'info').mockImplementation()
 
         expect(await marpCli([onePath, '-o', '-'])).toBe(0)
+        expect(stdout).toHaveBeenCalledTimes(1)
+
+        stdout.mockClear()
+        expect(await marpCli([onePath, '-o-'])).toBe(0)
         expect(stdout).toHaveBeenCalledTimes(1)
       })
 


### PR DESCRIPTION
Resolves #684.

Marp CLI's `--output` option may be passed `-` for indicating to output the conversion result into stdout. However, #684 has been reported that it was not working with `--output -` (It works with `-o -` and `--output=-`)

This PR fixes ambiguous CLI arguments parsing of yargs by setting the number of arguments about `--output` option, just like `nargs: 1`.

