### PR TITLE
Fix typo in converter.ts

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -783,7 +783,7 @@ export class Converter {
               failedFileSet.size > 1 ? 'They are' : 'That is'
             } blocked by security reason. Instead we recommend using assets uploaded to online. (Or you can use ${chalk.yellow(
               '--allow-local-files'
-            )} option if you are understood of security risk)`
+            )} option if you understand the security risk)`
           )
         }
       }


### PR DESCRIPTION
I noticed CLI is saying "if you are understood of security risk". I suggest we replace it with more standard English "if you understand the security risk".