### PR TITLE
feat(pptx): add `--pptx-native` (editable PPTX from the DOM, no LibreOffice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ marp --pptx --pptx-editable slide-deck.md
 >
 > Conversion to the editable PPTX results in **lower slide reproducibility compared to the conversion into regular PPTX and other formats.** Additionally, **presenter notes are not supported.** _We do not recommend to export the editable PPTX if maintaining the slide's appearance is important._
 
+#### _[EXPERIMENTAL]_ Generate native editable pptx (`--pptx-native`)
+
+`--pptx-native` generates an editable PPTX **directly from the rendered DOM** using the [`dom-to-pptx`](https://www.npmjs.com/package/dom-to-pptx) engine, instead of going through PDF and LibreOffice. Because a PDF stores text as one positioned block per line, the LibreOffice route (`--pptx-editable`) cannot reflow text; `--pptx-native` emits **native text boxes and tables** with no per-line splitting and **does not require LibreOffice**.
+
+```bash
+marp --pptx --pptx-native slide-deck.md
+```
+
+> [!IMPORTANT]
+>
+> `--pptx-native` requires the browser only (no LibreOffice). It is mutually exclusive with `--pptx-editable`.
+>
+> Text and tables are emitted as native PowerPoint objects. Some advanced CSS (gradients, shadows, rotation) is rasterized by the engine, and font embedding depends on the fonts being readable.
+
 ### Convert to PNG/JPEG image(s) 🌐
 
 #### Multiple images (`--images`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@marp-team/marpit": "^3.2.1",
         "chokidar": "^4.0.3",
         "cosmiconfig": "^9.0.1",
+        "dom-to-pptx": "^1.1.9",
         "puppeteer-core": "^24.39.1",
         "serve-index": "^1.9.2",
         "tmp": "^0.2.5",
@@ -5071,7 +5072,6 @@
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -6537,6 +6537,15 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7469,7 +7478,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -7601,6 +7609,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -8035,6 +8052,56 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-to-pptx": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/dom-to-pptx/-/dom-to-pptx-1.1.9.tgz",
+      "integrity": "sha512-jeNper2vhKn55ipBtnF+mn88X3dkaxl0A3kT9VkKXX/1fFIPjo2Y+/+QOIen0XotBps/xm0ArwwfUEtvmf1T2w==",
+      "license": "MIT",
+      "dependencies": {
+        "fonteditor-core": "^2.6.3",
+        "html2canvas": "^1.4.1",
+        "jszip": "^3.10.1",
+        "opentype.js": "^1.3.4",
+        "pako": "^2.1.0",
+        "pptxgenjs": "^3.12.0"
+      },
+      "bin": {
+        "dom-to-pptx-skills": "bin/cli.js"
+      }
+    },
+    "node_modules/dom-to-pptx/node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/dom-to-pptx/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/dom-to-pptx/node_modules/pptxgenjs": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-3.12.0.tgz",
+      "integrity": "sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.7.3",
+        "https": "^1.0.0",
+        "image-size": "^1.0.0",
+        "jszip": "^3.7.1"
       }
     },
     "node_modules/domelementtype": {
@@ -9376,6 +9443,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fonteditor-core": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/fonteditor-core/-/fonteditor-core-2.6.3.tgz",
+      "integrity": "sha512-YUryIKjkenjZ41E7JvM3V+02Ak4mTHDDTwBWgs9KBzypzHqLZHuua1UDRevZNTKawmnq1dbBAa70Jddl2+F4FQ==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.3"
+      }
+    },
+    "node_modules/fonteditor-core/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -10003,6 +10087,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -10083,7 +10180,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
       "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/https-proxy-agent": {
@@ -10191,7 +10287,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/immutable": {
@@ -12084,7 +12179,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -12097,14 +12191,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -12120,14 +12212,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -12227,7 +12317,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -13180,6 +13269,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/opentype.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+      "license": "MIT",
+      "dependencies": {
+        "string.prototype.codepointat": "^0.2.1",
+        "tiny-inflate": "^1.0.3"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -13390,7 +13495,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -14776,7 +14880,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -15111,7 +15214,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.3"
@@ -16635,7 +16737,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -17272,6 +17373,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
@@ -18049,6 +18156,21 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -18437,7 +18559,6 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -18614,6 +18735,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "@marp-team/marpit": "^3.2.1",
     "chokidar": "^4.0.3",
     "cosmiconfig": "^9.0.1",
+    "dom-to-pptx": "^1.1.9",
     "puppeteer-core": "^24.39.1",
     "serve-index": "^1.9.2",
     "tmp": "^0.2.5",

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,7 @@ interface IMarpCLIArguments {
   'pdfOutlines.headings'?: boolean
   pptx?: boolean
   pptxEditable?: boolean
+  pptxNative?: boolean
   preview?: boolean
   server?: boolean
   template?: string
@@ -287,6 +288,7 @@ export class MarpCLIConfig {
         : false
 
     const pptxEditable = !!(this.args.pptxEditable || this.conf.pptxEditable)
+    const pptxNative = !!(this.args.pptxNative || this.conf.pptxNative)
 
     const type = ((): ConvertType => {
       // CLI options
@@ -321,7 +323,7 @@ export class MarpCLIConfig {
 
       // Prefer PPTX than HTML if enabled PPTX option
       if ((this.args.pptx ?? this.conf.pptx) !== false) {
-        if (pptxEditable) return ConvertType.pptx
+        if (pptxEditable || pptxNative) return ConvertType.pptx
       }
 
       return ConvertType.html
@@ -370,6 +372,7 @@ export class MarpCLIConfig {
       pdfNotes,
       pdfOutlines,
       pptxEditable,
+      pptxNative,
       preview,
       server,
       template,

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,5 +1,6 @@
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
-import { URL } from 'node:url'
+import { URL, fileURLToPath } from 'node:url'
 import type { Marp, MarpOptions } from '@marp-team/marp-core'
 import { Marpit, Options as MarpitOptions } from '@marp-team/marpit'
 import chalk from 'chalk'
@@ -81,6 +82,7 @@ export interface ConverterOption {
         headings: boolean
       }
   pptxEditable?: boolean
+  pptxNative?: boolean
   preview?: boolean
   jpegQuality?: number
   server?: boolean
@@ -118,12 +120,68 @@ export type ConvertedCallback = (result: ConvertResult) => void
 // Markdown
 const stripBOM = (s: string) => (s.charCodeAt(0) === 0xfeff ? s.slice(1) : s)
 
+// Runs in the page: collect every local (file://) image URL referenced by
+// <img> elements or CSS background-image, so the Node side can inline them.
+const pptrCollectLocalImages = (): string[] => {
+  const urls = new Set<string>()
+  document.querySelectorAll('img').forEach((img) => {
+    if (img.src.startsWith('file://')) urls.add(img.src)
+  })
+  document.querySelectorAll('*').forEach((el) => {
+    const bg = window.getComputedStyle(el).backgroundImage
+    const m = bg && bg.match(/url\(["']?(file:\/\/[^"')]+)["']?\)/)
+    if (m) urls.add(m[1])
+  })
+  return [...urls]
+}
+
+// Runs in the page: replace file:// image references with provided data URIs.
+const pptrInlineImages = (map: Record<string, string>) => {
+  document.querySelectorAll('img').forEach((img) => {
+    if (map[img.src]) img.src = map[img.src]
+  })
+  document.querySelectorAll('*').forEach((el) => {
+    const bg = window.getComputedStyle(el).backgroundImage
+    const m = bg && bg.match(/url\(["']?(file:\/\/[^"')]+)["']?\)/)
+    if (m && map[m[1]]) (el as HTMLElement).style.backgroundImage = `url("${map[m[1]]}")`
+  })
+}
+
+// Runs inside the rendered page (Puppeteer). The dom-to-pptx browser bundle is
+// injected beforehand and exposes `window.domToPptx`. Builds a native editable
+// PPTX from every slide <section> and returns it base64-encoded.
+const pptrNativePptxExporter = async (
+  widthPx: number,
+  heightPx: number
+): Promise<string> => {
+  const { domToPptx } = window as unknown as {
+    domToPptx: {
+      exportToPptx: (
+        targets: Element[],
+        options: Record<string, unknown>
+      ) => Promise<Blob>
+    }
+  }
+  const sections = Array.from(document.querySelectorAll('section'))
+  const blob = await domToPptx.exportToPptx(sections, {
+    skipDownload: true,
+    width: widthPx / 96,
+    height: heightPx / 96,
+    autoEmbedFonts: true,
+  })
+  const bytes = new Uint8Array(await blob.arrayBuffer())
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+  return btoa(binary)
+}
+
 export class Converter {
   readonly options: ConverterOption
 
   private _sOffice: SOffice | undefined = undefined
   private _firefoxPDFConversionWarning = false
   private _experimentalEditablePPTXWarning = false
+  private _experimentalNativePPTXWarning = false
 
   constructor(opts: ConverterOption) {
     this.options = opts
@@ -250,11 +308,13 @@ export class Converter {
         case ConvertType.pptx:
           template = await useTemplate(true)
           files.push(
-            this.options.pptxEditable
-              ? await this.convertFileToEditablePPTX(template, file)
-              : await this.convertFileToPPTX(template, file, {
-                  scale: this.options.imageScale ?? 2,
-                })
+            this.options.pptxNative
+              ? await this.convertFileToNativePPTX(template, file)
+              : this.options.pptxEditable
+                ? await this.convertFileToEditablePPTX(template, file)
+                : await this.convertFileToPPTX(template, file, {
+                    scale: this.options.imageScale ?? 2,
+                  })
           )
           break
         case ConvertType.notes:
@@ -655,6 +715,72 @@ export class Converter {
 
     const ret = file.convert(this.options.output, { extension: 'pptx' })
     ret.buffer = await tmpPptxFile.load()
+
+    return ret
+  }
+
+  private async convertFileToNativePPTX(
+    tpl: TemplateResult,
+    file: File
+  ): Promise<File> {
+    // Experimental warning
+    if (this._experimentalNativePPTXWarning === false) {
+      this._experimentalNativePPTXWarning = true
+
+      warn(
+        `${chalk.yellow`[EXPERIMENTAL]`} Native editable PPTX is an experimental feature powered by the dom-to-pptx engine. The output is generated directly from the rendered DOM (no LibreOffice).`
+      )
+    }
+
+    // Locate the browser bundle of dom-to-pptx (exposes window.domToPptx).
+    // Its "exports" map hides subpaths, so resolve the package entry and take
+    // the sibling browser build in dist/.
+    const bundlePath = path.join(
+      path.dirname(require.resolve('dom-to-pptx')),
+      'dom-to-pptx.bundle.js'
+    )
+
+    const html = new File(file.absolutePath)
+    html.buffer = Buffer.from(tpl.result)
+
+    const base64 = await this.usePuppeteer(html, async (page, { render }) => {
+      await render()
+
+      // The deck renders from a file:// origin; dom-to-pptx cannot read those
+      // local images (file:// fetch is blocked and <canvas> is tainted), so
+      // inline them as data URIs first (read from disk on the Node side).
+      const localSrcs: string[] = await page.evaluate(pptrCollectLocalImages)
+      const dataUris: Record<string, string> = {}
+      for (const src of localSrcs) {
+        try {
+          const buf = await readFile(fileURLToPath(src))
+          const ext = path.extname(src).slice(1).toLowerCase()
+          const mime =
+            ext === 'svg'
+              ? 'image/svg+xml'
+              : ext === 'jpg'
+                ? 'image/jpeg'
+                : `image/${ext || 'png'}`
+          dataUris[src] = `data:${mime};base64,${buf.toString('base64')}`
+        } catch {
+          // Unreadable asset — leave as-is.
+        }
+      }
+      await page.evaluate(pptrInlineImages, dataUris)
+
+      await page.addScriptTag({ path: bundlePath })
+      await page.evaluate(
+        () => (document as { fonts?: { ready?: Promise<unknown> } }).fonts?.ready
+      )
+      return await page.evaluate(
+        pptrNativePptxExporter,
+        tpl.rendered.size.width,
+        tpl.rendered.size.height
+      )
+    })
+
+    const ret = file.convert(this.options.output, { extension: 'pptx' })
+    ret.buffer = Buffer.from(base64, 'base64')
 
     return ret
   }

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -230,6 +230,13 @@ export const marpCli = async (
           hidden: isOfficialContainerImage(), // Container image does not include LibreOffice Impress
           type: 'boolean',
         },
+        'pptx-native': {
+          describe:
+            '[EXPERIMENTAL] Generate editable PPTX directly from the DOM via dom-to-pptx (no LibreOffice)',
+          group: OptionGroup.Converter,
+          conflicts: ['pptx-editable'],
+          type: 'boolean',
+        },
         notes: {
           conflicts: ['image', 'images', 'pptx', 'pdf'],
           describe: 'Convert slide deck notes into a text file',

--- a/test/converter.ts
+++ b/test/converter.ts
@@ -1150,6 +1150,44 @@ describe('Converter', () => {
           timeout
         )
       })
+
+      describe('with pptxNative option', () => {
+        beforeEach(() => {
+          // Use the actually saved tmp file for conversion
+          writeFileSpy.mockRestore()
+        })
+
+        it(
+          'converts markdown into editable PPTX directly from the DOM',
+          async () => {
+            const cvt = converter({ pptxNative: true })
+            const nativePptxSpy = jest.spyOn(
+              cvt as any,
+              'convertFileToNativePPTX'
+            )
+            const fileSave = jest
+              .spyOn(File.prototype, 'save')
+              .mockImplementation()
+            const warn = jest.spyOn(console, 'warn').mockImplementation()
+
+            await cvt.convertFile(new File(onePath))
+            expect(nativePptxSpy).toHaveBeenCalled()
+            expect(warn).toHaveBeenCalledWith(
+              expect.stringContaining('Native editable PPTX is an experimental')
+            )
+            expect(fileSave).toHaveBeenCalled()
+
+            const savedFile = fileSave.mock.instances[0] as unknown as File
+            expect(savedFile).toBeInstanceOf(File)
+            expect(savedFile.path).toBe('test.pptx')
+
+            // ZIP PK header for Office Open XML
+            expect(savedFile.buffer?.toString('ascii', 0, 2)).toBe('PK')
+            expect(savedFile.buffer?.toString('hex', 2, 4)).toBe('0304')
+          },
+          timeoutLarge
+        )
+      })
     })
 
     describe('when convert type is PNG', () => {

--- a/test/marp-cli.ts
+++ b/test/marp-cli.ts
@@ -1598,6 +1598,20 @@ describe('Marp CLI', () => {
       })
     })
 
+    describe('with --pptx-native options', () => {
+      it('prefers PPTX than HTML if not specified conversion type', async () => {
+        const cmd = [onePath, '--pptx-native']
+        expect((await conversion(...cmd)).options.type).toBe(ConvertType.pptx)
+
+        // This option is actually not for defining conversion type so other
+        // options to set conversion type are always prioritized.
+        const cmdPptx = [onePath, '--pptx-native', '--pdf']
+        expect((await conversion(...cmdPptx)).options.type).toBe(
+          ConvertType.pdf
+        )
+      })
+    })
+
     describe('with PUPPETEER_TIMEOUT env', () => {
       beforeEach(() => {
         process.env.PUPPETEER_TIMEOUT = '12345'


### PR DESCRIPTION
> Tracking proposal: #725

## What

Adds an experimental `--pptx-native` mode that generates an **editable PPTX directly from the rendered DOM** via the [`dom-to-pptx`](https://www.npmjs.com/package/dom-to-pptx) engine — an alternative to `--pptx-editable` (PDF → LibreOffice).

```bash
marp --pptx --pptx-native slide-deck.md
```

## Why

`--pptx-editable` goes through PDF, where text is stored as **one positioned block per visual line**, so LibreOffice rebuilds one text box per line: text doesn't reflow, long runs overlap, tables lose row auto-height, and a LibreOffice install is required. Reading the DOM instead yields **native text boxes and tables** with no per-line splitting and **no LibreOffice dependency**.

## How

- New `--pptx-native` boolean flag (`conflicts: ['pptx-editable']`), plumbed through `config.ts` like `pptxEditable`.
- `Converter#convertFileToNativePPTX()` injects the `dom-to-pptx` browser bundle into marp-cli's **existing** Puppeteer page (`usePuppeteer`) and exports each slide `<section>`; output is written as the PPTX buffer.
- Local (`file://`) images are inlined as data URIs before export, so they embed under the `file://` origin (where `fetch`/`<canvas>` reads are otherwise blocked).
- Adds `dom-to-pptx` dependency.

## Tests

- `test/converter.ts` — `convertFileToNativePPTX` produces a valid (PK/zip) PPTX and emits the experimental warning.
- `test/marp-cli.ts` — `--pptx-native` infers PPTX type and yields to explicit conversion types.

## Notes / open questions

- **Dependency shape**: `dom-to-pptx` pulls `html2canvas`/`jszip`/`opentype.js`. Regular dep vs `optionalDependency` (with a friendly error like the soffice check)? Happy to switch.
- **CSS coverage**: text/tables/fills/borders/images are native; advanced CSS (gradients, shadows, rotation) is rasterized by the engine. Documented under the `[EXPERIMENTAL]` flag.
- Does not change `--pptx` or `--pptx-editable` behavior.
