### PR TITLE
Add linux aarch64 build target for GitHub releases

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
           - macOS-latest
 

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -31,13 +31,24 @@ const packToTarGz = (binary) => {
 fs.rmSync(dist, { recursive: true, force: true })
 fs.mkdirSync(dist)
 
-// Create package for Linux (.tar.gz)
-if (os.includes('linux') || os.includes('ubuntu')) {
+// Create package for Linux x64 (.tar.gz)
+if ((os.includes('linux') || os.includes('ubuntu')) && !os.includes('arm')) {
   fs.readFile(path.resolve(bin, 'marp-cli-linux'), (err, buffer) => {
     if (err) throw err
 
     packToTarGz(buffer).pipe(
       fs.createWriteStream(path.resolve(dist, `${prefix}-linux.tar.gz`))
+    )
+  })
+}
+
+// Create package for Linux ARM64 (.tar.gz)
+if ((os.includes('linux') || os.includes('ubuntu')) && os.includes('arm')) {
+  fs.readFile(path.resolve(bin, 'marp-cli-linux'), (err, buffer) => {
+    if (err) throw err
+
+    packToTarGz(buffer).pipe(
+      fs.createWriteStream(path.resolve(dist, `${prefix}-linux-arm64.tar.gz`))
     )
   })
 }


### PR DESCRIPTION
Manually tested as working here: https://github.com/philips/marp-cli/actions/runs/24098613859