### PR TITLE
Test against Node.js v26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,17 @@ jobs:
       - lint
       - test
 
+  test-node26:
+    executor:
+      name: node
+      browser: true
+      version: '26.0'
+    steps:
+      - prepare:
+          browser: true
+      - lint
+      - test
+
 workflows:
   test:
     jobs:
@@ -200,3 +211,6 @@ workflows:
       - test-node24:
           requires:
             - audit
+      # - test-node26:
+      #     requires:
+      #       - audit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,6 @@ workflows:
       - test-node24:
           requires:
             - audit
-      # - test-node26:
-      #     requires:
-      #       - audit
+      - test-node26:
+          requires:
+            - audit

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -20,6 +20,7 @@ jobs:
           - '^20.20.0'
           - '22.22.0'
           - '^24.14.0'
+          - '^26.0.0'
 
     steps:
       # - name: Output concurrency group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Added
 
-- Added Linux AArch64 (ARM64) build for standalone binary ([#718](https://github.com/marp-team/marp-cli/pull/718) by [@philips](https://github.com/philips))
+- Node.js v26 support ([#722](https://github.com/marp-team/marp-cli/pull/722))
+- Linux AArch64 (ARM64) build for standalone binary ([#718](https://github.com/marp-team/marp-cli/pull/718) by [@philips](https://github.com/philips))
+
+### Fixed
+
+- Failure to run due to an error while requiring yargs v17 in Node.js v25.7, v25.8.0, and v26 ([#708](https://github.com/marp-team/marp-cli/issues/708), [#722](https://github.com/marp-team/marp-cli/pull/722))
 
 ## v4.3.1 - 2026-03-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9112,6 +9112,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/extract-zip/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9228,6 +9238,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -19104,6 +19123,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
       "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5780,9 +5780,9 @@
       ]
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -6572,9 +6572,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13815,9 +13815,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -16995,12 +16995,12 @@
       }
     },
     "node_modules/speech-rule-engine": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.3.tgz",
-      "integrity": "sha512-SBMgkuJYvP4F62daRfBNwYC2nXTEhNXAfsBZ/BB7Ly85/KnbnjmKM7/45ZrFbH6jIMiAliDUDPSZFUuXDvcg6A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.4.tgz",
+      "integrity": "sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@xmldom/xmldom": "0.9.9",
+        "@xmldom/xmldom": "0.9.10",
         "commander": "13.1.0",
         "wicked-good-xpath": "1.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10340,9 +10340,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "puppeteer-core": "^24.39.1",
         "serve-index": "^1.9.2",
         "tmp": "^0.2.5",
-        "ws": "^8.19.0",
-        "yargs": "^17.7.2"
+        "ws": "^8.19.0"
       },
       "bin": {
         "marp": "marp-cli.js"
@@ -104,6 +103,7 @@
         "vhtml": "^2.2.0",
         "which": "^4.0.0",
         "wrap-ansi": "^9.0.2",
+        "yargs": "^17.7.2",
         "yauzl": "^3.2.1",
         "zip-stream": "^7.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -165,10 +165,7 @@
   },
   "overrides": {
     "@rollup/plugin-terser": {
-      "serialize-javascript": "^7.0.3"
-    },
-    "extract-zip": {
-      "yauzl": "^3.2.1"
+      "serialize-javascript": "^7.0.5"
     },
     "postcss-url": {
       "minimatch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "vhtml": "^2.2.0",
     "which": "^4.0.0",
     "wrap-ansi": "^9.0.2",
+    "yargs": "^17.7.2",
     "yauzl": "^3.2.1",
     "zip-stream": "^7.0.2"
   },
@@ -160,8 +161,7 @@
     "puppeteer-core": "^24.39.1",
     "serve-index": "^1.9.2",
     "tmp": "^0.2.5",
-    "ws": "^8.19.0",
-    "yargs": "^17.7.2"
+    "ws": "^8.19.0"
   },
   "overrides": {
     "@rollup/plugin-terser": {


### PR DESCRIPTION
https://nodejs.org/ja/blog/release/v26.0.0

### ToDo

- [x] Test for Linux (CircleCI)
- [x] Test for Windows (GitHub Actions)

### Note

- The unit test against Node.js v26 looks like good, but actually Marp CLI cannot work due to #708.
  - :arrow_right: [Moved `yargs` from dependencies to devDependencies](https://github.com/marp-team/marp-cli/pull/722/commits/c5d89eed5ccc6401480363e67d440762a949e52b) ([c5d89ee](https://github.com/marp-team/marp-cli/pull/722/commits/c5d89eed5ccc6401480363e67d440762a949e52b))

yargs v17 breaks `require('yargs/yargs')` in Node.js 26. By moving yargs from dependencies to devDependencies, rollup will bundle it while building, so `require('yargs/yargs')` can remove from the built source code.