### PR TITLE
Use Brotli compression to binary builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prepack": "npm-run-all --parallel check:* lint:* test:coverage --parallel build types",
     "prepare": "npx --no patch-package || exit 0",
     "preversion": "run-p check:* lint:* test:coverage",
-    "standalone": "node -e \"fs.rmSync('bin',{recursive:true,force:true})\" && pkg --sea -C Zstd --out-path ./bin .",
+    "standalone": "node -e \"fs.rmSync('bin',{recursive:true,force:true})\" && pkg --sea -C Brotli --out-path ./bin .",
     "standalone:pack": "node ./scripts/pack.mjs",
     "test": "jest",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
Now Marp CLI is using the Brotli compression to the code of the standalone binary.

Updating the base Node.js from 22 to 26 in v4.4.1 has increased both the binary and package sizes compared to v4.4.0. By adopting Brotli compression, we can minimize the size increase for Linux and macOS build. In Windows, the sizes actually decrease from v4.x rather than increase.

[According to the `@yao-pkg/pkg` documentation](https://yao-pkg.github.io/pkg/guide/compression), Brotli compression may result in the slowest decompression speed at runtime, but my measurement results show an increase of only 1-10ms when running several CLI workflows and it's acceptable.